### PR TITLE
Test Engineer role, AI-TDD methodology, test integrity, scoped debate

### DIFF
--- a/.claude/commands/run-phase.md
+++ b/.claude/commands/run-phase.md
@@ -18,7 +18,7 @@ Run the prepare command to create a run directory and instructions:
 Determine the Studio root path. If this repo contains a `studio/run_phase.py`, use that. Otherwise check `$STUDIO_ROOT`. Then run:
 
 ```bash
-python "$STUDIO_ROOT/run_phase.py" prepare $ARGUMENTS --no-scopes
+python "$STUDIO_ROOT/run_phase.py" prepare $ARGUMENTS
 ```
 
 If running from a repo that is NOT the Studio repo itself, artifacts will automatically land in the current repo under `.studio/output/`. A bridge doc will be created on first use.

--- a/.claude/commands/run-studio-phase.md
+++ b/.claude/commands/run-studio-phase.md
@@ -81,11 +81,27 @@ For each role in the Role Menu, spawn advocate + contrarian **in parallel** (all
 
 ---
 
-#### Scope 2: DEPTH (per-role, full, sequential)
+#### Scope 2: DEPTH (per-role, sequential, with briefs and scoped reads)
 
 **Goal:** Detailed analysis per discipline. "How exactly should we do this?"
 
-Process each role **sequentially** (later roles can read earlier roles' outputs):
+Process each role **sequentially** (later roles benefit from earlier outputs).
+
+**Token optimization — summarize-then-delegate:** After every 2-3 completed roles, write a condensed 1-page brief (`{run_dir}/S2-brief.md`) summarizing key decisions, concerns, and conditions from completed S2 roles. Update this brief as more roles complete. Later roles read the brief instead of all individual files.
+
+**Scoped reads — each role only reads what's relevant:**
+
+| Role | Must read (S2 files) | Brief sufficient |
+|------|---------------------|-----------------|
+| Product | (runs first) | S1 alignment only |
+| Marketing | Product S2 | S1 alignment |
+| Design | Product S2, Marketing S2 | S1 alignment |
+| Art | Design S2 | Brief for others |
+| Engineering | Design S2, Art S2 | Brief for others |
+| Test Engineer | Engineering S2, Design S2 | Brief for others |
+| QA | Engineering S2, Test Engineer S2 | Brief for others |
+
+Adjust based on the specific proposal — if a role clearly depends on another's output, add it.
 
 **Advocate prompt:**
 > You are the **{role_title} Advocate** for this Studio run — DEPTH SCOPE.
@@ -93,9 +109,13 @@ Process each role **sequentially** (later roles can read earlier roles' outputs)
 > **Focus:** {advocate_focus}
 > **Input/objective:** {the user's text}
 >
-> **Context from Alignment scope:** Read the alignment artifacts in `{run_dir}/*--S1-*.md` to understand what was agreed and what was flagged across all disciplines.
+> **Context from Alignment scope:** Read the alignment artifacts in `{run_dir}/*--S1-*.md` to understand what was agreed and what was flagged.
 >
 > {If this role was REJECTED in alignment: "Alignment contrarian flagged these concerns:" + rejection reasons}
+>
+> **Context from prior Depth roles (SCOPED — read only these):**
+> - {List specific S2 files this role needs per the dependency map}
+> - Condensed brief of all other roles: `{run_dir}/S2-brief.md`
 >
 > **Required deliverables:** {deliverables list from Role Menu}
 >
@@ -111,6 +131,10 @@ Process each role **sequentially** (later roles can read earlier roles' outputs)
 >
 > Read the advocate's depth proposal at `{run_dir}/advocate--{role}--S2-{NN}.md`.
 >
+> **Scoped reads (only these — do NOT read all S2 files):**
+> - {1-2 S2 files most relevant per dependency map}
+> - Condensed brief: `{run_dir}/S2-brief.md`
+>
 > Critically evaluate against your focus area with full rigor. Check for:
 > - Fatal flaws, unrealistic assumptions, missing considerations
 > - Whether alignment-scope concerns were actually addressed
@@ -121,40 +145,36 @@ Process each role **sequentially** (later roles can read earlier roles' outputs)
 > End with `VERDICT: APPROVED` or `VERDICT: REJECTED` with numbered reasons.
 > Save to `{run_dir}/contrarian--{role}--S2-{NN}.md`.
 
+**Brief update cadence:** After every 2-3 roles complete, update `{run_dir}/S2-brief.md` with their key decisions and conditions. Keep under 1 page.
+
 **Loop:** If REJECTED and iterations remain (up to 3), feed rejection back to advocate. If APPROVED, move to next role.
 
 ---
 
-#### Scope 3: POLISH (all roles, short, parallel, 1 pass)
+#### Scope 3: POLISH (single consolidated agent)
 
 **Goal:** Cross-discipline gut-check. "Anything still broken across disciplines?"
 
-After all Scope 2 roles are approved, run one final parallel pass:
+After all Scope 2 roles are approved, run **one consolidated agent** — not per-role pairs.
 
-**Advocate prompt:**
-> You are the **{role_title} Advocate** for this Studio run — POLISH SCOPE.
+**Consolidated polish prompt (ONE agent):**
+> You are the **Cross-Discipline Polish Reviewer** for this Studio run.
 >
-> **Keep your response under 300 words.**
+> Read these files:
+> - Condensed S2 brief: `{run_dir}/S2-brief.md`
+> - All S2 contrarian files: `{run_dir}/contrarian--*--S2-*.md` (for conditions attached to each approval)
 >
-> Read all Scope 2 artifacts in `{run_dir}/*--S2-*.md` to understand what each discipline proposed.
+> Produce a single document covering:
+> 1. **Unresolved cross-discipline conflicts** — where one role's decision contradicts another's
+> 2. **Conditions that overlap or conflict** — where two contrarians demanded incompatible things
+> 3. **Gaps between roles** — concerns that fell between disciplines and no one owns
+> 4. **Consolidated open items** — deduplicated list of all conditions, grouped by priority
 >
-> Confirm your discipline's concerns are addressed in the integrated depth outputs. Flag any remaining cross-discipline conflicts. Do not introduce new proposals — only flag issues.
->
-> Save to `{run_dir}/advocate--{role}--S3-01.md`.
+> Do NOT introduce new proposals or repeat S2 analysis.
+> **Keep under 800 words.** End with `VERDICT: APPROVED` or `VERDICT: REJECTED` with numbered reasons.
+> Save to `{run_dir}/polish--consolidated--S3-01.md`.
 
-**Contrarian prompt (SEPARATE agent):**
-> You are the **{role_title} Contrarian** for this Studio run — POLISH SCOPE.
->
-> **Keep your response under 300 words.**
->
-> Read the advocate's polish check at `{run_dir}/advocate--{role}--S3-01.md`.
->
-> Verify the advocate isn't rubber-stamping. Any real conflicts remaining?
->
-> End with `VERDICT: APPROVED` or `VERDICT: REJECTED` with numbered reasons.
-> Save to `{run_dir}/contrarian--{role}--S3-01.md`.
-
-**No iteration** — this is a single pass. If any role REJECTS, note the concern for the integrator but proceed.
+**No iteration** — single pass. If REJECTED, note concerns for integrator but proceed.
 
 ---
 
@@ -166,10 +186,12 @@ Same as standard integrator flow. Create `{run_dir}/integrator.md`:
 
 > You are the **Integrator Advocate** — a Systems Integrator & Ops Lead.
 >
-> Read ALL artifacts from all three scopes to understand the full debate arc:
-> - `*--S1-*.md` for alignment decisions
-> - `*--S2-*.md` for detailed proposals
-> - `*--S3-*.md` for final cross-checks
+> Read these artifacts (briefs over full files):
+> - S2 condensed brief: `{run_dir}/S2-brief.md` (primary context)
+> - S3 consolidated polish: `{run_dir}/polish--consolidated--S3-01.md` (cross-discipline conflicts and open items)
+> - S1 alignment verdicts: skim `{run_dir}/*--S1-*.md` for rejected roles and key flags
+>
+> You do NOT need to read every individual S2 advocate/contrarian file — the brief and polish doc contain the distilled decisions.
 >
 > Synthesize a unified plan. Write as `### Integrator Advocate` in `{run_dir}/integrator.md`.
 
@@ -217,8 +239,9 @@ Then run integrator duel and summary as above.
 ## Key Rules
 
 - **Advocate and Contrarian MUST be separate Agent invocations** — no shared context.
-- **Scope 1 and 3 run all roles in parallel** — they're short enough to parallelize.
-- **Scope 2 runs roles sequentially** — later roles benefit from reading earlier outputs.
+- **Scope 1 runs all roles in parallel** — short enough to parallelize.
+- **Scope 2 runs roles sequentially** with scoped reads and rolling briefs (`S2-brief.md`).
+- **Scope 3 is a single consolidated agent** — one cross-discipline check, not per-role pairs.
+- **Briefs over full reads** — later roles and integrator read `S2-brief.md` instead of all individual files.
 - **Word caps are instruction-enforced** — include them in the agent prompt, not as runtime truncation.
-- File naming: `advocate--marketing--S1-01.md`, `contrarian--engineering--S2-02.md`, `advocate--qa--S3-01.md`
-- The integrator reads ALL scope artifacts to synthesize the full debate arc.
+- File naming: `advocate--marketing--S1-01.md`, `contrarian--engineering--S2-02.md`, `polish--consolidated--S3-01.md`

--- a/.claude/commands/run-studio-phase.md
+++ b/.claude/commands/run-studio-phase.md
@@ -1,11 +1,12 @@
 # Studio Phase Run (Multi-Role)
 
-Execute a multi-role advocate/contrarian debate across disciplines (marketing, product, design, art, engineering, QA, etc.).
+Execute a multi-role advocate/contrarian debate across disciplines using a three-tier scoped debate: alignment → depth → polish.
 
 ## Arguments
 
 - `$ARGUMENTS` — Required. Format: `--text "your idea or objective"`
-- Optional: `--role-pack <name>` (default: studio_core), `--roles +role -role`, `--max-iterations N` (default 3)
+- Optional: `--role-pack <name>` (default: studio_core), `--roles +role -role`, `--max-iterations N` (default 6 across all scopes)
+- Optional: `--no-scopes` to use flat mode (all roles at full depth, no tiers)
 
 ## Instructions
 
@@ -13,124 +14,183 @@ You are executing a Studio multi-role phase run. Follow these steps exactly:
 
 ### Step 1: Prepare
 
-Run the prepare command to create a run directory and instructions:
-
 Determine the Studio root path. If this repo contains a `studio/run_phase.py`, use that. Otherwise check `$STUDIO_ROOT`. Then run:
 
 ```bash
-python "$STUDIO_ROOT/run_phase.py" prepare --phase studio $ARGUMENTS --no-scopes
+python "$STUDIO_ROOT/run_phase.py" prepare --phase studio $ARGUMENTS
 ```
 
-If running from a repo that is NOT the Studio repo itself, artifacts will automatically land in the current repo under `.studio/output/`. A bridge doc will be created on first use.
+If running from a repo that is NOT the Studio repo itself, artifacts will automatically land in the current repo under `.studio/output/`.
 
 Note the run_id and run directory path from the output.
 
 ### Step 2: Read Instructions and Role Menu
 
 Read the generated `instructions.md` file. Pay attention to:
-- The **Role Menu** table listing each invited role with its advocate/contrarian focuses and deliverables
-- The file naming convention: `advocate--<role>--<NN>.md` and `contrarian--<role>--<NN>.md`
-- The integrator duel section
+- The **Role Menu** table listing each invited role
+- The **Scope-Based Iteration Plan** (if scopes are enabled)
+- File naming convention
 
-### Step 3: Process Each Role Sequentially
+### Step 3: Execute Scoped Debate
 
-For each role listed in the Role Menu (process them in order):
+If `instructions.md` contains a **Scope-Based Iteration Plan**, follow the three-tier flow below. If `--no-scopes` was used, skip to the **Flat Mode** section at the bottom.
 
-#### a. Role Advocate
+---
 
-Use the Agent tool to spawn a subagent:
+#### Scope 1: ALIGNMENT (all roles, short, parallel)
 
-> You are the **{role_title} Advocate** for this Studio run.
+**Goal:** Directional alignment. "Should we go this way at all?"
+
+For each role in the Role Menu, spawn advocate + contrarian **in parallel** (all roles simultaneously):
+
+**Advocate prompt:**
+> You are the **{role_title} Advocate** for this Studio run — ALIGNMENT SCOPE.
 >
-> **Focus:** {advocate_focus from Role Menu}
->
+> **Focus:** {advocate_focus}
 > **Input/objective:** {the user's text}
 >
-> **Required deliverables:**
-> {deliverables list from Role Menu}
+> **IMPORTANT: Keep your response under 500 words.** This is a directional alignment pass. Focus on:
+> - Your high-level stance on the approach
+> - Any fatal flaws you see from your discipline
+> - Key trade-offs to flag for the room
+>
+> Do NOT produce full deliverables yet — save detail for the Depth scope.
+> Use bullet points, not full sections.
+>
+> Save to `{run_dir}/advocate--{role}--S1-01.md`.
+
+**Contrarian prompt (SEPARATE agent):**
+> You are the **{role_title} Contrarian** for this Studio run — ALIGNMENT SCOPE.
+>
+> **Focus:** {contrarian_focus}
+>
+> Read the advocate's alignment stance at `{run_dir}/advocate--{role}--S1-01.md`.
+>
+> **Keep your response under 500 words.** Only flag directional problems:
+> - Is the overall approach wrong?
+> - Are there fatal flaws the advocate missed?
+> - Any showstoppers from your discipline?
+>
+> End with `VERDICT: APPROVED` or `VERDICT: REJECTED` with numbered reasons.
+> Save to `{run_dir}/contrarian--{role}--S1-01.md`.
+
+**After all roles complete:** Read all contrarian verdicts.
+- If all APPROVED → proceed to Scope 2 with alignment context
+- If any REJECTED → note the rejection reasons. Proceed to Scope 2 anyway (the depth pass will address them), but include rejection context in each rejected role's depth prompt
+- If `max_iterations` for alignment scope allows iteration 2, loop rejected roles only (still with 500-word cap)
+
+---
+
+#### Scope 2: DEPTH (per-role, full, sequential)
+
+**Goal:** Detailed analysis per discipline. "How exactly should we do this?"
+
+Process each role **sequentially** (later roles can read earlier roles' outputs):
+
+**Advocate prompt:**
+> You are the **{role_title} Advocate** for this Studio run — DEPTH SCOPE.
+>
+> **Focus:** {advocate_focus}
+> **Input/objective:** {the user's text}
+>
+> **Context from Alignment scope:** Read the alignment artifacts in `{run_dir}/*--S1-*.md` to understand what was agreed and what was flagged across all disciplines.
+>
+> {If this role was REJECTED in alignment: "Alignment contrarian flagged these concerns:" + rejection reasons}
+>
+> **Required deliverables:** {deliverables list from Role Menu}
 >
 > {If this role has a prompt doc, read it at `studio/{prompt_doc}` for detailed guidance.}
 >
-> {If iteration > 1: "Previous contrarian feedback to address:" + rejection reasons}
->
-> Write a thorough advocate proposal covering all required deliverables. Save to `{run_dir}/advocate--{role}--{NN}.md`.
+> Write a thorough proposal covering all required deliverables. No word cap — this is the full analysis.
+> Save to `{run_dir}/advocate--{role}--S2-01.md`.
 
-#### b. Role Contrarian
-
-Use the Agent tool to spawn a SEPARATE subagent:
-
-> You are the **{role_title} Contrarian** for this Studio run.
+**Contrarian prompt (SEPARATE agent):**
+> You are the **{role_title} Contrarian** for this Studio run — DEPTH SCOPE.
 >
-> **Focus:** {contrarian_focus from Role Menu}
+> **Focus:** {contrarian_focus}
 >
-> Read the advocate's proposal at `{run_dir}/advocate--{role}--{NN}.md`.
+> Read the advocate's depth proposal at `{run_dir}/advocate--{role}--S2-{NN}.md`.
 >
-> Critically evaluate against your focus area. Check for:
-> - Fatal flaws in the proposal
-> - Unrealistic assumptions
-> - Missing considerations specific to your domain
-> - Risks that haven't been addressed
+> Critically evaluate against your focus area with full rigor. Check for:
+> - Fatal flaws, unrealistic assumptions, missing considerations
+> - Whether alignment-scope concerns were actually addressed
+> - Risks that haven't been mitigated
 >
-> **Escalation triggers** (flag immediately if found): {escalate_on from Role Menu}
+> **Escalation triggers** (flag immediately): {escalate_on from Role Menu}
 >
-> End with exactly `VERDICT: APPROVED` or `VERDICT: REJECTED`.
-> If REJECTED, list specific numbered reasons.
->
-> Save to `{run_dir}/contrarian--{role}--{NN}.md`.
+> End with `VERDICT: APPROVED` or `VERDICT: REJECTED` with numbered reasons.
+> Save to `{run_dir}/contrarian--{role}--S2-{NN}.md`.
 
-#### c. Check Verdict
+**Loop:** If REJECTED and iterations remain (up to 3), feed rejection back to advocate. If APPROVED, move to next role.
 
-Read the contrarian output. If `VERDICT: REJECTED` and iterations remain for this role, loop back to (a) with rejection feedback. If `VERDICT: APPROVED`, move to the next role.
+---
 
-### Step 4: Integrator Duel (after all roles complete)
+#### Scope 3: POLISH (all roles, short, parallel, 1 pass)
 
-Once all roles have been processed, create `{run_dir}/integrator.md` using separate Agent invocations:
+**Goal:** Cross-discipline gut-check. "Anything still broken across disciplines?"
+
+After all Scope 2 roles are approved, run one final parallel pass:
+
+**Advocate prompt:**
+> You are the **{role_title} Advocate** for this Studio run — POLISH SCOPE.
+>
+> **Keep your response under 300 words.**
+>
+> Read all Scope 2 artifacts in `{run_dir}/*--S2-*.md` to understand what each discipline proposed.
+>
+> Confirm your discipline's concerns are addressed in the integrated depth outputs. Flag any remaining cross-discipline conflicts. Do not introduce new proposals — only flag issues.
+>
+> Save to `{run_dir}/advocate--{role}--S3-01.md`.
+
+**Contrarian prompt (SEPARATE agent):**
+> You are the **{role_title} Contrarian** for this Studio run — POLISH SCOPE.
+>
+> **Keep your response under 300 words.**
+>
+> Read the advocate's polish check at `{run_dir}/advocate--{role}--S3-01.md`.
+>
+> Verify the advocate isn't rubber-stamping. Any real conflicts remaining?
+>
+> End with `VERDICT: APPROVED` or `VERDICT: REJECTED` with numbered reasons.
+> Save to `{run_dir}/contrarian--{role}--S3-01.md`.
+
+**No iteration** — this is a single pass. If any role REJECTS, note the concern for the integrator but proceed.
+
+---
+
+### Step 4: Integrator Duel (after Scope 3)
+
+Same as standard integrator flow. Create `{run_dir}/integrator.md`:
 
 #### a. Integrator Advocate
 
-Use the Agent tool:
-
 > You are the **Integrator Advocate** — a Systems Integrator & Ops Lead.
 >
-> Read ALL approved advocate and contrarian files from the run directory to understand what each discipline proposed and what concerns were raised.
+> Read ALL artifacts from all three scopes to understand the full debate arc:
+> - `*--S1-*.md` for alignment decisions
+> - `*--S2-*.md` for detailed proposals
+> - `*--S3-*.md` for final cross-checks
 >
-> Synthesize a unified plan that:
-> - Merges insights from all roles into a coherent roadmap
-> - Sequences work by priority and dependency
-> - Identifies cross-functional dependencies
-> - Proposes concrete next steps with owners
->
-> Write your synthesis as `### Integrator Advocate` in `{run_dir}/integrator.md`.
+> Synthesize a unified plan. Write as `### Integrator Advocate` in `{run_dir}/integrator.md`.
 
 #### b. Integrator Contrarian
 
-Use a SEPARATE Agent:
-
-> You are the **Integrator Contrarian** — a Director of Live Service Operations.
+> You are the **Integrator Contrarian** — Director of Live Service Operations.
 >
-> Read `{run_dir}/integrator.md` (the Integrator Advocate section).
->
-> Critique the integrated plan for:
-> - Feasibility and resource constraints
-> - Operational risk and maintenance burden
-> - Sequencing issues and dependency conflicts
-> - Missing stakeholders or unresolved tensions between roles
->
-> End with `VERDICT: APPROVED` or `VERDICT: REJECTED` with numbered reasons.
-> If REJECTED, the integrator gets one revision (max 2 total integrator iterations).
->
-> Append your review as `### Integrator Contrarian` in `{run_dir}/integrator.md`.
+> Read `{run_dir}/integrator.md`. Critique for feasibility, sequencing, and missing concerns.
+> End with `VERDICT: APPROVED` or `VERDICT: REJECTED`.
+> Append as `### Integrator Contrarian` in `{run_dir}/integrator.md`.
 
 #### c. Integrated Plan
 
-After the integrator duel resolves (approved or max iterations), append a `### Integrated Plan` section to `{run_dir}/integrator.md` that synthesizes both perspectives into the final roadmap with next steps.
+Append `### Integrated Plan` to `{run_dir}/integrator.md`.
 
 ### Step 5: Summary
 
 Write `{run_dir}/summary.md` covering:
 - Original input/objective
-- Which roles participated and their verdicts
-- Key recommendations from each discipline
+- Scope progression (what was caught at each tier)
+- Which roles participated and their verdicts per scope
 - The integrated plan highlights
 - Concrete next actions
 
@@ -140,11 +200,25 @@ Write `{run_dir}/summary.md` covering:
 python "$STUDIO_ROOT/run_phase.py" finalize --phase studio --run-id {run_id} --status completed --verdict {APPROVED|REJECTED}
 ```
 
+---
+
+## Flat Mode (--no-scopes)
+
+When `--no-scopes` is used, fall back to the original single-tier flow:
+
+For each role sequentially:
+1. Spawn advocate agent (full depth, no word cap)
+2. Spawn SEPARATE contrarian agent
+3. If REJECTED and iterations remain, loop
+4. If APPROVED, next role
+
+Then run integrator duel and summary as above.
+
 ## Key Rules
 
-- **Each role's Advocate and Contrarian MUST be separate Agent invocations** — no shared context.
-- **Process roles sequentially** — later roles can benefit from reading earlier roles' outputs if relevant.
-- **Integrator Advocate and Contrarian are also separate agents.**
-- The contrarian reads ONLY the advocate's written file for that role.
-- File naming: `advocate--marketing--01.md`, `contrarian--engineering--02.md`, etc.
-- The integrator reads ALL role artifacts to synthesize.
+- **Advocate and Contrarian MUST be separate Agent invocations** — no shared context.
+- **Scope 1 and 3 run all roles in parallel** — they're short enough to parallelize.
+- **Scope 2 runs roles sequentially** — later roles benefit from reading earlier outputs.
+- **Word caps are instruction-enforced** — include them in the agent prompt, not as runtime truncation.
+- File naming: `advocate--marketing--S1-01.md`, `contrarian--engineering--S2-02.md`, `advocate--qa--S3-01.md`
+- The integrator reads ALL scope artifacts to synthesize the full debate arc.

--- a/.claude/projects/-Users-orcpunk-Repos--TheGameStudio/memory/project_aitdd_integration.md
+++ b/.claude/projects/-Users-orcpunk-Repos--TheGameStudio/memory/project_aitdd_integration.md
@@ -1,0 +1,11 @@
+---
+name: AI-TDD Integration Initiative
+description: Integrating AI-assisted TDD methodology into Studio workflow — new test_engineer role, enforcement at validation and instruction generation layers
+type: project
+---
+
+AI-TDD methodology is being baked into the Studio workflow as a first-class concern. Core principles: scenario-first (Given-When-Then before code), stack boundary declarations, human-owned assertions, mutation verification, anti-pattern detection (self-mocking, tautological assertions, green checkmark trap).
+
+**Why:** AI-generated tests that mock the SUT or write tautological assertions create dangerous false confidence. The existing QA role focuses on release ops, not test methodology integrity.
+
+**How to apply:** A new `test_engineer` role is proposed (not in studio_core by default — opt-in via `+test_engineer` or `studio_tech` role pack). The methodology doc lives at `studio/docs/AI_TDD_METHODOLOGY.md`. Changes touch the manifest, role prompts, slash commands, validators, and instruction generation. Engineering and QA contrarians get sharpened with AI-TDD awareness too.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add:*)",
+      "Bash(done)",
+      "Bash(gh pr:*)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Use the slash command to run a full advocate/contrarian debate:
 /run-studio-phase --text "Add AI critique engine" --roles +marketing +engineering
 ```
 
-Single-phase runs (`/run-phase`) spawn separate Advocate and Contrarian agents per iteration. Multi-role runs (`/run-studio-phase`) process each discipline sequentially, then run an Integrator duel. See `studio/docs/CLAUDE_CODE_USAGE.md` for details.
+Single-phase runs (`/run-phase`) spawn separate Advocate and Contrarian agents per iteration. Multi-role runs (`/run-studio-phase`) use a three-tier scoped debate by default: **alignment** (all roles, short, parallel) → **depth** (per-role, full, sequential) → **polish** (all roles, short, 1 pass) → integrator duel. Use `--no-scopes` for flat mode. See `studio/docs/CLAUDE_CODE_USAGE.md` for details.
 
 ## CLI Commands
 
@@ -53,15 +53,16 @@ All source lives under `studio/`. `run_phase.py` is the sole entrypoint using on
 - **`run_phase.py`** — Primary entrypoint: `prepare`, `finalize`, `validate`, `cleanup` subcommands.
 - **`run_phase_roles.py`** — Role system: loads `studio.manifest.json`, resolves role packs, builds per-role file naming (`advocate--<role>--NN.md`).
 - **`cleanup.py`** — TTL-based (30 days) and budget-based (900MB) run artifact cleanup.
-- **`scopes.py`** — Scope-based iteration allocation (high_level / implementation / polish).
+- **`scopes.py`** — Three-tier scope system (alignment / depth / polish) with output budgets and debate modes (`all_roles` vs `per_role`).
 - **`rerun.py`** — Detects rejection context from prior runs and generates rerun instructions.
 - **`verdict.py`** — Extracts APPROVED/REJECTED/UNKNOWN verdict from text.
 - **`validators/`** — `DocumentValidator` and `CodeValidator` for post-run quality checks.
 
 ### Configuration files
 
-- **`studio.manifest.json`** — Defines all disciplines (marketing, product, design, art, engineering, qa, ml, pmm) with advocate/contrarian focuses, deliverables, and escalation cues.
-- **`role_packs/*.json`** — Curated pod presets (e.g., `studio_core` = marketing + product + design + art + engineering + qa). Override with `--roles +role/-role`.
+- **`studio.manifest.json`** — Defines all disciplines (marketing, product, design, art, engineering, test_engineer, qa, ml, pmm) with advocate/contrarian focuses, deliverables, escalation cues, and role dependencies.
+- **`role_packs/*.json`** — Curated pod presets (e.g., `studio_core` = marketing + product + design + art + engineering + test_engineer + qa). Override with `--roles +role/-role`. Role dependencies in the manifest auto-inject co-required roles (e.g., engineering always brings test_engineer).
+- **`config/scopes.toml`** — Default three-tier scope configuration (alignment → depth → polish) with output budgets and debate modes.
 - **`config/studio_settings.toml`** — Cleanup TTL and storage limits.
 - **`.studio/scopes.toml`** — Scope-based iteration budgets (auto-loaded if present).
 - **`.studio/validation.toml`** — Validation configuration.
@@ -71,7 +72,8 @@ All source lives under `studio/`. `run_phase.py` is the sole entrypoint using on
 Runs produce timestamped directories under `output/<phase>/run_<phase>_<timestamp>/` containing:
 - `instructions.md`, `run.json`, `summary.md`
 - `advocate_N.md` / `contrarian_N.md` (simple phases)
-- `advocate--<role>--NN.md` / `contrarian--<role>--NN.md` + `integrator.md` (studio phase)
+- `advocate--<role>--NN.md` / `contrarian--<role>--NN.md` + `integrator.md` (studio flat mode)
+- `advocate--<role>--S1-NN.md` / `S2-NN.md` / `S3-NN.md` (studio scoped mode: alignment/depth/polish)
 
 ### Phases
 
@@ -81,7 +83,7 @@ Four phases: `market`, `design`, `tech`, `studio`. Each has distinct advocate/co
 
 - **Python 3.10+** required. Uses `tomllib` (3.11+) with `tomli` fallback.
 - **No heavy dependencies** — keep `run_phase.py` small and bash-friendly.
-- **Test-driven discipline** is mandatory for tech phase implementations.
+- **AI-TDD discipline** is mandatory for tech phase implementations. AI writes scenarios and boilerplate; humans own assertions. See `studio/docs/AI_TDD_METHODOLOGY.md` for the full methodology (scenario-first, stack boundary, mutation verification, anti-pattern detection).
 - **Documentation contract**: changes to workflow must update README, STUDIO_INTERACTION_GUIDE.md, and affected bridge docs simultaneously.
 - **Working directories**: `.scratch/` for temp files, `.private/` for sensitive data — both gitignored. Never commit `studio/output/` or `studio/knowledge/`.
 - Cross-repo usage: when run outside this repo, artifacts go to `<repo>/.studio/output/`. First run auto-scaffolds `.studio/` and a bridge doc. Override with `--artifact-root` flag or `STUDIO_ARTIFACT_ROOT` env var. Priority: flag > env > cwd detection.

--- a/README.md
+++ b/README.md
@@ -2,237 +2,260 @@
 
 Studio is an **instruction generator** for structured advocate/contrarian debates. It prepares run directories with instructions that an AI assistant (Claude Code, Windsurf/Cascade, or any capable agent) executes, then packages the results as versioned artifacts.
 
-Key goals:
-
-1. **Assistant-agnostic workflow** — no runtime, no API keys; any capable AI assistant can execute the generated instructions.
-2. **Deterministic packaging** — every phase run creates a folder with instructions, iteration transcripts, summary, and metadata.
-3. **Cross-project visibility** — every artifact root gets its own `output/index.md` and `knowledge/run_log.md` so any repo can pick up the latest context.
+**No runtime. No API keys. No dependencies beyond Python stdlib.** All intelligence lives in the assistant's execution — Studio just keeps the prompts, roles, artifacts, and logs organized.
 
 ---
 
-## Role Packs & Role Menu
+## Quick Start
 
-- **Manifest (`studio.manifest.json`)** defines every discipline (title, focuses, prompt doc, deliverables, escalation cues).
-- **Role packs (`role_packs/*.json`)** are curated pod presets (e.g., `studio_core` = marketing + product + design + art + engineering + QA). Downstream repos do *not* fork them; they supply `--roles` overrides (typically `+product +engineering +qa`, with optional `-role` removals when needed).
-- **Instructions** now include a Role Menu table linking to prompt docs and file names (e.g., `advocate--design--02.md`).
-- **Finalize** validates that each invited role produced both advocate/contrarian artifacts and records missing pods inside `run.json["studio_roles"]["missing"]`.
-- **Integrator duel** is captured inside `integrator.md` with `### Integrator Advocate`, `### Integrator Contrarian (VERDICT)`, and `### Integrated Plan`.
-
-When in doubt, run:
 ```bash
-python run_phase.py prepare --phase studio --text "..." --role-pack studio_core
+# 1. Clone this repo
+git clone <repo-url> && cd TheGameStudio
+
+# 2. Run a single-phase debate (market, design, or tech)
+python studio/run_phase.py prepare --phase market --text "A cozy farming sim with time travel"
+
+# 3. Hand the generated instructions.md to your AI assistant
+#    It will produce advocate_1.md, contrarian_1.md, summary.md
+
+# 4. Finalize the run
+python studio/run_phase.py finalize --phase market --run-id <run_id> --status completed --verdict APPROVED
 ```
-and add attendees via `--roles +product +engineering +qa`.
 
-## Test-Driven Development Discipline
-
-**All tech phase implementations must follow test-driven discipline:**
-
-- Define testable requirements in the advocate phase
-- Write test specifications before implementation
-- Write test code that initially fails
-- Implement code to pass the tests
-- Include verification instructions
-
-Tech implementations without tests are incomplete. See **[docs/TEST_DRIVEN_GUIDE.md](./studio/docs/TEST_DRIVEN_GUIDE.md)** for the complete workflow, examples, and quality standards.
-
-## What's in the box?
-
-| Path | Purpose |
-| --- | --- |
-| `run_phase.py` | Primary CLI entrypoint. Creates instructions + folders (`prepare`) and finalizes runs after the assistant finishes (`finalize`). Also `validate` and `cleanup`. |
-| `output/` or `.studio/output/` | Auto-generated artifacts grouped by phase (`<artifact_root>/output/<phase>/run_<phase>_<timestamp>/…`). |
-| `knowledge/run_log.md` or `.studio/knowledge/run_log.md` | Chronological feed of finalized runs with verdict, hours, cost, and summary links. |
-| `docs/` | Guides, bridge templates, and architecture notes. |
-| `studio.manifest.json` (optional) | Example of per-repo role overrides for advocates/contrarians. |
+**With Claude Code**, use slash commands instead:
+```
+/run-phase --phase market --text "A cozy farming sim with time travel"
+/run-studio-phase --text "Evaluate our multiplayer architecture" --roles +engineering +qa
+```
 
 ---
 
-## Zero-Setup Quick Start
+## How It Works
 
-1. **Clone** this repo somewhere long-lived.
-2. **(Optional)** Set `STUDIO_ROOT` if needed:
-   ```bash
-   export STUDIO_ROOT="/absolute/path/to/studio"
-   ```
-3. **Prepare a run** from any other repo or terminal:
-   ```bash
-   python $STUDIO_ROOT/run_phase.py \
-     prepare --phase market \
-     --text "A cozy farming sim with time travel"
-   ```
-   Output:
-   - `.studio/output/market/run_market_20251223_170045/instructions.md` (when run outside Studio)
-   - `run.json` metadata + empty artifact placeholders
-   - `.studio/output/index.md` updated with the new run ID
-4. **(Studio phase only)** If you want multiple disciplines in the room, add:
-   ```bash
-   python $STUDIO_ROOT/run_phase.py \
-     prepare --phase studio \
-     --text "Self-critique Studio" \
-     --role-pack studio_core --roles +product +engineering +qa
-   ```
-   - `--role-pack` pulls a preset pod from `role_packs/`.
-   - `--roles` lets you include/exclude roles (`+role`/`-role`) without editing instructions.
-   - You can pass role overrides either as `--roles +product +engineering +qa` or repeated `--roles=+product --roles=+engineering --roles=+qa`.
-   - Instructions will list a **Role Menu** with per-role file targets like `advocate--design--01.md`.
-5. **Execute with your AI assistant**:
-   - Paste the instructions into your assistant (Claude Code, Windsurf/Cascade, etc.).
-   - For each iteration, save files exactly where the instructions specify (`advocate_1.md`, `contrarian_1.md`, etc.).
-   - Generate `summary.md` (and `implementation.md` for tech phase, `integrator.md` for studio phase).
-6. **Finalize** once artifacts are in place:
-   ```bash
-   python $STUDIO_ROOT/run_phase.py \
-     finalize --phase market \
-     --run-id run_market_20251223_170045 \
-     --status completed --verdict APPROVED \
-     --hours 0.75 --cost 0
-   ```
-   Finalize will:
-   - Validate required artifacts are present.
-   - Count iterations automatically.
-   - Refresh `<active_output_root>/index.md`.
-   - Append an entry to `<active_knowledge_root>/run_log.md`.
-7. **Validate** (optional but recommended):
-   ```bash
-   python $STUDIO_ROOT/run_phase.py \
-     validate --phase market \
-     --run-id run_market_20251223_170045
-   ```
-   Validates document quality and code (if tech phase).
+```
+prepare ──→ instructions.md ──→ AI assistant executes ──→ finalize
+   │                                    │                      │
+   │  Creates run directory,            │  Advocate argues      │  Logs results,
+   │  role menu, personas,              │  for the idea.        │  updates indexes,
+   │  iteration rules                   │  Contrarian attacks   │  runs quality checks
+   │                                    │  it. Loop until       │
+   │                                    │  VERDICT: APPROVED    │
+```
 
-That's the whole loop.
+### Four Phases
+
+| Phase | What It Does | Output |
+|-------|-------------|--------|
+| `market` | Viability analysis — audience, competition, GTM | `advocate_N.md`, `contrarian_N.md`, `summary.md` |
+| `design` | Game design — core loop, mechanics, scope | Same |
+| `tech` | Technical architecture — stack, performance, ops | Same + `implementation.md` with tests |
+| `studio` | Multi-role debate — all disciplines in the room | Per-role files + `integrator.md` |
 
 ---
 
-## Artifact Root Behavior (Cross-Repo Safety)
+## Multi-Role Studio Runs
 
-- If you run `run_phase.py` **inside this Studio repo**, artifacts stay in `studio/output` and `studio/knowledge`.
-- If you run it from a **different repo**, artifacts now default to that repo under:
-  - `.studio/output/<phase>/run_*`
-  - `.studio/knowledge/run_log.md`
-- You can override artifact placement explicitly with:
-  ```bash
-  export STUDIO_ARTIFACT_ROOT="/absolute/path/to/host-repo"
-  ```
+The `studio` phase brings multiple disciplines into a structured debate. The default `studio_core` pack includes 7 roles:
 
-This keeps generated docs/working files with the repo that requested the run, while still using centralized Studio prompts and role packs.
+| Role | Advocate Focus | Contrarian Focus |
+|------|---------------|-----------------|
+| **Marketing** | Viral hook, audience segmentation, GTM | TAM realism, UA cost scrutiny |
+| **Product** | Roadmap sequencing, staffing, success metrics | Priority tradeoffs, ownership gaps |
+| **Design** | Experience pillars, core loop | Scope control, UX clarity |
+| **Art** | Visual north star, references | Production feasibility, tooling readiness |
+| **Engineering** | Architecture, integrations, performance | Ops toil, technical risk |
+| **Test Engineer** | Scenario-first test design, mutation verification | Self-mocking tests, hallucinated assertions |
+| **QA** | Validation strategy, telemetry | Coverage gaps, environment readiness |
+
+### Role Dependencies
+
+Engineering automatically brings Test Engineer into the room (`engineering → test_engineer`). Override with `-test_engineer` if explicitly unwanted.
+
+### Three-Tier Scoped Debate (Default)
+
+Studio runs use a scoped debate flow to manage token usage and debate quality:
+
+```
+┌─ ALIGNMENT ─────────────────────────────────┐
+│ All roles in parallel. ~500 words each.     │
+│ "Should we go this way at all?"             │
+│ Catches fatal flaws cheaply.                │
+├─ DEPTH ─────────────────────────────────────┤
+│ Each role sequentially. Full deliverables.  │
+│ "How exactly should we do this?"            │
+│ Starts focused thanks to alignment context. │
+├─ POLISH ────────────────────────────────────┤
+│ All roles in parallel. ~300 words each.     │
+│ "Anything still broken across disciplines?" │
+│ Final cross-check before integrator.        │
+├─ INTEGRATOR ────────────────────────────────┤
+│ Synthesize all roles into unified roadmap.  │
+│ Own advocate/contrarian duel.               │
+└─────────────────────────────────────────────┘
+```
+
+Use `--no-scopes` for flat mode (all roles at full depth, no tiers).
+
+Scope configuration lives in `config/scopes.toml` and can be overridden per-project.
 
 ---
 
-## Standard Workflow (per phase)
+## CLI Reference
 
-1. **Bridge doc first** — copy `docs/STUDIO_BRIDGE_TEMPLATE.md` into each dependent repo (e.g., `docs/studio-bridge.md`) and fill in:
-   - Where Studio lives.
-   - Canonical project docs the assistant must load.
-   - Prompt template referencing the bridge doc, canon, objectives, and run folder.
-2. **Prepare** with `run_phase.py`.
-3. **Assistant executes** Advocate → Contrarian loops using the generated instructions.
-4. **Finalize** to lock the run and log it.
-5. **Link back** to the run folder inside your project issue, PR, or design doc.
+```bash
+# Prepare a run
+python studio/run_phase.py prepare --phase <market|design|tech|studio> --text "description"
 
-All automation, scripting, or CI integrations should call `run_phase.py` rather than importing Python modules.
+# Prepare with role pack and overrides
+python studio/run_phase.py prepare --phase studio --text "..." \
+  --role-pack studio_core --roles +product +engineering +qa
+
+# Finalize a completed run
+python studio/run_phase.py finalize --phase <phase> --run-id <run_id> \
+  --status completed --verdict APPROVED
+
+# Validate document quality and code
+python studio/run_phase.py validate --phase <phase> --run-id <run_id>
+
+# Preview / execute storage cleanup
+python studio/run_phase.py cleanup --dry-run
+python studio/run_phase.py cleanup
+```
+
+---
+
+## Cross-Repo Usage
+
+Run Studio from any repo — artifacts stay with the calling repo:
+
+```bash
+export STUDIO_ROOT="/path/to/TheGameStudio/studio"
+cd ~/my-game-project
+python $STUDIO_ROOT/run_phase.py prepare --phase tech --text "Build lobby system"
+# Artifacts land in ./my-game-project/.studio/output/tech/run_tech_<timestamp>/
+```
+
+First run auto-scaffolds `.studio/` and creates a bridge doc. Override with `--artifact-root` or `STUDIO_ARTIFACT_ROOT` env var. Priority: flag > env > cwd detection.
+
+---
 
 ## Run Directory Anatomy
 
 ```
-.studio/output/                         # when run from another repo
+.studio/output/
   market/
-    run_market_20251223_170045/
-      instructions.md
-      advocate_1.md
-      contrarian_1.md
-      implementation.md   # tech phase; optional for market/design
-      summary.md
-      run.json
+    run_market_20260314_034202/
+      instructions.md          # Generated prompts and personas
+      advocate_1.md            # Advocate's proposal
+      contrarian_1.md          # Contrarian's critique + VERDICT
+      summary.md               # Run summary
+      run.json                 # Metadata, quality checks, token budget
   studio/
-    run_studio_20251223_230322/
+    run_studio_20260314_034202/
       instructions.md
-      advocate--marketing--01.md
-      contrarian--marketing--01.md
-      ... (per-role files)
-      integrator.md
+      advocate--marketing--S1-01.md    # Alignment scope
+      contrarian--marketing--S1-01.md
+      advocate--engineering--S2-01.md  # Depth scope
+      contrarian--engineering--S2-01.md
+      advocate--qa--S3-01.md           # Polish scope
+      contrarian--qa--S3-01.md
+      integrator.md                    # Integrated roadmap
       summary.md
       run.json
 ```
 
-`run.json` fields:
+### run.json Metadata
 
 | Key | Meaning |
-| --- | --- |
-| `run_id` | Unique identifier (`run_<phase>_<timestamp>`). |
-| `phase` | `market`, `design`, `tech`, or `studio`. |
-| `input` | Text supplied via `--text`. |
-| `max_iterations` | Cap provided at prepare time. |
-| `status` / `verdict` | Filled in when finalized. |
-| `iterations_run`, `hours`, `cost` | Auto-tracked or provided on finalize. |
-| `summary_path` | Resolved path to `summary.md` (auto-set if blank). |
-| `studio_roles` | Studio-only metadata: `{pack, overrides, invited, completed, missing}`. |
+|-----|---------|
+| `run_id` | Unique identifier (`run_<phase>_<timestamp>`) |
+| `phase` | `market`, `design`, `tech`, or `studio` |
+| `status` / `verdict` | `COMPLETED` + `APPROVED`/`REJECTED` after finalize |
+| `studio_roles` | `{pack, overrides, invited, completed, missing}` |
+| `quality` | Finalize-time quality checks: `{checks_run, warnings, errors}` |
+| `token_budget` | Per-scope output stats: `{files, total_chars, avg_words}` |
 
-When you run from inside the Studio repo, the same structure appears under `studio/output/` and `studio/knowledge/`.
+---
 
-Use these files as the single source of truth when referencing decisions or continuing work.
+## AI-TDD Discipline
+
+All tech phase implementations follow AI-assisted test-driven development:
+
+- **Scenario-first**: Generate Given-When-Then scenarios before any test code
+- **Context boundary**: Declare exact stack, ban incompatible frameworks
+- **Assertion ownership**: AI writes setup and boilerplate; humans own assertions
+- **Mutation verification**: Deliberately break production code to verify tests catch it
+- **Anti-pattern detection**: Reject self-mocking tests, hallucinated assertions, implementation-coupled tests
+
+The **Test Engineer** role enforces these in every run that includes engineering. See [AI_TDD_METHODOLOGY.md](./studio/docs/AI_TDD_METHODOLOGY.md).
+
+---
+
+## Quality Checks
+
+Finalize runs quality checks on every advocate/contrarian artifact (warnings only, never blocks):
+
+- **Verdict presence**: Warns if contrarian files lack `VERDICT: APPROVED/REJECTED`
+- **Rubber-stamp detection**: Flags files under 200 characters
+- **Format validation**: Checks markdown structure, title presence, list formatting
+- **Token budget tracking**: Measures output per scope (chars, words, file count)
+
+Results are stored in `run.json["quality"]` and `run.json["token_budget"]`.
 
 ---
 
 ## Cleanup & Storage
 
-Studio enforces dual cleanup rules automatically on every `prepare` call:
+Automatic on every `prepare` call:
 
-1. **Time-to-live:** runs older than **30 days** are purged.
-2. **Storage budget:** total run storage is capped at **900 MB**. When exceeded, oldest runs are deleted until under budget.
+- **TTL**: Runs older than 30 days are purged
+- **Budget**: Total storage capped at 900MB; oldest runs deleted first
 
-Controls live in `config/studio_settings.toml`:
+Configure in `config/studio_settings.toml`. Use `--skip-cleanup` to bypass.
 
-```toml
-[cleanup]
-ttl_days = 30
-size_limit_mb = 900
+---
+
+## Project Structure
+
 ```
+studio/
+  run_phase.py              # CLI entrypoint: prepare, finalize, validate, cleanup
+  run_phase_roles.py        # Role system: manifest, packs, dependencies, file naming
+  scopes.py                 # Three-tier scope allocation (alignment/depth/polish)
+  cleanup.py                # TTL + budget-based artifact cleanup
+  rerun.py                  # Rejection context injection for iterate-on-failure
+  verdict.py                # APPROVED/REJECTED extraction
+  validators/               # DocumentValidator + CodeValidator
+  studio.manifest.json      # Role definitions (9 disciplines)
+  role_packs/*.json          # Curated role sets (studio_core, etc.)
+  config/scopes.toml         # Default scope configuration
+  config/studio_settings.toml # Cleanup settings
+  docs/                     # Guides, role prompts, architecture
+  tests/                    # 204 tests (pytest)
+```
+
+---
+
+## Testing
 
 ```bash
-# Preview what would be deleted
-python run_phase.py cleanup --dry-run
-
-# Execute cleanup
-python run_phase.py cleanup
+cd studio && python -m pytest tests/ -v
 ```
 
-| Option | Purpose |
-| --- | --- |
-| `--skip-cleanup` / `STUDIO_SKIP_CLEANUP=1` | Bypass the cleanup pass. |
-| `--cleanup-dry-run` / `STUDIO_CLEANUP_DRY_RUN=1` | Log what would be deleted without touching files. |
+204 tests covering: prepare/finalize lifecycle, role resolution with dependency injection, TTL/budget cleanup with boundary conditions, scope allocation, rerun detection, verdict extraction, document validation, code validation, and cross-repo artifact routing.
 
-See **[docs/STORAGE_MANAGEMENT.md](./studio/docs/STORAGE_MANAGEMENT.md)** for details.
+Python 3.10+ required. stdlib only, plus `tomli` on Python 3.10 (see `pyproject.toml`).
 
 ---
 
-## Documentation Contract
+## Documentation
 
-Whenever you change the workflow:
-
-1. Update **this README**.
-2. Update **STUDIO_INTERACTION_GUIDE.md**.
-3. Update every affected **bridge doc** in downstream repos.
-
-No change is "done" until all three are in sync.
-
-Reference material:
-
-- [STUDIO_INTERACTION_GUIDE.md](./studio/STUDIO_INTERACTION_GUIDE.md) — hands-on instructions and troubleshooting.
-- [docs/INDEX.md](./studio/docs/INDEX.md) — full documentation index.
-- [docs/STUDIO_BRIDGE_TEMPLATE.md](./studio/docs/STUDIO_BRIDGE_TEMPLATE.md) — copy into other repos before running Studio.
-- [docs/ARCHITECTURE.md](./studio/docs/ARCHITECTURE.md) — system design and extensibility.
-
----
-
-## Testing & Dev Notes
-
-- Run tests (from `studio/` directory):
-  ```bash
-  cd studio && python -m pytest tests/ -v
-  ```
-- Python dependencies are minimal: stdlib only, plus `tomli` on Python 3.10 (see `pyproject.toml`).
+- [ARCHITECTURE.md](./studio/docs/ARCHITECTURE.md) — system design and extensibility
+- [AGENTS_REFERENCE.md](./studio/docs/AGENTS_REFERENCE.md) — role definitions and debate flow
+- [AI_TDD_METHODOLOGY.md](./studio/docs/AI_TDD_METHODOLOGY.md) — AI-assisted testing methodology
+- [TEST_DRIVEN_GUIDE.md](./studio/docs/TEST_DRIVEN_GUIDE.md) — tech phase TDD workflow
+- [INTEGRATION_GUIDE.md](./studio/docs/INTEGRATION_GUIDE.md) — cross-repo setup
+- [STUDIO_BRIDGE_TEMPLATE.md](./studio/docs/STUDIO_BRIDGE_TEMPLATE.md) — template for downstream repos
 
 ---
 

--- a/studio/config/scopes.toml
+++ b/studio/config/scopes.toml
@@ -1,0 +1,21 @@
+# Default scope configuration for Studio multi-role runs.
+#
+# Three-tier scoped debate: alignment → depth → polish.
+# Override with --scopes <path> or --no-scopes for flat mode.
+
+[scopes.alignment]
+focus = "Directional alignment — approach, fatal flaws, high-level trade-offs only. Save detail for Depth."
+max_iterations = 2
+output_budget = 500
+debate_mode = "all_roles"
+
+[scopes.depth]
+focus = "Full analysis — detailed deliverables, edge cases, concrete recommendations per discipline."
+max_iterations = 3
+debate_mode = "per_role"
+
+[scopes.polish]
+focus = "Cross-discipline conflicts — flag remaining issues across roles, no new proposals."
+max_iterations = 1
+output_budget = 300
+debate_mode = "all_roles"

--- a/studio/docs/AGENTS_REFERENCE.md
+++ b/studio/docs/AGENTS_REFERENCE.md
@@ -43,9 +43,21 @@ Studio phase now hosts as many Advocate↔Contrarian duos as needed. The default
 | design | Lead Systems Designer | Experience pillars, core loop | Scope control, UX clarity | Loop sketch, risks list |
 | art | Art Director | Visual north star, references | Production feasibility, tooling readiness | Mood board, style guardrails |
 | engineering | Principal Gameplay Engineer | Architecture, integrations, performance | Ops toil, technical risk | System outline, stack choices, ops checklist |
-| qa | Release QA & Launch Ops Lead | Validation strategy, telemetry | Coverage gaps, environment readiness | Test matrix, rollback plan, instrumentation gaps |
+| test_engineer | Staff Test Engineer — AI-TDD Integrity | Scenario-first test design, stack boundaries, mutation verification | Self-mocking tests, hallucinated assertions, green checkmark trap | Test spec (GWT), context boundary, mutation plan, anti-pattern audit |
+| qa | Release QA & Launch Ops Lead | Validation strategy, telemetry | Coverage breadth, environment readiness, support gaps | Test matrix, rollback plan, instrumentation gaps |
 
-Each invited role writes `advocate--<role>--NN.md` and `contrarian--<role>--NN.md` until the contrarian issues `VERDICT: APPROVED`. After all critical roles approve, the Integrator runs a capped duel (two passes max) inside `integrator.md`.
+**Role dependencies:** The manifest declares co-requirements — `engineering → test_engineer`. When engineering is present, test_engineer is automatically injected after it. This ensures test integrity is always debated when technical work is proposed. Override with `-test_engineer` only when explicitly unwanted.
+
+### Three-Tier Scoped Debate (Default)
+
+Studio runs use a scoped flow by default (override with `--no-scopes`):
+
+1. **Alignment** — All roles debate in parallel, ~500-word cap. Catches directional problems cheaply before deep dives. File naming: `advocate--<role>--S1-NN.md`
+2. **Depth** — Each role debates sequentially with full deliverables, no word cap. Starts focused because alignment context is available. File naming: `advocate--<role>--S2-NN.md`
+3. **Polish** — All roles in parallel, ~300-word cap, single pass. Cross-discipline gut-check. File naming: `advocate--<role>--S3-NN.md`
+4. **Integrator** — After all roles approve in polish, synthesizes into `integrator.md` with capped duel (two passes max).
+
+In flat mode (`--no-scopes`), each role writes `advocate--<role>--NN.md` and `contrarian--<role>--NN.md` until approved, then the Integrator runs.
 
 ---
 
@@ -63,7 +75,8 @@ Each invited role writes `advocate--<role>--NN.md` and `contrarian--<role>--NN.m
 | --- | --- | --- | --- |
 | Market/Design | `advocate_<n>.md` | `contrarian_<n>.md` | `summary.md` (discussion phases) |
 | Tech | `advocate_<n>.md` | `contrarian_<n>.md` | `implementation.md` (with tests) |
-| Studio | `advocate--<role>--<n>.md` | `contrarian--<role>--<n>.md` | `integrator.md` (with duel sections) |
+| Studio (flat) | `advocate--<role>--<n>.md` | `contrarian--<role>--<n>.md` | `integrator.md` (with duel sections) |
+| Studio (scoped) | `advocate--<role>--S1-<n>.md` etc. | `contrarian--<role>--S1-<n>.md` etc. | `integrator.md` (with duel sections) |
 
 Contrarians must always end with `VERDICT: APPROVED` or `VERDICT: REJECTED`. Finalize will flag missing files per role and record `completed`/`missing` lists in `run.json["studio_roles"]`.
 

--- a/studio/docs/AI_TDD_METHODOLOGY.md
+++ b/studio/docs/AI_TDD_METHODOLOGY.md
@@ -1,0 +1,123 @@
+# AI-Assisted Test-Driven Development (AI-TDD) Methodology
+
+This document codifies how we use AI assistants for test generation and validation. It exists because **AI is excellent at brainstorming and boilerplate but dangerous at assertions** — and our workflow must enforce that boundary.
+
+---
+
+## The Core Problem
+
+When you ask an AI to "write tests," it optimizes for green checkmarks, not correctness. It will:
+- Mock the system under test itself (testing nothing)
+- Write tautological assertions (`assertTrue(true)`)
+- Use deprecated frameworks or mix incompatible ones
+- Verify that mocks *weren't* called when they clearly should be
+- Produce 100% coverage of 0% of your actual logic
+
+**The fix is structural, not prompting harder.** Our workflow separates the things AI is good at from the things it will silently get wrong.
+
+---
+
+## The Paradigm: AI as Scenario Generator, Not SDET
+
+| AI's Job | Human's Job |
+|----------|-------------|
+| Brainstorm edge cases and scenarios | Decide which scenarios matter |
+| Generate Given-When-Then specs | Review and approve the spec list |
+| Write mock setup and boilerplate | Write or strictly review assertions |
+| Generate parameterized test data | Validate data correctness |
+| Format and structure test files | Verify tests actually catch bugs |
+
+**You are the SDET. The AI is your brainstorming assistant and boilerplate typist.**
+
+---
+
+## Three Rules for AI-Assisted Testing
+
+### Rule 1: Scenario-First (Given-When-Then Brainstorm)
+
+**Never ask AI to write test code first.** Ask it to generate scenarios in plain English.
+
+Bad:
+> "Write tests for this checkout function."
+
+Good:
+> "Read this CheckoutUseCase. List all test scenarios using Given-When-Then format. Pay special attention to edge cases, null values, concurrency failures, and boundary conditions. Do not write any code yet."
+
+Once you review the scenario list, selectively approve which ones to implement:
+> "Write test code for scenarios 3, 5, and 8."
+
+This prevents the AI from deciding what matters — that's your job.
+
+### Rule 2: Context Boundary (Define the Stack)
+
+Testing frameworks are fragmented. If you don't specify, AI will mix JUnit 4 and 5, Mockito and MockK, pytest and unittest in the same file.
+
+**Every test generation request must open with a stack declaration:**
+
+> "We are using [framework]. We DO NOT use [banned framework]. Write the setup block and initialize mocks for dependencies. Do not write test cases yet."
+
+By constraining the AI to setup-only, you get the tedious boilerplate done without risking assertion integrity.
+
+### Rule 3: Parameterized Data Typist
+
+For pure functions (formatters, validators, calculators), AI excels at generating exhaustive data tables:
+
+> "Here is a function that calculates shipping costs based on weight, region, and loyalty tier. Generate a CSV-formatted table of 20 diverse test cases including extreme edge cases, invalid inputs, and boundary values."
+
+You write the single parameterized test function. AI provides the data.
+
+---
+
+## Anti-Patterns to Catch and Kill
+
+### The Hallucinated Assertion
+AI writes `verify(mock).wasNotCalled()` when the logic clearly should call that dependency. **Always manually review assert/verify blocks.**
+
+### The Self-Mocking Test
+AI mocks the class under test, then asserts the mock returns what it was told to return. This tests the mocking framework, not your code. **If the test would pass even with the implementation deleted, it's worthless.**
+
+### Testing Implementation, Not Behavior
+If renaming a private variable breaks the test, it's testing internals. **Tests must target the public API and observable behavior.**
+
+### The Green Checkmark Trap
+All tests pass, coverage looks great, nothing is actually validated. **Mutation test: deliberately introduce a bug (change + to -). If the test still passes, the test is broken.**
+
+---
+
+## The Mutation Verification Rule
+
+Every AI-generated test suite MUST pass this check before acceptance:
+
+1. Pick 2-3 critical assertions
+2. Deliberately break the production code they should guard
+3. Run the tests
+4. If tests still pass → the AI wrote bad tests → reject and redo
+
+This is non-negotiable. A test that doesn't catch a known bug is worse than no test — it creates false confidence.
+
+---
+
+## Workflow Integration
+
+This methodology applies everywhere AI generates or reviews test code in our Studio workflow:
+
+- **Tech phase implementations** must follow scenario-first test specification
+- **QA role advocates** must demand AI-TDD compliance in test strategies
+- **QA role contrarians** must verify tests aren't self-mocking or tautological
+- **Engineering contrarians** must challenge test quality, not just coverage numbers
+- **Code validators** should flag common anti-patterns (mock-of-SUT, assertTrue(true))
+
+See `TEST_DRIVEN_GUIDE.md` for the full tech phase TDD workflow.
+See `role_prompts/qa.md` for QA role-specific enforcement.
+
+---
+
+## Summary
+
+| Principle | One-liner |
+|-----------|-----------|
+| Scenarios before code | AI lists what to test; you decide what matters |
+| Stack boundary | Declare frameworks explicitly; ban what you don't use |
+| Data, not assertions | AI generates test data; you own the assertions |
+| Mutation verification | Break the code; if tests still pass, tests are broken |
+| Behavior over implementation | Test public API, not private internals |

--- a/studio/docs/ARCHITECTURE.md
+++ b/studio/docs/ARCHITECTURE.md
@@ -29,9 +29,11 @@ All intelligence lives inside the assistant’s execution. Studio’s job is to 
 | Component | Purpose |
 | --- | --- |
 | `run_phase.py` | CLI entrypoint for `prepare` and `finalize`. Generates instructions, enforces artifact checklists, and keeps indexes current. |
-| `run_phase_roles.py` | Helper module that loads `studio.manifest.json`, applies role packs, and normalizes per-role filenames. |
-| `studio.manifest.json` | Declarative description of phase-level personas plus Studio role definitions (title, focuses, deliverables, prompt doc, escalation cues). |
+| `run_phase_roles.py` | Helper module that loads `studio.manifest.json`, applies role packs with dependency injection, and normalizes per-role filenames (flat and scoped). |
+| `scopes.py` | Three-tier scope configuration: alignment → depth → polish, with output budgets and debate modes. |
+| `studio.manifest.json` | Declarative description of phase-level personas, Studio role definitions, and role dependencies. |
 | `role_packs/*.json` | Curated sets of Studio roles (e.g., `studio_core`). Operators pick a pack, then add/remove roles with CLI flags. |
+| `config/scopes.toml` | Default scope configuration for studio phase runs. |
 | `docs/role_prompts/*.md` | Long-form prompts for each role. Instructions link to these files rather than inlining pages of text. |
 | Active output root (`output/` or `.studio/output/`) | Run folders containing instructions, advocate/contrarian artifacts, integrator plans, summaries, and metadata. |
 | Active knowledge log (`knowledge/run_log.md` or `.studio/knowledge/run_log.md`) | Append-only log of finalized runs for easy reference across repos. |
@@ -58,14 +60,28 @@ No other services, runtimes, or APIs exist.
 
 ## 4. Execute via AI Assistant
 
-The assistant reads `instructions.md`, the bridge doc, and any prompt docs linked from the Role Menu. Operators ensure:
+The assistant reads `instructions.md`, the bridge doc, and any prompt docs linked from the Role Menu.
 
-- Every invited role produces matching `advocate--<role>--NN.md` and `contrarian--<role>--NN.md` files until the role’s contrarian issues `VERDICT: APPROVED`.
-- For Studio, once all necessary contrarians approve, the Integrator performs a capped duel inside `integrator.md` with three sections:
-  1. `### Integrator Advocate`
-  2. `### Integrator Contrarian (VERDICT: …)`
-  3. `### Integrated Plan`
-- All summaries land in `summary.md`.
+### Simple Phases (market, design, tech)
+
+Advocate → Contrarian loop until `VERDICT: APPROVED` or max iterations exhausted. Then implementation (tech) or summary.
+
+### Studio Phase — Three-Tier Scoped Debate (Default)
+
+Studio runs use a scoped flow configured in `config/scopes.toml`:
+
+1. **Alignment** (all roles, parallel, ~500 words each): Directional check — approach, fatal flaws, high-level tradeoffs. Catches bad directions cheaply before deep dives.
+2. **Depth** (per-role, sequential, no word cap): Full deliverables per discipline. Starts focused because alignment context is available.
+3. **Polish** (all roles, parallel, ~300 words, 1 pass): Cross-discipline gut-check. Flag remaining conflicts, no new proposals.
+4. **Integrator duel**: Synthesize all scope artifacts into `integrator.md` with `### Integrator Advocate`, `### Integrator Contrarian`, `### Integrated Plan`.
+
+File naming encodes scope: `advocate--marketing--S1-01.md` (alignment), `advocate--engineering--S2-02.md` (depth iteration 2), `advocate--qa--S3-01.md` (polish).
+
+Use `--no-scopes` for flat mode (all roles at full depth, original behavior).
+
+### Scope Configuration
+
+`scopes.py` provides `ScopeConfig` with fields: `name`, `focus`, `max_iterations`, `output_budget` (word cap, optional), `debate_mode` (`"all_roles"` or `"per_role"`). The `generate_scope_instructions()` function embeds scope guidance into `instructions.md`.
 
 No automation runs outside the assistant; the instructions are simply executed as a structured conversation.
 
@@ -79,7 +95,8 @@ No automation runs outside the assistant; the instructions are simply executed a
    - Non-Studio phases: glob `advocate_<n>.md` / `contrarian_<n>.md` / `implementation.md`.
    - Studio phase: iterate through the invited roles stored in `run.json["studio_roles"]["invited"]`, using `collect_role_artifacts` to confirm both advocate and contrarian files exist. Missing roles are recorded.
    - Verify `integrator.md` and `summary.md`.
-4. Finalize updates `run.json` with status, verdict, hours, cost, iterations, and for Studio: `completed` + `missing` role lists.
+   - **Quality checks** (single-pass, warnings only): verdict presence, rubber-stamp detection (<200 chars), format validation, and token budget tracking per scope. Results stored in `run.json["quality"]` and `run.json["token_budget"]`.
+4. Finalize updates `run.json` with status, verdict, hours, cost, iterations, quality checks, token budget, and for Studio: `completed` + `missing` role lists.
 5. The active index/log (`<active_output_root>/index.md` and `<active_knowledge_root>/run_log.md`) are refreshed, giving downstream repos searchable entries with summary links.
 
 ---
@@ -92,7 +109,8 @@ No automation runs outside the assistant; the instructions are simply executed a
   - `deliverables`
   - `escalate_on`
   - `prompt_doc` (Markdown file inside `docs/role_prompts/`)
-- **Role packs** enforce consistent combinations. Example `studio_core` includes marketing, product, design, art, engineering, and QA.
+- **Role packs** enforce consistent combinations. Example `studio_core` includes marketing, product, design, art, engineering, test_engineer, and QA.
+- **Role dependencies** are declared in `defaults.role_dependencies` (e.g., `engineering → test_engineer`). After resolving overrides, `resolve_role_list` injects co-required roles immediately after their trigger role — unless the operator explicitly removed them with `-role`. This guarantees that test integrity is always debated when engineering is present.
 - Operators select a pack via `--role-pack` and tweak attendance with `--roles` additions/removals. This keeps instructions concise while maintaining a single source of truth.
 
 ---
@@ -106,7 +124,8 @@ No automation runs outside the assistant; the instructions are simply executed a
       instructions.md
       run.json
       advocate_<n>.md / contrarian_<n>.md / implementation.md (non-studio)
-      advocate--<role>--<n>.md / contrarian--<role>--<n>.md / integrator.md (studio)
+      advocate--<role>--<n>.md / contrarian--<role>--<n>.md / integrator.md (studio, flat)
+      advocate--<role>--S1-<n>.md / S2-<n>.md / S3-<n>.md (studio, scoped)
       summary.md
 ```
 

--- a/studio/docs/TEST_DRIVEN_GUIDE.md
+++ b/studio/docs/TEST_DRIVEN_GUIDE.md
@@ -2,6 +2,8 @@
 
 This guide defines the test-driven discipline for technical implementations produced through Studio.
 
+> **See also: [AI_TDD_METHODOLOGY.md](./AI_TDD_METHODOLOGY.md)** for the AI-specific testing methodology (scenario-first, stack boundaries, mutation verification, anti-pattern detection). The Test Engineer role enforces AI-TDD principles in every run that includes engineering.
+
 ---
 
 ## Philosophy

--- a/studio/docs/role_prompts/qa.md
+++ b/studio/docs/role_prompts/qa.md
@@ -13,13 +13,14 @@ Plan validation strategy, tooling hooks, and telemetry coverage. Your job is to:
 - Map test environments and data needs
 
 ## Contrarian Focus
-Attack blind spots in test coverage, environments, and support readiness. Your job is to:
+Attack blind spots in test coverage breadth, environment parity, and support readiness. Your job is to:
 - Question gaps in test coverage or automation
 - Flag missing test environments or data
 - Identify edge cases and failure modes
 - Challenge assumptions about reliability
 - Expose support/documentation gaps
 - Push back on manual processes that should be automated
+- Defer test methodology integrity (mock correctness, assertion quality, anti-patterns) to Test Engineer when present; escalate to add +test_engineer if methodology concerns arise without one
 
 ## Required Deliverables
 1. **Test matrix + gate criteria** — what gets tested, when, and how
@@ -30,6 +31,7 @@ Attack blind spots in test coverage, environments, and support readiness. Your j
 Escalate immediately if you identify:
 - Lack of automation coverage
 - Need for customer support/CSM alignment
+- Test suite methodology concerns with no Test Engineer in the pod
 
 ## Output Format
 Structure your response with clear sections for each deliverable. Use tables for test matrices, concrete examples of failure scenarios, and specific metrics to track. End with **VERDICT: APPROVED** or **VERDICT: REJECTED** with specific rationale.

--- a/studio/docs/role_prompts/test_engineer.md
+++ b/studio/docs/role_prompts/test_engineer.md
@@ -1,0 +1,46 @@
+# Staff Test Engineer — AI-TDD Integrity — Studio Role Prompt
+
+## Context
+You are the **Staff Test Engineer** responsible for AI-TDD integrity in Studio initiatives. You ensure that tests produced by or with AI assistants are methodologically sound — not just syntactically correct or green. You exist because AI-generated tests routinely mock the system under test, write tautological assertions, and produce 100% coverage of 0% of actual logic.
+
+You follow the methodology defined in `AI_TDD_METHODOLOGY.md`.
+
+## Advocate Focus
+Enforce scenario-first test design and rigorous test methodology. Your job is to:
+
+- **Scenario-first**: Demand Given-When-Then specifications in plain English before any test code is written. The AI generates scenarios; humans decide which matter.
+- **Context boundary**: Require an explicit declaration of test framework, assertion library, language version, and a ban-list of frameworks/patterns that must not appear. No mixing JUnit 4 and 5, no pytest and unittest in the same file.
+- **Parameterized data tables**: Design parameterized test structures where AI generates diverse input data (edge cases, boundary values, invalid inputs) but humans own the assertion logic.
+- **Mutation verification plan**: For each critical path, specify at least 2 production mutations (e.g., change + to -, swap > for >=, remove a null check) that the test suite must catch. If a test doesn't fail when the code is broken, the test is broken.
+- **Test architecture**: Ensure tests target observable behavior through public APIs, not private implementation details.
+
+## Contrarian Focus
+Hunt and kill AI-TDD anti-patterns. Your job is to:
+
+- **Self-mocking tests**: Flag any test that mocks the class/module under test. Mocks are for dependencies, never the SUT. If the test would pass with the implementation deleted, it tests nothing.
+- **Hallucinated assertions**: Identify assertions that would pass regardless of actual behavior — `assertTrue(true)`, `expect(result).toBeDefined()` when you need `expect(result.amount).toBe(42)`, `verify(mock).wasNotCalled()` when the logic should call it.
+- **Implementation coupling**: Call out tests that break when internal refactoring happens without behavior change — testing private methods, asserting on internal state, checking call order of internal helpers.
+- **Green checkmark trap**: Challenge suites where all tests pass but coverage of meaningful behavior paths is low. Demand evidence: "If you removed this feature entirely, which specific test would fail?" If the answer is unclear, the test suite is theatrical.
+- **Framework contamination**: Flag mixed framework imports, deprecated testing APIs, or patterns from a different language/ecosystem.
+
+## Required Deliverables
+1. **Scenario-first test specification** — Given-When-Then scenarios in plain English, reviewed and approved before code. Minimum 5 scenarios for any non-trivial feature, including at least 2 edge cases.
+2. **Context boundary declaration** — Exact stack (language version, test framework, assertion library, mock library) plus explicit ban-list. This is the contract that all test code must respect.
+3. **Mutation verification plan** — Table of production mutations that must be caught: which line to break, how to break it, which test should fail. At least 2 mutations per critical path.
+4. **Anti-pattern audit checklist** — Assessment of the test code for: self-mocking (PASS/FAIL), hallucinated assertions (PASS/FAIL), implementation coupling (PASS/FAIL), green checkmark trap (PASS/FAIL). Each with specific evidence.
+
+## Escalation Triggers
+Escalate immediately if you identify:
+- Tests mock the system under test instead of its dependencies
+- No mutation verification evidence — tests pass but may not catch real regressions
+- Test suite uses frameworks or patterns outside the declared context boundary
+- Assertions are tautological or would pass regardless of implementation correctness
+- Test coverage numbers are high but no test would fail if the feature were removed
+
+## Relationship to Other Roles
+- **Engineering** defines the architecture and stack. You take that as the context boundary and verify tests stay within it. Engineering's contrarian flags reliability risks; you verify whether the tests would actually *catch* those risks.
+- **QA** owns the release gate: test matrix, environments, rollback. You own *test integrity*: are the individual tests in that matrix trustworthy? QA says "we need integration tests for auth." You say "that auth test mocks the auth module itself — it proves nothing."
+- **Product** defines success metrics. You translate those into scenario specifications that must exist before implementation starts.
+
+## Output Format
+Structure your response with clear sections for each deliverable. Use tables for mutation verification plans and anti-pattern audit results. Include specific code examples when flagging anti-patterns. End with **VERDICT: APPROVED** or **VERDICT: REJECTED** with specific rationale tied to the four deliverables.

--- a/studio/role_packs/pictorly_execution.json
+++ b/studio/role_packs/pictorly_execution.json
@@ -1,10 +1,11 @@
 {
   "name": "pictorly_execution",
-  "description": "Focused execution pod for Pictorly MVP planning (product, design, engineering, qa).",
+  "description": "Focused execution pod for Pictorly MVP planning (product, design, engineering, test integrity, qa).",
   "roles": [
     "product",
     "design",
     "engineering",
+    "test_engineer",
     "qa"
   ]
 }

--- a/studio/role_packs/studio_core.json
+++ b/studio/role_packs/studio_core.json
@@ -1,12 +1,13 @@
 {
   "name": "studio_core",
-  "description": "Default Studio pod covering GTM, product, experiential design, art, engineering, and QA/launch readiness.",
+  "description": "Default Studio pod covering GTM, product, experiential design, art, engineering, test integrity, and QA/launch readiness.",
   "roles": [
     "marketing",
     "product",
     "design",
     "art",
     "engineering",
+    "test_engineer",
     "qa"
   ]
 }

--- a/studio/role_packs/studio_core_with_ml.json
+++ b/studio/role_packs/studio_core_with_ml.json
@@ -7,6 +7,7 @@
     "design",
     "art",
     "engineering",
+    "test_engineer",
     "qa",
     "ml",
     "pmm"

--- a/studio/run_phase.py
+++ b/studio/run_phase.py
@@ -22,12 +22,14 @@ from cleanup import (
     format_bytes,
     load_cleanup_settings,
 )
+from validators.document_validator import DocumentValidator
 from run_phase_roles import (
     RoleConfigError,
     RoleDetails,
     build_role_details,
     collect_role_artifacts,
     default_role_pack_name,
+    parse_role_filename,
     load_manifest,
     load_role_pack,
     normalize_role_filename,
@@ -412,6 +414,83 @@ def _validate_artifacts(
     advocate_names = []
     if phase != "studio":
         advocate_names = [file.name for file in advocate_files]  # type: ignore[name-defined]
+
+    # --- Quality checks (warnings only, never block finalize) ---
+    quality_warnings: List[str] = []
+    quality_errors: List[str] = []
+    checks_run = 0
+    doc_validator = DocumentValidator()
+
+    all_advocate_paths: List[Path] = []
+    all_contrarian_paths: List[Path] = []
+    if phase == "studio":
+        for role in completed_roles:
+            all_advocate_paths.extend(collect_role_artifacts(run_dir, role, "advocate"))
+            all_contrarian_paths.extend(collect_role_artifacts(run_dir, role, "contrarian"))
+    else:
+        all_advocate_paths = sorted(run_dir.glob("advocate_*.md"))
+        all_contrarian_paths = sorted(run_dir.glob("contrarian_*.md"))
+
+    all_artifact_paths = all_advocate_paths + all_contrarian_paths
+
+    contrarian_set = set(all_contrarian_paths)
+    scope_stats: Dict[str, Dict] = {}
+
+    for fpath in all_artifact_paths:
+        try:
+            content = fpath.read_text(encoding="utf-8")
+        except OSError:
+            quality_warnings.append(f"{fpath.name}: could not read file")
+            continue
+
+        # 1. Verdict check (contrarian files only)
+        if fpath in contrarian_set:
+            checks_run += 1
+            verdict_result = doc_validator.check_verdict(fpath)
+            if not verdict_result.passed:
+                quality_warnings.append(f"{fpath.name}: no VERDICT found")
+            quality_warnings.extend(f"{fpath.name}: {w}" for w in verdict_result.warnings)
+
+        # 2. Rubber-stamp detector
+        checks_run += 1
+        stripped_len = len(content.strip())
+        if stripped_len < 200:
+            quality_warnings.append(
+                f"{fpath.name}: only {stripped_len} chars (possible rubber-stamp)"
+            )
+
+        # 3. Format check
+        checks_run += 1
+        fmt_result = doc_validator.check_format(fpath)
+        quality_warnings.extend(f"{fpath.name}: {w}" for w in fmt_result.warnings)
+        quality_errors.extend(f"{fpath.name}: {issue}" for issue in fmt_result.issues)
+
+        # 4. Token budget tracking
+        _, _, scope, _ = parse_role_filename(fpath.name)
+        scope_key = scope or "flat"
+        if scope_key not in scope_stats:
+            scope_stats[scope_key] = {"files": 0, "total_chars": 0, "total_words": 0}
+        scope_stats[scope_key]["files"] += 1
+        scope_stats[scope_key]["total_chars"] += len(content)
+        scope_stats[scope_key]["total_words"] += len(content.split())
+
+    if quality_warnings or quality_errors:
+        print("Quality warnings:")
+        for w in quality_warnings:
+            print(f"  ⚠ {w}")
+        for e in quality_errors:
+            print(f"  ✗ {e}")
+
+    if meta is not None:
+        meta["quality"] = {
+            "checks_run": checks_run,
+            "warnings": quality_warnings,
+            "errors": quality_errors,
+        }
+
+        for stats in scope_stats.values():
+            stats["avg_words"] = round(stats["total_words"] / max(stats["files"], 1))
+        meta["token_budget"] = scope_stats
 
     return iterations_value, advocate_names, completed_roles, missing_roles
 

--- a/studio/run_phase_roles.py
+++ b/studio/run_phase_roles.py
@@ -77,6 +77,12 @@ def load_role_pack(studio_root: Path, pack_name: str) -> Dict:
         raise RoleConfigError(f"Role pack '{pack_name}' is invalid JSON: {exc}") from exc
 
 
+def _get_role_dependencies(manifest: Dict) -> Dict[str, List[str]]:
+    """Return the role_dependencies map from manifest defaults."""
+    defaults = manifest.get("defaults") or {}
+    return dict(defaults.get("role_dependencies") or {})
+
+
 def resolve_role_list(
     manifest: Dict,
     pack_data: Dict,
@@ -85,6 +91,7 @@ def resolve_role_list(
     overrides = overrides or []
     allowed_roles = set((manifest.get("roles") or {}).keys())
     selected = list(pack_data.get("roles") or [])
+    explicitly_removed: set[str] = set()
     for token in overrides:
         token = token.strip()
         if not token:
@@ -100,30 +107,63 @@ def resolve_role_list(
             if role not in selected:
                 selected.append(role)
         else:
+            explicitly_removed.add(role)
             selected = [existing for existing in selected if existing != role]
-    return selected
+
+    # Enforce role dependencies: if a role is present, its co-required
+    # roles are injected immediately after it (unless explicitly removed).
+    deps = _get_role_dependencies(manifest)
+    injected: List[str] = []
+    for role in selected:
+        injected.append(role)
+        for dep in deps.get(role, []):
+            if dep not in selected and dep not in injected and dep not in explicitly_removed and dep in allowed_roles:
+                injected.append(dep)
+    return injected
 
 
 def build_role_details(manifest: Dict, role_names: Sequence[str]) -> List[RoleDetails]:
     return [get_role_spec(manifest, name) for name in role_names]
 
 
-def normalize_role_filename(role: str, iteration: int, kind: str) -> str:
+def normalize_role_filename(
+    role: str, iteration: int, kind: str, scope: str | None = None
+) -> str:
     slug = role.replace(" ", "-")
+    if scope:
+        return f"{kind}--{slug}--{scope}-{iteration:02d}.md"
     return f"{kind}--{slug}--{iteration:02d}.md"
 
 
-def parse_iteration_from_filename(filename: str) -> int:
-    # Expected pattern: kind--role--NN.md
+def parse_role_filename(filename: str) -> Tuple[str, str, str | None, int]:
+    """Parse a role artifact filename into (kind, role, scope, iteration).
+
+    Handles both flat (``kind--role--NN.md``) and scoped
+    (``kind--role--scope-NN.md``) patterns.  Returns ``("", "", None, 0)``
+    for filenames that don't match.
+    """
     stem = filename.split("/")[-1]
     parts = stem.split("--")
     if len(parts) < 3:
-        return 0
-    iteration_part = parts[-1].split(".")[0]
+        return ("", "", None, 0)
+    kind = parts[0]
+    role = parts[1]
+    iter_part = parts[-1].split(".")[0]
+    scope: str | None = None
+    if "-" in iter_part:
+        scope, iter_str = iter_part.rsplit("-", 1)
+    else:
+        iter_str = iter_part
     try:
-        return int(iteration_part)
+        iteration = int(iter_str)
     except ValueError:
-        return 0
+        iteration = 0
+    return (kind, role, scope, iteration)
+
+
+def parse_iteration_from_filename(filename: str) -> int:
+    """Return just the iteration number from a role artifact filename."""
+    return parse_role_filename(filename)[3]
 
 
 def collect_role_artifacts(run_dir: Path, role: str, kind: str) -> List[Path]:

--- a/studio/scopes.py
+++ b/studio/scopes.py
@@ -17,16 +17,25 @@ from pathlib import Path
 from typing import Dict, List
 
 
+VALID_DEBATE_MODES = {"all_roles", "per_role"}
+
+
 @dataclass
 class ScopeConfig:
     """Configuration for a single scope level."""
     name: str
     focus: str
     max_iterations: int
-    
+    output_budget: int | None = None    # word cap per stance doc (None = unlimited)
+    debate_mode: str = "per_role"       # "all_roles" or "per_role"
+
     def __post_init__(self):
         if self.max_iterations < 1:
             raise ValueError(f"Scope '{self.name}' must have at least 1 iteration")
+        if self.debate_mode not in VALID_DEBATE_MODES:
+            raise ValueError(
+                f"Scope '{self.name}' debate_mode must be one of {VALID_DEBATE_MODES}, got '{self.debate_mode}'"
+            )
 
 
 @dataclass
@@ -107,10 +116,18 @@ def load_scopes_config(config_path: Path) -> ScopesConfig:
         if not isinstance(max_iterations, int):
             raise ValueError(f"Scope '{scope_name}' max_iterations must be an integer")
         
+        output_budget = scope_config.get("output_budget")
+        if output_budget is not None and not isinstance(output_budget, int):
+            raise ValueError(f"Scope '{scope_name}' output_budget must be an integer")
+
+        debate_mode = scope_config.get("debate_mode", "per_role")
+
         scopes.append(ScopeConfig(
             name=scope_name,
             focus=focus,
-            max_iterations=max_iterations
+            max_iterations=max_iterations,
+            output_budget=output_budget,
+            debate_mode=debate_mode,
         ))
     
     if not scopes:
@@ -187,12 +204,16 @@ def generate_scope_instructions(scopes_config: ScopesConfig, allocations: Dict[s
     
     for scope in scopes_config.scopes:
         allocated = allocations.get(scope.name, 0)
+        mode_label = "All roles debate simultaneously" if scope.debate_mode == "all_roles" else "Each role debates sequentially"
         lines.extend([
             f"### {scope.name.replace('_', ' ').title()}",
             f"- **Focus**: {scope.focus}",
+            f"- **Debate mode**: {mode_label}",
             f"- **Max iterations**: {allocated}",
-            "",
         ])
+        if scope.output_budget:
+            lines.append(f"- **Output budget**: ~{scope.output_budget} words per stance document")
+        lines.append("")
     
     total = sum(allocations.values())
     lines.extend([

--- a/studio/studio.manifest.json
+++ b/studio/studio.manifest.json
@@ -94,10 +94,27 @@
         "SRE or infra buy-in required"
       ]
     },
+    "test_engineer": {
+      "title": "Staff Test Engineer — AI-TDD Integrity",
+      "advocate_focus": "Enforce scenario-first test design: demand Given-When-Then specifications before any test code, declare context boundaries (exact stack and banned frameworks), design parameterized data tables for AI-generated test inputs, and require mutation verification evidence that tests genuinely detect regressions.",
+      "contrarian_focus": "Hunt and kill AI-TDD anti-patterns: self-mocking tests that mock the system under test, hallucinated assertions that pass regardless of behavior, tests coupled to implementation details instead of observable behavior, and the green checkmark trap where passing tests create false confidence without meaningful coverage.",
+      "prompt_doc": "docs/role_prompts/test_engineer.md",
+      "deliverables": [
+        "Scenario-first test specification (Given-When-Then before code)",
+        "Context boundary declaration (stack, frameworks, banned patterns)",
+        "Mutation verification plan (which production mutations must be caught)",
+        "Anti-pattern audit checklist (self-mock, hallucinated assertion, impl-coupling, green trap)"
+      ],
+      "escalate_on": [
+        "Tests mock the system under test instead of its dependencies",
+        "No mutation verification evidence — tests pass but may not catch real regressions",
+        "Test suite uses frameworks or patterns outside the declared context boundary"
+      ]
+    },
     "qa": {
       "title": "Release QA & Launch Ops Lead",
       "advocate_focus": "Plan validation strategy, tooling hooks, and telemetry coverage.",
-      "contrarian_focus": "Attack blind spots in test coverage, environments, and support readiness.",
+      "contrarian_focus": "Attack blind spots in test coverage breadth, environment parity, and support readiness. Defer test methodology integrity (mock correctness, assertion quality, anti-patterns) to Test Engineer when present; escalate to add +test_engineer if methodology concerns arise without one.",
       "prompt_doc": "docs/role_prompts/qa.md",
       "deliverables": [
         "Test matrix + gate criteria",
@@ -106,7 +123,8 @@
       ],
       "escalate_on": [
         "Lack of automation coverage",
-        "Need for customer support/CSM alignment"
+        "Need for customer support/CSM alignment",
+        "Test suite methodology concerns with no Test Engineer in the pod"
       ]
     },
     "ml": {
@@ -142,6 +160,9 @@
     }
   },
   "defaults": {
-    "studio_role_pack": "studio_core"
+    "studio_role_pack": "studio_core",
+    "role_dependencies": {
+      "engineering": ["test_engineer"]
+    }
   }
 }

--- a/studio/tests/conftest.py
+++ b/studio/tests/conftest.py
@@ -67,8 +67,19 @@ MINIMAL_MANIFEST = {
             "deliverables": ["System outline"],
             "escalate_on": [],
         },
+        "test_engineer": {
+            "title": "Staff Test Engineer",
+            "advocate_focus": "Enforce scenario-first test design.",
+            "contrarian_focus": "Hunt AI-TDD anti-patterns.",
+            "prompt_doc": "docs/role_prompts/test_engineer.md",
+            "deliverables": ["Test specification", "Anti-pattern audit"],
+            "escalate_on": [],
+        },
     },
-    "defaults": {"studio_role_pack": "studio_core"},
+    "defaults": {
+        "studio_role_pack": "studio_core",
+        "role_dependencies": {"engineering": ["test_engineer"]},
+    },
 }
 
 
@@ -88,7 +99,7 @@ def _seed_studio_root(root: Path) -> None:
     packs_dir.mkdir(exist_ok=True)
     (packs_dir / "studio_core.json").write_text(
         json.dumps(
-            {"name": "studio_core", "description": "Default pack", "roles": ["marketing", "design", "engineering"]},
+            {"name": "studio_core", "description": "Default pack", "roles": ["marketing", "design", "engineering", "test_engineer"]},
             indent=2,
         ),
         encoding="utf-8",
@@ -97,7 +108,7 @@ def _seed_studio_root(root: Path) -> None:
     # Prompt docs
     docs_dir = root / "docs" / "role_prompts"
     docs_dir.mkdir(parents=True, exist_ok=True)
-    for role in ("marketing", "design", "engineering"):
+    for role in ("marketing", "design", "engineering", "test_engineer"):
         (docs_dir / f"{role}.md").write_text(f"# {role.title()} prompt\n")
 
 

--- a/studio/tests/test_cleanup.py
+++ b/studio/tests/test_cleanup.py
@@ -1,31 +1,50 @@
-import importlib.util
-import sys
-from datetime import datetime, timezone, timedelta
+#!/usr/bin/env python3
+"""Tests for TTL and budget-based cleanup of run artifacts."""
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-CLEANUP_PATH = Path(__file__).resolve().parents[1] / "cleanup.py"
-_spec = importlib.util.spec_from_file_location("cleanup_module", CLEANUP_PATH)
-cleanup = importlib.util.module_from_spec(_spec)
-assert _spec and _spec.loader
-sys.modules[_spec.name] = cleanup
-_spec.loader.exec_module(cleanup)
+import pytest
+
+from cleanup import (
+    CleanupSettings,
+    cleanup_runs,
+    format_bytes,
+    load_cleanup_settings,
+    DEFAULT_TTL_DAYS,
+    DEFAULT_SIZE_LIMIT_MB,
+)
 
 
-def _write_run(output_root: Path, phase: str, run_id: str, created_iso: str, size_bytes: int) -> Path:
+def _write_run(
+    output_root: Path,
+    phase: str,
+    run_id: str,
+    created_iso: str,
+    size_bytes: int,
+    *,
+    run_json_content: str | None = None,
+) -> Path:
+    """Create a fake run directory with run.json and an artifact of *size_bytes*."""
     run_dir = output_root / phase / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
-    (run_dir / "run.json").write_text(
-        f'{{"run_id":"{run_id}","phase":"{phase}","created_iso":"{created_iso}"}}',
-        encoding="utf-8",
-    )
+    if run_json_content is not None:
+        (run_dir / "run.json").write_text(run_json_content, encoding="utf-8")
+    else:
+        (run_dir / "run.json").write_text(
+            f'{{"run_id":"{run_id}","phase":"{phase}","created_iso":"{created_iso}"}}',
+            encoding="utf-8",
+        )
     (run_dir / "artifact.bin").write_bytes(b"x" * size_bytes)
     return run_dir
 
 
+# ── existing tests ────────────────────────────────────────────────────
+
+
 def test_load_cleanup_settings_defaults_when_missing(tmp_path):
-    settings = cleanup.load_cleanup_settings(tmp_path)
-    assert settings.ttl_days == cleanup.DEFAULT_TTL_DAYS
-    assert settings.size_limit_mb == cleanup.DEFAULT_SIZE_LIMIT_MB
+    settings = load_cleanup_settings(tmp_path)
+    assert settings.ttl_days == DEFAULT_TTL_DAYS
+    assert settings.size_limit_mb == DEFAULT_SIZE_LIMIT_MB
 
 
 def test_cleanup_runs_enforces_ttl_and_size_budget(tmp_path):
@@ -38,8 +57,8 @@ def test_cleanup_runs_enforces_ttl_and_size_budget(tmp_path):
     mid_run = _write_run(output_root, "market", "run_market_mid", recent_iso, size_bytes=700_000)
     newest_run = _write_run(output_root, "market", "run_market_new", recent_iso, size_bytes=600_000)
 
-    settings = cleanup.CleanupSettings(ttl_days=7, size_limit_mb=1)
-    report = cleanup.cleanup_runs(output_root, settings, now=now, dry_run=False)
+    settings = CleanupSettings(ttl_days=7, size_limit_mb=1)
+    report = cleanup_runs(output_root, settings, now=now, dry_run=False)
 
     removed_ids = {record.run.run_id: record.reason for record in report.deletions}
     assert removed_ids["run_market_old"] == "ttl"
@@ -55,9 +74,151 @@ def test_cleanup_runs_dry_run_does_not_delete(tmp_path):
     output_root = tmp_path / "output"
     iso = datetime(2025, 1, 1, tzinfo=timezone.utc).isoformat()
     run_dir = _write_run(output_root, "design", "run_design_old", iso, size_bytes=100_000)
-    settings = cleanup.CleanupSettings(ttl_days=1, size_limit_mb=1)
+    settings = CleanupSettings(ttl_days=1, size_limit_mb=1)
 
-    report = cleanup.cleanup_runs(output_root, settings, now=datetime(2025, 1, 10, tzinfo=timezone.utc), dry_run=True)
+    report = cleanup_runs(output_root, settings, now=datetime(2025, 1, 10, tzinfo=timezone.utc), dry_run=True)
 
     assert report.deletions
     assert run_dir.exists()
+
+
+# ── TTL boundary tests ────────────────────────────────────────────────
+
+
+def test_ttl_boundary_exact_30_days_kept(tmp_path):
+    """A run created exactly 30 days ago should NOT be deleted (cutoff is strict <)."""
+    output_root = tmp_path / "output"
+    now = datetime(2025, 2, 1, tzinfo=timezone.utc)
+    boundary_iso = (now - timedelta(days=30)).isoformat()
+    run_dir = _write_run(output_root, "market", "run_market_boundary", boundary_iso, size_bytes=1_000)
+
+    settings = CleanupSettings(ttl_days=30, size_limit_mb=900)
+    report = cleanup_runs(output_root, settings, now=now, dry_run=False)
+
+    removed_ids = {record.run.run_id for record in report.deletions}
+    assert "run_market_boundary" not in removed_ids
+    assert run_dir.exists()
+
+
+def test_ttl_boundary_31_days_deleted(tmp_path):
+    """A run created 31 days ago should be deleted by TTL."""
+    output_root = tmp_path / "output"
+    now = datetime(2025, 2, 1, tzinfo=timezone.utc)
+    old_iso = (now - timedelta(days=31)).isoformat()
+    run_dir = _write_run(output_root, "market", "run_market_expired", old_iso, size_bytes=1_000)
+
+    settings = CleanupSettings(ttl_days=30, size_limit_mb=900)
+    report = cleanup_runs(output_root, settings, now=now, dry_run=False)
+
+    removed_ids = {record.run.run_id: record.reason for record in report.deletions}
+    assert removed_ids.get("run_market_expired") == "ttl"
+    assert not run_dir.exists()
+
+
+# ── Budget-only test ──────────────────────────────────────────────────
+
+
+def test_budget_only_deletes_oldest_first(tmp_path):
+    """Runs within TTL but exceeding budget: oldest runs deleted first."""
+    output_root = tmp_path / "output"
+    now = datetime(2025, 2, 1, tzinfo=timezone.utc)
+
+    oldest_iso = (now - timedelta(days=5)).isoformat()
+    middle_iso = (now - timedelta(days=3)).isoformat()
+    newest_iso = (now - timedelta(days=1)).isoformat()
+
+    oldest_run = _write_run(output_root, "tech", "run_tech_oldest", oldest_iso, size_bytes=400_000)
+    _write_run(output_root, "tech", "run_tech_middle", middle_iso, size_bytes=400_000)
+    newest_run = _write_run(output_root, "tech", "run_tech_newest", newest_iso, size_bytes=400_000)
+
+    settings = CleanupSettings(ttl_days=30, size_limit_mb=1)
+    report = cleanup_runs(output_root, settings, now=now, dry_run=False)
+
+    removed_ids = {record.run.run_id: record.reason for record in report.deletions}
+    assert all(reason == "budget" for reason in removed_ids.values())
+    assert "run_tech_oldest" in removed_ids
+    assert "run_tech_newest" not in removed_ids
+    assert not oldest_run.exists()
+    assert newest_run.exists()
+
+
+# ── TTL-only test ─────────────────────────────────────────────────────
+
+
+def test_ttl_only_within_budget(tmp_path):
+    """Expired runs are deleted even when total size is within budget."""
+    output_root = tmp_path / "output"
+    now = datetime(2025, 3, 1, tzinfo=timezone.utc)
+
+    expired_iso = (now - timedelta(days=60)).isoformat()
+    fresh_iso = (now - timedelta(days=1)).isoformat()
+
+    expired_run = _write_run(output_root, "design", "run_design_old", expired_iso, size_bytes=500)
+    fresh_run = _write_run(output_root, "design", "run_design_new", fresh_iso, size_bytes=500)
+
+    settings = CleanupSettings(ttl_days=30, size_limit_mb=900)
+    report = cleanup_runs(output_root, settings, now=now, dry_run=False)
+
+    removed_ids = {record.run.run_id: record.reason for record in report.deletions}
+    assert removed_ids.get("run_design_old") == "ttl"
+    assert "run_design_new" not in removed_ids
+    assert not expired_run.exists()
+    assert fresh_run.exists()
+
+
+# ── Corrupt run.json test ─────────────────────────────────────────────
+
+
+def test_corrupt_run_json_does_not_crash(tmp_path):
+    """A run directory with invalid JSON in run.json should not crash cleanup."""
+    output_root = tmp_path / "output"
+    now = datetime(2025, 2, 1, tzinfo=timezone.utc)
+
+    corrupt_run = _write_run(
+        output_root,
+        "market",
+        "run_market_corrupt",
+        "",
+        size_bytes=500,
+        run_json_content="NOT VALID JSON {{{",
+    )
+
+    valid_iso = (now - timedelta(days=1)).isoformat()
+    valid_run = _write_run(output_root, "market", "run_market_valid", valid_iso, size_bytes=500)
+
+    settings = CleanupSettings(ttl_days=30, size_limit_mb=900)
+    report = cleanup_runs(output_root, settings, now=now, dry_run=False)
+
+    assert report.total_runs == 2
+    assert report.errors == []
+    assert valid_run.exists()
+
+
+# ── format_bytes edge cases ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "input_bytes, expected",
+    [
+        (0, "0.0B"),
+        (1023, "1023.0B"),
+        (1024, "1.0KB"),
+        (1024 * 1024, "1.0MB"),
+        (1024 * 1024 * 1024, "1.0GB"),
+        (1024 * 1024 * 1024 * 1024, "1.0TB"),
+        (512, "512.0B"),
+        (1536, "1.5KB"),
+    ],
+    ids=[
+        "zero_bytes",
+        "just_under_1KB",
+        "exactly_1KB",
+        "exactly_1MB",
+        "exactly_1GB",
+        "exactly_1TB",
+        "mid_range_bytes",
+        "fractional_KB",
+    ],
+)
+def test_format_bytes_edge_cases(input_bytes, expected):
+    assert format_bytes(input_bytes) == expected

--- a/studio/tests/test_rerun.py
+++ b/studio/tests/test_rerun.py
@@ -163,9 +163,11 @@ Timeline is too aggressive
     
     reasons = extract_rejection_reasons(content)
     
-    assert len(reasons) >= 2
+    assert len(reasons) == 4
     assert any("user research" in r.lower() for r in reasons)
     assert any("testing plan" in r.lower() for r in reasons)
+    assert any("success metrics" in r.lower() for r in reasons)
+    assert any("too aggressive" in r.lower() for r in reasons)
 
 
 def test_extract_rejection_reasons_paragraph_format():
@@ -184,8 +186,8 @@ Third, the go-to-market strategy relies on unproven channels.
     
     reasons = extract_rejection_reasons(content)
     
-    # Should extract at least some paragraphs
-    assert len(reasons) > 0
+    # Paragraph fallback extracts substantive paragraphs after VERDICT
+    assert len(reasons) >= 2
     assert any("market validation" in r.lower() for r in reasons)
 
 

--- a/studio/tests/test_run_phase.py
+++ b/studio/tests/test_run_phase.py
@@ -269,3 +269,68 @@ def test_instructions_finalize_snippet_uses_absolute_path(studio_root):
     # Should contain absolute path, not just "python run_phase.py"
     assert "/run_phase.py" in instructions
     assert "finalize --phase market" in instructions
+
+
+def test_finalize_updates_status_to_completed(studio_root):
+    """finalize_run should update run.json status from PENDING to COMPLETED."""
+    run_id = run_phase.prepare_run(make_prepare_args())
+    run_dir = studio_root / "output" / "market" / run_id
+
+    # Verify initial PENDING status
+    meta_before = run_phase.load_json(run_dir / "run.json")
+    assert meta_before["status"] == "PENDING"
+
+    # Create required artifacts
+    (run_dir / "advocate_1.md").write_text("Advocate output", encoding="utf-8")
+    (run_dir / "contrarian_1.md").write_text("Contrarian output", encoding="utf-8")
+    (run_dir / "summary.md").write_text("Summary output", encoding="utf-8")
+
+    run_phase.finalize_run(make_finalize_args(run_id=run_id))
+
+    meta_after = run_phase.load_json(run_dir / "run.json")
+    assert meta_after["status"] == "COMPLETED"
+    assert meta_after["verdict"] == "APPROVED"
+    assert meta_after["iterations_run"] == 1
+
+
+def test_finalize_updates_status_to_rejected(studio_root):
+    """finalize_run with REJECTED verdict records it correctly."""
+    run_id = run_phase.prepare_run(make_prepare_args(phase="design"))
+    run_dir = studio_root / "output" / "design" / run_id
+
+    (run_dir / "advocate_1.md").write_text("Advocate output", encoding="utf-8")
+    (run_dir / "contrarian_1.md").write_text("Contrarian output", encoding="utf-8")
+    (run_dir / "summary.md").write_text("Summary output", encoding="utf-8")
+
+    run_phase.finalize_run(
+        make_finalize_args(phase="design", run_id=run_id, verdict="REJECTED")
+    )
+
+    meta_after = run_phase.load_json(run_dir / "run.json")
+    assert meta_after["status"] == "COMPLETED"
+    assert meta_after["verdict"] == "REJECTED"
+
+
+def test_prepare_with_scopes_integration(studio_root):
+    """prepare_run with scopes enabled embeds scope content in instructions."""
+    # Create scopes.toml in the studio root
+    scopes_dir = studio_root / ".studio"
+    scopes_dir.mkdir(parents=True, exist_ok=True)
+    (scopes_dir / "scopes.toml").write_text(
+        '[scopes.high_level]\n'
+        'focus = "Architecture and strategic decisions"\n'
+        'max_iterations = 3\n'
+        '\n'
+        '[scopes.implementation]\n'
+        'focus = "Detailed design and API contracts"\n'
+        'max_iterations = 2\n',
+        encoding="utf-8",
+    )
+
+    run_id = run_phase.prepare_run(
+        make_prepare_args(no_scopes=False, max_iterations=5)
+    )
+    run_dir = studio_root / "output" / "market" / run_id
+
+    instructions = (run_dir / "instructions.md").read_text(encoding="utf-8")
+    assert "high_level" in instructions.lower() or "High Level" in instructions

--- a/studio/tests/test_run_phase_roles.py
+++ b/studio/tests/test_run_phase_roles.py
@@ -164,6 +164,49 @@ class TestResolveRoleList:
         result = resolve_role_list(MINIMAL_MANIFEST, pack, ["", "  ", "+design"])
         assert result == ["marketing", "design"]
 
+    def test_engineering_auto_injects_test_engineer(self):
+        """When engineering is in the pack, test_engineer is injected after it."""
+        pack = {"roles": ["marketing", "engineering"]}
+        result = resolve_role_list(MINIMAL_MANIFEST, pack)
+        assert "test_engineer" in result
+        eng_idx = result.index("engineering")
+        te_idx = result.index("test_engineer")
+        assert te_idx == eng_idx + 1
+
+    def test_engineering_added_via_override_injects_test_engineer(self):
+        """Adding +engineering via override also injects test_engineer."""
+        pack = {"roles": ["marketing"]}
+        result = resolve_role_list(MINIMAL_MANIFEST, pack, ["+engineering"])
+        assert "test_engineer" in result
+
+    def test_no_duplicate_when_test_engineer_already_present(self):
+        """If test_engineer is already in the pack, don't inject a duplicate."""
+        pack = {"roles": ["engineering", "test_engineer"]}
+        result = resolve_role_list(MINIMAL_MANIFEST, pack)
+        assert result.count("test_engineer") == 1
+
+    def test_explicit_removal_of_test_engineer_honored(self):
+        """User can explicitly remove test_engineer with -test_engineer."""
+        pack = {"roles": ["engineering", "test_engineer"]}
+        result = resolve_role_list(MINIMAL_MANIFEST, pack, ["-test_engineer"])
+        assert "test_engineer" not in result
+
+    def test_no_injection_without_engineering(self):
+        """Without engineering, test_engineer is not auto-injected."""
+        pack = {"roles": ["marketing", "design"]}
+        result = resolve_role_list(MINIMAL_MANIFEST, pack)
+        assert "test_engineer" not in result
+
+    def test_no_dependency_without_config(self):
+        """Manifests without role_dependencies skip injection."""
+        manifest_no_deps = {
+            "roles": MINIMAL_MANIFEST["roles"],
+            "defaults": {"studio_role_pack": "studio_core"},
+        }
+        pack = {"roles": ["engineering"]}
+        result = resolve_role_list(manifest_no_deps, pack)
+        assert result == ["engineering"]
+
 
 # ---------------------------------------------------------------------------
 # build_role_details
@@ -198,6 +241,16 @@ class TestNormalizeRoleFilename:
     def test_double_digit(self):
         assert normalize_role_filename("qa", 12, "advocate") == "advocate--qa--12.md"
 
+    def test_scoped_filename(self):
+        assert normalize_role_filename("marketing", 1, "advocate", scope="S1") == "advocate--marketing--S1-01.md"
+
+    def test_scoped_filename_contrarian(self):
+        assert normalize_role_filename("engineering", 2, "contrarian", scope="S2") == "contrarian--engineering--S2-02.md"
+
+    def test_no_scope_default(self):
+        """Without scope parameter, produces flat filename."""
+        assert normalize_role_filename("qa", 1, "advocate", scope=None) == "advocate--qa--01.md"
+
 
 # ---------------------------------------------------------------------------
 # parse_iteration_from_filename
@@ -215,6 +268,15 @@ class TestParseIterationFromFilename:
 
     def test_single_part_returns_zero(self):
         assert parse_iteration_from_filename("summary.md") == 0
+
+    def test_scoped_pattern(self):
+        assert parse_iteration_from_filename("advocate--marketing--S1-01.md") == 1
+
+    def test_scoped_pattern_higher_iteration(self):
+        assert parse_iteration_from_filename("contrarian--engineering--S2-03.md") == 3
+
+    def test_scoped_pattern_with_path(self):
+        assert parse_iteration_from_filename("run_dir/advocate--qa--S3-01.md") == 1
 
 
 # ---------------------------------------------------------------------------
@@ -240,3 +302,13 @@ class TestCollectRoleArtifacts:
         (temp_run_dir / "contrarian--qa--01.md").write_text("c1")
         result = collect_role_artifacts(temp_run_dir, "qa", "contrarian")
         assert len(result) == 1
+
+    def test_collects_scoped_artifacts(self, temp_run_dir):
+        """collect_role_artifacts finds files with scope prefixes."""
+        (temp_run_dir / "advocate--marketing--S1-01.md").write_text("s1")
+        (temp_run_dir / "advocate--marketing--S2-01.md").write_text("s2")
+        (temp_run_dir / "advocate--marketing--S2-02.md").write_text("s2r2")
+        (temp_run_dir / "advocate--marketing--S3-01.md").write_text("s3")
+
+        result = collect_role_artifacts(temp_run_dir, "marketing", "advocate")
+        assert len(result) == 4

--- a/studio/tests/test_scopes.py
+++ b/studio/tests/test_scopes.py
@@ -8,6 +8,7 @@ import pytest
 from scopes import (
     ScopeConfig,
     ScopesConfig,
+    VALID_DEBATE_MODES,
     allocate_iterations,
     generate_scope_instructions,
     load_scopes_config,
@@ -259,3 +260,124 @@ max_iterations = 1
         assert allocations["polish"] == 2  # Gets remaining to avoid rounding errors
     finally:
         config_path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# New: output_budget, debate_mode, scoped filenames
+# ---------------------------------------------------------------------------
+
+
+def test_scope_config_output_budget():
+    """ScopeConfig accepts optional output_budget."""
+    scope = ScopeConfig("alignment", "Direction", 2, output_budget=500)
+    assert scope.output_budget == 500
+
+    scope_no_budget = ScopeConfig("depth", "Detail", 3)
+    assert scope_no_budget.output_budget is None
+
+
+def test_scope_config_debate_mode_default():
+    """ScopeConfig defaults to per_role debate_mode."""
+    scope = ScopeConfig("depth", "Detail", 3)
+    assert scope.debate_mode == "per_role"
+
+
+def test_scope_config_debate_mode_all_roles():
+    """ScopeConfig accepts all_roles debate_mode."""
+    scope = ScopeConfig("alignment", "Direction", 2, debate_mode="all_roles")
+    assert scope.debate_mode == "all_roles"
+
+
+def test_scope_config_invalid_debate_mode():
+    """ScopeConfig rejects invalid debate_mode."""
+    with pytest.raises(ValueError, match="debate_mode"):
+        ScopeConfig("bad", "Bad", 1, debate_mode="invalid")
+
+
+def test_load_scopes_config_with_budget_and_mode():
+    """Loading TOML with output_budget and debate_mode fields."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write("""
+[scopes.alignment]
+focus = "Direction"
+max_iterations = 2
+output_budget = 500
+debate_mode = "all_roles"
+
+[scopes.depth]
+focus = "Detail"
+max_iterations = 3
+debate_mode = "per_role"
+
+[scopes.polish]
+focus = "Cross-check"
+max_iterations = 1
+output_budget = 300
+debate_mode = "all_roles"
+""")
+        config_path = Path(f.name)
+
+    try:
+        config = load_scopes_config(config_path)
+        assert len(config.scopes) == 3
+
+        alignment = config.get_scope("alignment")
+        assert alignment is not None
+        assert alignment.output_budget == 500
+        assert alignment.debate_mode == "all_roles"
+
+        depth = config.get_scope("depth")
+        assert depth is not None
+        assert depth.output_budget is None
+        assert depth.debate_mode == "per_role"
+
+        polish = config.get_scope("polish")
+        assert polish is not None
+        assert polish.output_budget == 300
+        assert polish.debate_mode == "all_roles"
+    finally:
+        config_path.unlink()
+
+
+def test_generate_scope_instructions_with_budget_and_mode():
+    """Instructions include output budget and debate mode when set."""
+    config = ScopesConfig(scopes=[
+        ScopeConfig("alignment", "Direction", 2, output_budget=500, debate_mode="all_roles"),
+        ScopeConfig("depth", "Detail", 3, debate_mode="per_role"),
+    ])
+    allocations = {"alignment": 2, "depth": 3}
+
+    instructions = generate_scope_instructions(config, allocations)
+
+    assert "~500 words" in instructions
+    assert "All roles debate simultaneously" in instructions
+    assert "Each role debates sequentially" in instructions
+    # Depth scope should NOT have an output budget line
+    lines = instructions.split("\n")
+    depth_idx = next(i for i, l in enumerate(lines) if "Depth" in l)
+    # Check next few lines after Depth header don't mention output budget
+    depth_section = "\n".join(lines[depth_idx:depth_idx + 5])
+    assert "Output budget" not in depth_section
+
+
+def test_load_default_scopes_config():
+    """The shipped default scopes.toml loads correctly."""
+    default_path = Path(__file__).resolve().parents[1] / "config" / "scopes.toml"
+    if not default_path.exists():
+        pytest.skip("Default scopes.toml not found")
+
+    config = load_scopes_config(default_path)
+    assert len(config.scopes) == 3
+
+    names = [s.name for s in config.scopes]
+    assert "alignment" in names
+    assert "depth" in names
+    assert "polish" in names
+
+    alignment = config.get_scope("alignment")
+    assert alignment.output_budget == 500
+    assert alignment.debate_mode == "all_roles"
+
+    depth = config.get_scope("depth")
+    assert depth.output_budget is None
+    assert depth.debate_mode == "per_role"

--- a/studio/tests/test_validators.py
+++ b/studio/tests/test_validators.py
@@ -157,11 +157,51 @@ VERDICT: REJECTED
 """)
     
     result = doc_validator.check_consistency(advocate_path, contrarian_path)
-    
+
     # Should pass (always passes, uses warnings)
     assert result.passed
-    # Should have few or no warnings since points are addressed
-    assert len(result.warnings) <= 3
+    # All advocate points are addressed — no warnings expected
+    assert len(result.warnings) == 0
+
+
+def test_check_consistency_unaddressed_points(doc_validator, temp_dir):
+    """Test consistency check when contrarian ignores advocate points."""
+    advocate_path = temp_dir / "advocate.md"
+    advocate_path.write_text("""
+# Advocate Proposal
+
+## Key Points
+
+1. **Serverless architecture** reduces operational overhead significantly
+2. **GraphQL federation** enables independent team deployments
+3. **Event sourcing** provides complete audit trail for compliance
+4. **Blue-green deployments** minimize downtime during releases
+5. **Chaos engineering** practices ensure system resilience
+
+We should adopt all five pillars immediately.
+""")
+
+    contrarian_path = temp_dir / "contrarian.md"
+    contrarian_path.write_text("""
+# Contrarian Response
+
+The proposal is interesting but I have different concerns.
+
+The timeline seems overly optimistic for a team of this size.
+Budget projections do not account for training costs.
+Stakeholder alignment has not been demonstrated.
+
+VERDICT: REJECTED
+""")
+
+    result = doc_validator.check_consistency(advocate_path, contrarian_path)
+
+    # Should pass (consistency never hard-fails)
+    assert result.passed
+    # Should have warnings because >3 advocate points are unaddressed
+    assert len(result.warnings) > 0
+    # Warnings should contain the unaddressed advocate points
+    assert any("serverless" in w.lower() or "graphql" in w.lower() for w in result.warnings)
 
 
 def test_check_format_valid_document(doc_validator, temp_dir):
@@ -346,9 +386,12 @@ Reasons:
 """)
     
     result = doc_validator.validate_run(temp_dir, "market")
-    
-    # Should have some warnings but overall structure is valid
-    assert isinstance(result, ValidationResult)
+
+    # Structure is valid — advocate/contrarian paired, verdict present with reasons
+    assert result.passed is True
+    assert isinstance(result.issues, list)
+    assert len(result.issues) == 0
+    assert isinstance(result.warnings, list)
 
 
 def test_validate_run_missing_files(doc_validator, temp_dir):
@@ -511,24 +554,30 @@ def test_check_format_empty_file(doc_validator, temp_dir):
 def test_validate_run_studio_phase(doc_validator, temp_dir):
     """validate_run for studio phase should look for role-based files."""
     (temp_dir / "advocate--marketing--01.md").write_text(
-        "# Marketing Advocate\n\n## Hook\n\nViral concept.\n\n## Audience\n\nGamers."
+        "# Marketing Advocate\n\n## Hook\n\nViral concept that leverages the nostalgia of classic arcade games with modern social mechanics.\n\n## Audience\n\nGamers aged 25-40 who grew up with retro titles and now seek cozy experiences.\n\n## Strategy\n\nLaunch on Steam with a free demo, then expand to mobile platforms.\n"
     )
     (temp_dir / "contrarian--marketing--01.md").write_text(
-        "# Marketing Contrarian\n\n## Analysis\n\nTAM is questionable.\n\nVERDICT: APPROVED"
+        "# Marketing Contrarian\n\n## Analysis\n\nThe TAM estimate of $500M is questionable given the niche audience. The competitive landscape includes several established titles in this space. Customer acquisition costs are underestimated by at least 2x.\n\nVERDICT: APPROVED\n"
     )
 
     result = doc_validator.validate_run(temp_dir, "studio")
-    assert isinstance(result, ValidationResult)
+    assert result.passed is True
+    assert isinstance(result.issues, list)
+    assert len(result.issues) == 0
+    assert isinstance(result.warnings, list)
 
 
 def test_validate_run_tech_phase(doc_validator, temp_dir):
     """validate_run for tech phase should look for standard files."""
     (temp_dir / "advocate_1.md").write_text(
-        "# Tech Advocate\n\n## Architecture\n\nMicroservices.\n\n## Stack\n\nPython + FastAPI."
+        "# Tech Advocate\n\n## Architecture\n\nMicroservices architecture with event-driven communication between services. Each service owns its data store and communicates via async message queues.\n\n## Stack\n\nPython + FastAPI for API gateway, PostgreSQL for persistence, Redis for caching and pub/sub.\n"
     )
     (temp_dir / "contrarian_1.md").write_text(
-        "# Tech Contrarian\n\n## Concerns\n\nToo complex.\n\nVERDICT: REJECTED\n\n1. Scaling risk"
+        "# Tech Contrarian\n\n## Concerns\n\nThe microservices approach is too complex for a team of three. The operational overhead of managing multiple services, message queues, and distributed data stores will consume most of the engineering bandwidth.\n\nVERDICT: REJECTED\n\n1. Scaling risk\n2. Operational complexity\n"
     )
 
     result = doc_validator.validate_run(temp_dir, "tech")
-    assert isinstance(result, ValidationResult)
+    assert result.passed is True
+    assert isinstance(result.issues, list)
+    assert len(result.issues) == 0
+    assert isinstance(result.warnings, list)

--- a/studio/tests/test_verdict.py
+++ b/studio/tests/test_verdict.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Tests for extract_verdict() — the core APPROVED/REJECTED decision point."""
+from verdict import extract_verdict
+
+
+def test_approved_verdict():
+    """Given text with 'VERDICT: APPROVED', returns 'APPROVED'."""
+    text = "After careful review:\n\nVERDICT: APPROVED\n\nThe proposal is solid."
+    assert extract_verdict(text) == "APPROVED"
+
+
+def test_rejected_verdict():
+    """Given text with 'VERDICT: REJECTED', returns 'REJECTED'."""
+    text = "Several critical issues found.\n\nVERDICT: REJECTED\n\n1. Missing data."
+    assert extract_verdict(text) == "REJECTED"
+
+
+def test_mixed_case_verdict_approved():
+    """Given text with verdict in mixed case, returns uppercased result."""
+    text = "Verdict: Approved"
+    assert extract_verdict(text) == "APPROVED"
+
+
+def test_mixed_case_verdict_rejected():
+    """Given text with verdict keyword in various cases, returns uppercased result."""
+    text = "verdict: rejected"
+    assert extract_verdict(text) == "REJECTED"
+
+
+def test_no_verdict_returns_unknown():
+    """Given text with no verdict string, returns 'UNKNOWN'."""
+    text = "This is a regular document with no decision rendered."
+    assert extract_verdict(text) == "UNKNOWN"
+
+
+def test_multiple_verdicts_first_wins():
+    """Given text with multiple verdict strings, the first match wins."""
+    text = (
+        "Round 1:\nVERDICT: REJECTED\n\n"
+        "Round 2:\nVERDICT: APPROVED\n"
+    )
+    assert extract_verdict(text) == "REJECTED"
+
+
+def test_verdict_buried_in_markdown():
+    """Given text with verdict buried in markdown context, extracts correctly."""
+    text = """# Contrarian Response — Tech Phase
+
+## Analysis
+
+The architecture has several concerning aspects that need attention.
+
+### Scalability
+
+The proposed monolith will not scale past 10k concurrent users.
+
+### Security
+
+No mention of authentication or authorization.
+
+## Decision
+
+After weighing all factors:
+
+VERDICT: REJECTED
+
+### Reasons for Rejection
+
+1. Missing horizontal scaling strategy
+2. No auth layer defined
+3. Unrealistic timeline
+"""
+    assert extract_verdict(text) == "REJECTED"
+
+
+def test_empty_string_returns_unknown():
+    """Given an empty string, returns 'UNKNOWN'."""
+    assert extract_verdict("") == "UNKNOWN"
+
+
+def test_verdict_with_extra_whitespace():
+    """Given verdict with extra whitespace between colon and value, handles correctly."""
+    text = "VERDICT:   APPROVED"
+    assert extract_verdict(text) == "APPROVED"
+
+
+def test_verdict_with_tab_whitespace():
+    """Given verdict with tab whitespace, handles correctly."""
+    text = "VERDICT:\tREJECTED"
+    assert extract_verdict(text) == "REJECTED"
+
+
+def test_verdict_word_without_colon_ignored():
+    """Given text mentioning APPROVED/REJECTED without 'VERDICT:' prefix, returns UNKNOWN."""
+    text = "The proposal was APPROVED by the committee in the last meeting."
+    assert extract_verdict(text) == "UNKNOWN"


### PR DESCRIPTION
## Summary
- Add `test_engineer` role with AI-TDD methodology and auto-injection (`engineering → test_engineer`)
- Wire `DocumentValidator` into finalize as quality warnings (verdict check, rubber-stamp detection, format validation)
- Fix test integrity findings: 3 theater tests, missing `test_verdict.py`, loose assertions, cleanup coverage
- Add three-tier scoped debate: alignment → depth → polish with output budgets and token tracking
- Update all docs (README rewrite, ARCHITECTURE, AGENTS_REFERENCE)
- Test count: 162 → 204

Depends on #11 (targets `pr/1-modernize`). Retarget to `main` after #11 merges.

## Test plan
- [ ] `cd studio && python -m pytest tests/ -v` — 204 tests pass
- [ ] Scoped filenames: `normalize_role_filename("qa", 1, "advocate", scope="S1")` → `advocate--qa--S1-01.md`
- [ ] Role dependency: adding `+engineering` auto-injects `test_engineer`
- [ ] Quality checks: finalize warns on missing verdicts and short files

🤖 Generated with [Claude Code](https://claude.com/claude-code)