### PR TITLE
Codify MVI (Minimum Viable Interaction) methodology

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ Four phases: `market`, `design`, `tech`, `studio`. Each has distinct advocate/co
 
 - **Python 3.10+** required. Uses `tomllib` (3.11+) with `tomli` fallback.
 - **No heavy dependencies** — keep `run_phase.py` small and bash-friendly.
+- **MVI (Minimum Viable Interaction)** — every task, sprint, and milestone must end in something usable. "Build a skateboard, not a wheel." Product, Engineering, and Design contrarians enforce this. See `studio/docs/MVI_METHODOLOGY.md`.
 - **AI-TDD discipline** is mandatory for tech phase implementations. AI writes scenarios and boilerplate; humans own assertions. See `studio/docs/AI_TDD_METHODOLOGY.md` for the full methodology (scenario-first, stack boundary, mutation verification, anti-pattern detection).
 - **Documentation contract**: changes to workflow must update README, STUDIO_INTERACTION_GUIDE.md, and affected bridge docs simultaneously.
 - **Working directories**: `.scratch/` for temp files, `.private/` for sensitive data — both gitignored. Never commit `studio/output/` or `studio/knowledge/`.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,21 @@ First run auto-scaffolds `.studio/` and creates a bridge doc. Override with `--a
 
 ---
 
+## MVI (Minimum Viable Interaction)
+
+Every task, sprint, and milestone must end in something **usable** — not a partial component that becomes useful later.
+
+> "Build a skateboard, not a wheel." Each increment is rideable.
+
+- **Tasks** produce an interactable result, not isolated backend/frontend pieces
+- **Sprints** end with a working flow, not a layer of the stack
+- **Milestones** are demonstrable without caveats like "once we also finish X"
+- **Roadmaps** are sequences of increasingly capable MVIs — if cancelled at any point, something usable exists
+
+Product, Engineering, and Design contrarians enforce MVI. See [MVI_METHODOLOGY.md](./studio/docs/MVI_METHODOLOGY.md).
+
+---
+
 ## AI-TDD Discipline
 
 All tech phase implementations follow AI-assisted test-driven development:
@@ -252,6 +267,7 @@ Python 3.10+ required. stdlib only, plus `tomli` on Python 3.10 (see `pyproject.
 
 - [ARCHITECTURE.md](./studio/docs/ARCHITECTURE.md) — system design and extensibility
 - [AGENTS_REFERENCE.md](./studio/docs/AGENTS_REFERENCE.md) — role definitions and debate flow
+- [MVI_METHODOLOGY.md](./studio/docs/MVI_METHODOLOGY.md) — Minimum Viable Interaction methodology
 - [AI_TDD_METHODOLOGY.md](./studio/docs/AI_TDD_METHODOLOGY.md) — AI-assisted testing methodology
 - [TEST_DRIVEN_GUIDE.md](./studio/docs/TEST_DRIVEN_GUIDE.md) — tech phase TDD workflow
 - [INTEGRATION_GUIDE.md](./studio/docs/INTEGRATION_GUIDE.md) — cross-repo setup

--- a/studio/docs/AGENTS_REFERENCE.md
+++ b/studio/docs/AGENTS_REFERENCE.md
@@ -96,6 +96,13 @@ Contrarians must always end with `VERDICT: APPROVED` or `VERDICT: REJECTED`. Fin
 
 Because everything is declarative, there’s no hidden CrewAI config to edit—just JSON + Markdown.
 
+### Methodology Enforcement
+
+Roles enforce two methodologies via their contrarian focuses and escalation triggers:
+
+- **MVI (Minimum Viable Interaction)**: Product, Engineering, and Design contrarians reject plans where milestones, sprints, or tasks end in unusable states. "Build a skateboard, not a wheel." See [MVI_METHODOLOGY.md](./MVI_METHODOLOGY.md).
+- **AI-TDD**: Test Engineer and Engineering contrarians enforce scenario-first test design, mutation verification, and anti-pattern detection. See [AI_TDD_METHODOLOGY.md](./AI_TDD_METHODOLOGY.md).
+
 ---
 
 ## 5. Best Practices for Operators

--- a/studio/docs/ARCHITECTURE.md
+++ b/studio/docs/ARCHITECTURE.md
@@ -112,6 +112,7 @@ No automation runs outside the assistant; the instructions are simply executed a
 - **Role packs** enforce consistent combinations. Example `studio_core` includes marketing, product, design, art, engineering, test_engineer, and QA.
 - **Role dependencies** are declared in `defaults.role_dependencies` (e.g., `engineering → test_engineer`). After resolving overrides, `resolve_role_list` injects co-required roles immediately after their trigger role — unless the operator explicitly removed them with `-role`. This guarantees that test integrity is always debated when engineering is present.
 - Operators select a pack via `--role-pack` and tweak attendance with `--roles` additions/removals. This keeps instructions concise while maintaining a single source of truth.
+- **Methodology enforcement**: Product, Engineering, and Design roles enforce MVI (Minimum Viable Interaction) — every milestone must end in something usable. Engineering and Test Engineer enforce AI-TDD. See `docs/MVI_METHODOLOGY.md` and `docs/AI_TDD_METHODOLOGY.md`.
 
 ---
 

--- a/studio/docs/MVI_METHODOLOGY.md
+++ b/studio/docs/MVI_METHODOLOGY.md
@@ -1,0 +1,74 @@
+# Minimum Viable Interaction (MVI) Methodology
+
+Every unit of work Studio produces — from a single task to a full roadmap — must end in a **complete, usable interaction**, not a partial component that becomes useful later.
+
+---
+
+## The Principle
+
+**Not this:** wheel → axle → chassis → car (each step is useless until the last)
+
+**Like this:** skateboard → scooter → bicycle → motorcycle → car (each step is rideable)
+
+The key word is **Interaction**, not Product. You're not shipping incrementally toward a product — you're shipping incrementally toward richer interactions. A skateboard isn't a car, but you can ride it today.
+
+---
+
+## How It Applies to Studio Outputs
+
+### Tasks End in an MVI
+
+A task should not produce "the database schema" or "the API types" in isolation. It should produce something a user can interact with, even if crude:
+
+- Bad: "Define the data model for user profiles"
+- Good: "Users can create and view a profile (hardcoded storage, no auth)"
+
+### Sprints End in an MVI
+
+A sprint should not end with "backend complete, frontend next sprint." It should end with a usable interaction, even if limited:
+
+- Bad: Sprint 1 = API endpoints, Sprint 2 = UI, Sprint 3 = integration
+- Good: Sprint 1 = one flow works end-to-end (create + view), Sprint 2 = add edit + delete, Sprint 3 = add auth + polish
+
+### Milestones End in an MVI
+
+A milestone should be demonstrable to a stakeholder without caveats like "once we also finish X":
+
+- Bad: M1 = architecture, M2 = core features, M3 = integration, M4 = polish
+- Good: M1 = one feature works (skateboard), M2 = three features work (bicycle), M3 = full feature set (motorcycle), M4 = polished release (car)
+
+### Roadmaps Are MVI Sequences
+
+The roadmap is a sequence of increasingly capable MVIs. Each point on the roadmap is independently valuable. If the project is cancelled at any milestone, something usable exists.
+
+---
+
+## The Contrarian Test
+
+When reviewing any plan, milestone, sprint, or task breakdown, apply this test:
+
+> "If we stopped here, could someone use what we've built?"
+
+If the answer is "no, they'd need to wait for the next milestone/sprint/task," the plan is building wheels, not skateboards. Reject it and demand resequencing.
+
+---
+
+## Enforcement in Studio Roles
+
+- **Product** advocate must sequence milestones as MVI progressions. Contrarian rejects milestone plans where any milestone ends in an unusable state.
+- **Engineering** advocate must decompose work into tasks that each produce interactable results. Contrarian rejects task lists that are "backend then frontend" or "types then logic then UI."
+- **Design** advocate must define experience progressions where each tier is playable/usable. Contrarian rejects designs that require "all systems online" before any interaction works.
+- **Integrator** must verify the integrated roadmap follows MVI sequencing. Each phase gate should be demonstrable.
+
+---
+
+## Relationship to Scoped Debate
+
+The three-tier scoped debate (alignment → depth → polish) is itself an MVI pattern:
+
+- **Alignment** produces a usable directional decision (skateboard)
+- **Depth** produces a detailed plan with deliverables (bicycle)
+- **Polish** produces a cross-checked, conflict-resolved plan (motorcycle)
+- **Integrator** produces the final unified roadmap (car)
+
+Each scope is independently valuable. If the run stops after alignment, you still have directional decisions. If it stops after depth, you have per-discipline plans.

--- a/studio/studio.manifest.json
+++ b/studio/studio.manifest.json
@@ -36,8 +36,8 @@
     },
     "product": {
       "title": "Group Product Manager",
-      "advocate_focus": "Align the concept with roadmap sequencing, measurable outcomes, and staffing envelopes.",
-      "contrarian_focus": "Challenge priority tradeoffs, ownership gaps, and unclear success metrics.",
+      "advocate_focus": "Align the concept with roadmap sequencing, measurable outcomes, and staffing envelopes. Every milestone must end in an MVI (Minimum Viable Interaction) — something usable, not a partial component.",
+      "contrarian_focus": "Challenge priority tradeoffs, ownership gaps, unclear success metrics, and MVI compliance. Reject milestone plans where any milestone ends in an unusable state.",
       "prompt_doc": "docs/role_prompts/product.md",
       "deliverables": [
         "Milestone plan with staffing callouts",
@@ -46,13 +46,14 @@
       ],
       "escalate_on": [
         "Unstaffed critical path",
-        "Dependencies on teams not yet engaged"
+        "Dependencies on teams not yet engaged",
+        "Milestone or sprint that ends in an unusable state (violates MVI)"
       ]
     },
     "design": {
       "title": "Lead Systems Designer",
-      "advocate_focus": "Define the fantasy, core loop, and experiential pillars that make the idea shippable.",
-      "contrarian_focus": "Call out scope bloat, UX ambiguity, and missing experiential guardrails.",
+      "advocate_focus": "Define the fantasy, core loop, and experiential pillars that make the idea shippable. Each experience tier must be playable/usable on its own (MVI).",
+      "contrarian_focus": "Call out scope bloat, UX ambiguity, missing experiential guardrails, and MVI violations. Reject designs that require all systems online before any interaction works.",
       "prompt_doc": "docs/role_prompts/design.md",
       "deliverables": [
         "Experience pillars + player promise",
@@ -81,8 +82,8 @@
     },
     "engineering": {
       "title": "Principal Gameplay Engineer",
-      "advocate_focus": "Lay out the technical architecture, integrations, and performance budgets.",
-      "contrarian_focus": "Highlight ops toil, reliability risks, and tech debt implications.",
+      "advocate_focus": "Lay out the technical architecture, integrations, and performance budgets. Decompose work into tasks that each produce an interactable result (MVI).",
+      "contrarian_focus": "Highlight ops toil, reliability risks, tech debt implications, and MVI compliance. Reject task breakdowns that are 'backend then frontend' or require multiple tasks to complete before anything is usable.",
       "prompt_doc": "docs/role_prompts/engineering.md",
       "deliverables": [
         "High-level architecture outline",
@@ -91,7 +92,8 @@
       ],
       "escalate_on": [
         "Dependencies on unbuilt platform features",
-        "SRE or infra buy-in required"
+        "SRE or infra buy-in required",
+        "Task list where no single task produces a usable interaction (violates MVI)"
       ]
     },
     "test_engineer": {


### PR DESCRIPTION
## Summary
- Add `MVI_METHODOLOGY.md` defining the skateboard-not-wheel principle at task/sprint/milestone/roadmap levels
- Product, Engineering, Design roles gain MVI enforcement in advocate focus, contrarian focus, and escalation triggers
- CLAUDE.md updated with MVI as a core convention

## Test plan
- [ ] `cd studio && python -m pytest tests/ -v` — 204 tests pass
- [ ] Manifest loads correctly with new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)