### PR TITLE
Rename project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Game Studio
+# Studio
 
 Studio is an **instruction generator** for structured advocate/contrarian debates. It prepares run directories with instructions that an AI assistant (Claude Code, Windsurf/Cascade, or any capable agent) executes, then packages the results as versioned artifacts.
 


### PR DESCRIPTION
Updated project name from 'The Game Studio' to 'Studio' in README.