### PR TITLE
feat: contrarian editor mandate + always-on open-questions pre-flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ All notable changes to TheGameStudio are documented here.
 ## [Unreleased]
 
 ### Added
+- Contrarian editor mandate (always on) — every deliverable run's contrarian now carries a built-in bias toward removal, merge, and simplification on top of flaw-hunting. The advocate piles it on; the contrarian carves out the essence. Shared `CONTRARIAN_MANDATE` injected across single-phase, flat, and scoped studio prompts; phase contrarians reframed as editors. Off in `--mode questions` (there the contrarian judges question relevance, never cuts genuinely-open questions)
+- Open-Questions Pre-Flight (Step 0) — every deliverable run opens by surfacing what is genuinely unsettled, pausing on P0 blockers, and recording answers before the iteration loop, so no run silently assumes; later passes keep raising new questions as they surface. Reuses existing decision/clarity machinery
 - Project-overridable single-phase personas via `.studio/personas.toml` — `persona_overrides.py` per-phase shallow-merges advocate/contrarian/notes/implementer/integrator overrides over the shipped `PHASE_DETAILS` defaults; setup wizard gains a `persona_customization` step (`CURRENT_SETUP_VERSION` 2) that authors the file and can sniff the project stack (`Cargo.toml`/`package.json`/`*.csproj`) to suggest a fitting persona
 - `/offload` slash command — analyzes CLAUDE.md for content safe to move to companion docs, with section classification, pointer strength scoring, canary token verification, and reconciliation against existing docs (`offload.py`, 23 tests)
 - `/detest` slash command — audits test suites against AI-TDD methodology, finds anti-patterns, fixes them
 - `/unstale` Agent 5 — project tracking audit (GitHub Issues + local tracking files) with permission-gated destructive actions
+- Stack-agnostic `/unstale` — the command now self-detects the project stack (Rust/Unity/Node/Python/Go) from marker files instead of assuming the Studio Python layout, so it works in any installed repo. Optional per-repo `.studio/unstale.toml` override pins exact snapshot commands and audit globs; authored by a new setup wizard `unstale_config` step (`CURRENT_SETUP_VERSION` 3) via `suggest_unstale_from_stack`
 - `ai_engineer` role in manifest — Staff AI Engineer specializing in prompt architecture & agent optimization
 - `/studio-setup` slash command + `setup` CLI subcommand — post-install wizard for role pack selection, role customization, scope tuning, and cleanup settings with incremental versioned steps (`setup.py`, 43 tests)
 - `docs/CODING_PRINCIPLES.md` — standalone Karpathy-inspired principles file, shipped with cross-repo installs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,9 @@ Use the slash command to run a full advocate/contrarian debate:
 
 Single-phase runs (`/run-phase`) spawn separate Advocate and Contrarian agents per iteration. Multi-role runs (`/run-studio-phase`) use a three-tier scoped debate by default: **alignment** (all roles, short, parallel) → **depth** (per-role, full, sequential) → **polish** (all roles, short, 1 pass) → integrator duel. Use `--no-scopes` for flat mode. See `studio/docs/CLAUDE_CODE_USAGE.md` for details.
 
-All runs (except `--mode questions`) include inline **decision point surfacing** — agents flag P0 (blocking), P1 (important), and P2 (context) decisions using a standard blockquote format. Use `--mode questions` as a pre-flight step to collect key decisions before committing to a full deliverables run.
+All runs (except `--mode questions`) include inline **decision point surfacing** — agents flag P0 (blocking), P1 (important), and P2 (context) decisions using a standard blockquote format. Every deliverable run also opens with a built-in **Open-Questions Pre-Flight** (Step 0): a fast pass that surfaces what is genuinely unsettled, pauses on P0 blockers, and records the answers before the iteration loop begins — so no run silently assumes. The standalone `--mode questions` remains a heavier, questions-only run for when you want a full prioritized decision set with no deliverables.
+
+The **Contrarian is an editor by default** — beyond hunting flaws and edge cases, it carries an always-on mandate to remove, merge, and simplify. The advocate piles it on; the contrarian carves out the essence (bias toward deletion, clarity, conciseness). This mandate is on in every deliverable run and stance, but deliberately **off in `--mode questions`**, where the contrarian instead judges question *relevance* and must not drop genuinely-open questions to keep the list lean.
 
 ## CLI Commands
 

--- a/studio/CHANGELOG.md
+++ b/studio/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to Studio will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Contrarian editor mandate** (always on) — a shared `CONTRARIAN_MANDATE` (`scopes.py`) injected into every deliverable-producing contrarian prompt (single-phase, flat studio, and scoped studio). The contrarian now carries a bias toward removal/merge/simplification alongside flaw-hunting; the four `PHASE_DETAILS` contrarians are reframed as editors. Deliberately omitted in `--mode questions`, where the contrarian instead judges question *relevance* and must not drop genuinely-open questions.
+- **Open-Questions Pre-Flight** (Step 0) — every deliverable run now opens with a required questions pass that surfaces what is unsettled, pauses on P0 blockers, and records answers (raising the clarity score) before the iteration loop. Reuses the existing decision/clarity machinery — no new module. The Decision Point Protocol now states explicitly that every later pass must keep raising new questions.
 - Project-overridable single-phase personas via `.studio/personas.toml` (`persona_overrides.py`) — per-phase shallow-merge over the shipped `PHASE_DETAILS` defaults; setup wizard `persona_customization` step (`CURRENT_SETUP_VERSION` 2) with stack-sniffing suggestions.
-- 14 Python modules in `studio/` (added `persona_overrides.py`); 517 tests.
+- Stack-agnostic `/unstale` — the command self-detects the stack (Rust/Unity/Node/Python/Go) from marker files, with an optional per-repo `.studio/unstale.toml` override (`[snapshot]` commands + `[audit]` globs). Setup wizard `unstale_config` step (`CURRENT_SETUP_VERSION` 3) with `suggest_unstale_from_stack` sniffing; shared `_toml_quote` helper.
+- 14 Python modules in `studio/` (added `persona_overrides.py`); 546 tests.
 
 ### Fixed
 - Stack-neutral phase personas — removed hardcoded "Three.js / WebGL" and "Steam hook" wording from `PHASE_DETAILS`.

--- a/studio/docs/CLAUDE_CODE_USAGE.md
+++ b/studio/docs/CLAUDE_CODE_USAGE.md
@@ -10,19 +10,22 @@ Run Studio phase debates natively in Claude Code using slash commands.
 
 This triggers the full advocate/contrarian loop:
 1. Prepares a run directory with instructions
-2. Spawns an Advocate agent to build the case
-3. Spawns a separate Contrarian agent to stress-test it
-4. Iterates until APPROVED or max iterations exhausted
-5. Generates implementation deliverables (if approved)
-6. Writes summary and finalizes the run
+2. Runs the **Open-Questions Pre-Flight** (Step 0) — surfaces what is genuinely unsettled, pauses on P0 blockers, records the answers
+3. Spawns an Advocate agent to build the case
+4. Spawns a separate Contrarian agent to stress-test it
+5. Iterates until APPROVED or max iterations exhausted
+6. Generates implementation deliverables (if approved)
+7. Writes summary and finalizes the run
+
+The **Contrarian is an editor by default**: alongside flaws and edge cases it carries an always-on mandate to cut, merge, and simplify — the advocate adds, the contrarian carves out the essence. (This mandate is off in `--mode questions`, where the contrarian instead judges whether each surfaced question is *relevant* and must not drop genuinely-open questions.)
 
 ## Available Phases
 
 | Phase | Advocate | Contrarian | Output |
 |-------|----------|------------|--------|
-| `market` | Market Growth Strategist | Reality Check | Audience profile, competitor analysis, GTM plan |
-| `design` | Lead Systems Designer | Scope-Creep Police | Core loop, progression, mechanics, UX |
-| `tech` | Technical Architect | Senior SRE | Architecture, stack, tests, implementation |
+| `market` | Market Growth Strategist | Reality Check & Editor | Audience profile, competitor analysis, GTM plan |
+| `design` | Lead Systems Designer | Scope-Creep Police & Editor | Core loop, progression, mechanics, UX |
+| `tech` | Technical Architect | Senior SRE & Editor | Architecture, stack, tests, implementation |
 
 ## Options
 

--- a/studio/docs/INDEX.md
+++ b/studio/docs/INDEX.md
@@ -13,11 +13,15 @@
 - **[SCOPES_GUIDE.md](./SCOPES_GUIDE.md)** - Scope-based iteration allocation
 - **[VALIDATION_GUIDE.md](./VALIDATION_GUIDE.md)** - Document and code validation
 - **[TEST_DRIVEN_GUIDE.md](./TEST_DRIVEN_GUIDE.md)** - Test-driven discipline for tech phase
+- **[AI_TDD_METHODOLOGY.md](./AI_TDD_METHODOLOGY.md)** - Full AI-TDD methodology (scenario-first, stack boundary, mutation verification)
+- **[MVI_METHODOLOGY.md](./MVI_METHODOLOGY.md)** - Minimum Viable Interaction — every milestone ends in something usable
 - **[STORAGE_MANAGEMENT.md](./STORAGE_MANAGEMENT.md)** - Cleanup, TTL, and storage budgets
 
 ## Integration
 - **[INTEGRATION_GUIDE.md](./INTEGRATION_GUIDE.md)** - Using Studio from other repos
 - **[STUDIO_BRIDGE_TEMPLATE.md](./STUDIO_BRIDGE_TEMPLATE.md)** - Bridge doc template for downstream repos
+- **[BRIDGE_COMMANDS_TEMPLATE.md](./BRIDGE_COMMANDS_TEMPLATE.md)** - Slash command files to copy into a downstream repo's `.claude/commands/`
+- **[CROSS_REPO_CHECK_MVI.md](./CROSS_REPO_CHECK_MVI.md)** - `studio check` version comparison against the source repo
 
 ## Execution Guides
 - **[CLAUDE_CODE_USAGE.md](./CLAUDE_CODE_USAGE.md)** - Claude Code slash commands and agent workflow

--- a/studio/question_mode.py
+++ b/studio/question_mode.py
@@ -117,7 +117,12 @@ def generate_question_instructions(role_data: Dict) -> Tuple[str, str]:
            reveal but do not explicitly name.
         4. Identify at least **2 missing decision points** the advocate failed
            to surface.
-        5. Remove any duplicate or overly generic questions.
+        5. Remove duplicate or overly generic questions. Judge each remaining
+           question on *relevance* — does answering it move us toward the best,
+           simplest system? Do NOT drop a genuinely-open question just to keep
+           the list short. At this stage, missing a real question is worse than
+           carrying one extra; the bias toward cutting belongs in the
+           deliverable phases, not in deciding what to ask.
 
         ## Output format
 

--- a/studio/run_phase.py
+++ b/studio/run_phase.py
@@ -40,6 +40,7 @@ from run_phase_roles import (
     resolve_role_list,
 )
 from scopes import (
+    CONTRARIAN_MANDATE,
     allocate_iterations,
     generate_scope_instructions,
     generate_scope_prompt,
@@ -124,7 +125,7 @@ def get_storage_stats() -> dict:
 PHASE_DETAILS = {
     "market": {
         "advocate": "Market Growth Strategist — steel-man the idea into a high-virality launch hook for its target platform.",
-        "contrarian": "The Reality Check — hunt for fatal market flaws and issue VERDICT: APPROVED/REJECTED.",
+        "contrarian": "The Reality Check & Editor — cut the pitch to its essential hook, kill fatal market flaws, and issue VERDICT: APPROVED/REJECTED.",
         "implementer": {
             "title": "Market Research Analyst",
             "deliverables": [
@@ -139,7 +140,7 @@ PHASE_DETAILS = {
     },
     "design": {
         "advocate": "Lead Systems Designer — craft the Minimum Viable Fun core loop.",
-        "contrarian": "Scope-Creep Police — attack complexity, timeline, and missing UX safeguards.",
+        "contrarian": "Scope-Creep Police & Editor — cut the loop to its essence; attack complexity, timeline, and missing UX safeguards.",
         "implementer": {
             "title": "Game Design Documenter",
             "deliverables": [
@@ -154,7 +155,7 @@ PHASE_DETAILS = {
     },
     "tech": {
         "advocate": "Technical Architect — define a performant, idiomatic architecture for the project's stack.",
-        "contrarian": "Senior SRE — flag performance, compatibility, and ops risks.",
+        "contrarian": "Senior SRE & Editor — delete needless moving parts; flag performance, compatibility, and ops risks.",
         "implementer": {
             "title": "Technical Architect & Code Generator",
             "deliverables": [
@@ -172,7 +173,7 @@ PHASE_DETAILS = {
     },
     "studio": {
         "advocate": "Studio Workflow Producer — articulate the inspiring yet actionable vision.",
-        "contrarian": "Bootstrapped Reality Auditor — interrogate costs, scope, and maintenance burden.",
+        "contrarian": "Bootstrapped Reality Auditor & Editor — cut scope to the essential; interrogate costs, scope, and maintenance burden.",
         "integrator": "Systems Integrator & Ops Lead — merge inspiration + constraints into a pragmatic upgrade plan after approval.",
         "notes": (
             "Iterate like every other phase until the Contrarian issues VERDICT: APPROVED. "
@@ -726,6 +727,12 @@ def build_instruction_doc(
         f"- **Advocate:** {info['advocate']}",
         f"- **Contrarian:** {info['contrarian']}",
     ]
+    # Editor mandate is always on for deliverable runs; in question-surfacing mode
+    # the contrarian judges question relevance instead and must not cut questions.
+    if not is_qmode:
+        roles_section.append("")
+        roles_section.extend(CONTRARIAN_MANDATE)
+        roles_section.append("")
     if phase != "studio":
         if is_qmode:
             roles_section.extend([
@@ -759,6 +766,30 @@ def build_instruction_doc(
             roles_section.append(
                 "- Integrator runs its own capped duel (Advocate vs. Contrarian) inside `integrator.md` once the pods approve."
             )
+
+    # Open-Questions Pre-Flight — every deliverable run opens by surfacing what is
+    # genuinely unsettled before anyone dives in. Reuses the decision/clarity machinery
+    # so answers raise the clarity score and later passes only re-ask what is still open.
+    preflight_section: List[str] = []
+    if not is_qmode:
+        preflight_section.extend([
+            "",
+            "## Step 0: Open-Questions Pre-Flight (required before the loop)",
+            "",
+            "Before anyone produces deliverables, run a fast reconnaissance pass to surface what is genuinely unsettled. The point is to stop building on silent assumptions — not to gate progress. Keep it lean.",
+            "",
+            "1. Across the participating role(s), surface the **open questions** that must be answered to build the *simplest system that actually solves the problem*. Tag each P0/P1/P2 using the Decision Point format (defined under **Decision Point Protocol** below).",
+            "2. **Pause on every P0** and ask the user — batch all P0s into a single message. For P1s, state your assumption and proceed but flag it for override. Log P2s only.",
+            "3. Record the answers so every later pass treats them as settled:",
+            "",
+            "```bash",
+            f'python "{get_studio_root()}/run_phase.py" record-decisions --run-dir {rel_dir} --decisions-file <answers.json>',
+            "```",
+            "",
+            "4. If nothing is genuinely open, say so in one line and proceed. Then begin the Iteration Loop.",
+            "",
+            "In scoped studio runs, fold this into the start of the **Alignment** scope (S1). This pre-flight front-loads the obvious questions; it does **not** replace ongoing flagging — every later pass must keep raising new questions as they surface.",
+        ])
 
     loop_section = [
         "",
@@ -801,7 +832,7 @@ def build_instruction_doc(
             "",
             "## Decision Point Protocol",
             "",
-            "When you encounter a gap, ambiguity, or fork that could meaningfully change your approach, flag it as a decision point. Do NOT silently assume — surface it.",
+            "When you encounter a gap, ambiguity, or fork that could meaningfully change your approach, flag it as a decision point. Do NOT silently assume — surface it. This applies to **every pass** — the pre-flight front-loads the obvious questions, but each later pass must keep raising new ones as they surface.",
             "",
             "### Format",
             "",
@@ -957,6 +988,7 @@ def build_instruction_doc(
                 + scope_section
                 + rerun_section
                 + roles_section
+                + preflight_section
                 + loop_section
                 + decision_point_section
                 + clarity_section
@@ -1725,7 +1757,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     # --- Setup wizard ---
     setup_parser = subparsers.add_parser(
-        "setup", help="Configure Studio for a project (roles, scopes, cleanup)."
+        "setup", help="Configure Studio for a project (roles, personas, scopes, cleanup, unstale)."
     )
     setup_parser.add_argument(
         "--target", type=Path, default=Path("."),
@@ -2115,6 +2147,7 @@ def inject_context(args: argparse.Namespace) -> None:
         raise FileNotFoundError(f"run.json not found in {run_dir}")
     meta = load_json(meta_path)
     user_text = meta.get("input", "")
+    qmode = is_question_mode(meta.get("output_type"))
 
     # Resolve scope config
     studio_root = get_studio_root()
@@ -2177,6 +2210,7 @@ def inject_context(args: argparse.Namespace) -> None:
             decisions_md_exists=decisions_md_exists,
             s1_files=s1_files,
             s2_brief_exists=s2_brief_exists,
+            question_mode=qmode,
         ))
 
     # 2. Settled decisions — only add if generate_scope_prompt didn't already cover it
@@ -2273,7 +2307,7 @@ def _do_init(args: argparse.Namespace) -> None:
     print(f"Studio installed to {dot_studio}")
     print(f"  Slash commands: {target / '.claude' / 'commands'}")
     print(f"  Source: {dot_studio / 'source'}")
-    print(f"\nRun /studio-setup to configure roles, scopes, and cleanup.")
+    print(f"\nRun /studio-setup to configure roles, personas, scopes, cleanup, and unstale audit.")
     print(f"Then use /run-phase or /run-studio-phase — pause-and-ask included.")
     print(f"NOTE: Start a NEW Claude Code session (not just /clear) to discover the commands.")
 

--- a/studio/scopes.py
+++ b/studio/scopes.py
@@ -20,6 +20,23 @@ from typing import Dict, List
 VALID_DEBATE_MODES = {"all_roles", "per_role"}
 
 
+# Shared contrarian identity, injected into every deliverable-producing contrarian
+# prompt (single-phase, flat studio, and scoped studio alike). The contrarian is not
+# only a flaw-hunter — it is an editor with a bias toward removal. The advocate adds;
+# the contrarian carves out the essence. This is always on by default.
+CONTRARIAN_MANDATE = [
+    "**Contrarian Mandate — you are an editor, not only a critic.**",
+    "",
+    "Hunting flaws and edge cases is half your job. The other half is carving the proposal down to its essence. The advocate's instinct is to add; yours is to cut.",
+    "",
+    "- **Default to deletion.** Every feature, abstraction, step, and dependency the advocate proposed must justify its existence. If it does not clearly earn its keep, recommend removing it.",
+    "- **Name the cut, specifically.** Do not just say \"this is complex\" — point at the exact feature, layer, option, or step and say what to delete or merge, and what (if anything) is actually lost.",
+    "- **Simpler beats more complete.** A shorter, clearer proposal that still solves the real problem is a better outcome than a thorough one that does more than the problem requires.",
+    "- **Collapse, don't accumulate.** Prefer merging two things into one over adding a third. Prefer removing an option over adding configuration to support it.",
+    "- **Guard the essence.** Cutting serves clarity and the core problem — never amputate what the problem genuinely requires. If a cut would break the core, say so and stop.",
+]
+
+
 @dataclass
 class ScopeConfig:
     """Configuration for a single scope level."""
@@ -209,6 +226,7 @@ def generate_scope_prompt(
     s1_files: List[str] | None = None,
     s2_brief_exists: bool = False,
     rejection_context: str | None = None,
+    question_mode: bool = False,
 ) -> str:
     """Generate scope-specific agent instructions for a single agent prompt.
 
@@ -230,6 +248,9 @@ def generate_scope_prompt(
         s1_files: For S2/S3: list of S1 file paths this agent should read.
         s2_brief_exists: Whether S2-brief.md exists in run_dir.
         rejection_context: Rejection reasons from prior iteration, if any.
+        question_mode: When True, this is a question-surfacing run — the
+            contrarian editor mandate (bias toward cutting) is suppressed so it
+            does not drop genuinely-open questions.
 
     Returns:
         Markdown prompt fragment for inclusion in agent instructions.
@@ -247,6 +268,12 @@ def generate_scope_prompt(
         f"**Input/objective:** {user_text}",
         "",
     ]
+
+    # Contrarian editor mandate — always on for the contrarian stance, except in
+    # question-surfacing mode where cutting questions is exactly wrong.
+    if stance == "contrarian" and not question_mode:
+        lines.extend(CONTRARIAN_MANDATE)
+        lines.append("")
 
     # Word cap
     if scope.output_budget:

--- a/studio/tests/test_run_phase.py
+++ b/studio/tests/test_run_phase.py
@@ -137,6 +137,34 @@ def test_instruction_doc_has_think_first_checkpoint(studio_root):
     assert "correct analysis of the wrong problem" in instructions
 
 
+def test_instruction_doc_has_contrarian_editor_mandate(studio_root):
+    """Deliverable runs carry the always-on contrarian editor mandate."""
+    run_id = run_phase.prepare_run(make_prepare_args())
+    run_dir = studio_root / "output" / "market" / run_id
+    instructions = (run_dir / "instructions.md").read_text()
+    assert "Contrarian Mandate" in instructions
+    assert "Default to deletion" in instructions
+
+
+def test_instruction_doc_has_open_questions_preflight(studio_root):
+    """Deliverable runs open with a required open-questions pre-flight."""
+    run_id = run_phase.prepare_run(make_prepare_args())
+    run_dir = studio_root / "output" / "market" / run_id
+    instructions = (run_dir / "instructions.md").read_text()
+    assert "Open-Questions Pre-Flight" in instructions
+    assert "Pause on every P0" in instructions
+
+
+def test_question_mode_omits_editor_mandate_and_preflight(studio_root):
+    """Question-surfacing runs must not cut questions or front-load a separate pass."""
+    run_id = run_phase.prepare_run(make_prepare_args(mode="questions"))
+    run_dir = studio_root / "output" / "market" / run_id
+    instructions = (run_dir / "instructions.md").read_text()
+    assert "Contrarian Mandate" not in instructions
+    assert "Default to deletion" not in instructions
+    assert "Open-Questions Pre-Flight" not in instructions
+
+
 def test_output_root_defaults_to_origin_repo_when_running_outside_studio(tmp_path, monkeypatch):
     studio_root = tmp_path / "studio"
     studio_root.mkdir()

--- a/studio/tests/test_scoped_debate.py
+++ b/studio/tests/test_scoped_debate.py
@@ -423,6 +423,43 @@ class TestInjectContextCLI:
         )
         inject_context(args)
 
+    def test_inject_context_contrarian_mandate_gated_by_question_mode(self, tmp_path, monkeypatch):
+        """inject-context emits the editor mandate for a normal contrarian but
+        suppresses it when the run is in question-surfacing mode."""
+        studio_root = Path(__file__).resolve().parent.parent
+        scopes_path = studio_root / "config" / "scopes.toml"
+        monkeypatch.setenv("STUDIO_ROOT", str(studio_root))
+
+        import argparse
+        from run_phase import inject_context, set_artifact_root
+        set_artifact_root(tmp_path)
+
+        def _run(output_type):
+            run_dir = tmp_path / f"run_{output_type}"
+            run_dir.mkdir()
+            meta = {
+                "run_id": run_dir.name,
+                "phase": "studio",
+                "input": "A cozy farming sim",
+                "max_iterations": 3,
+                "output_type": output_type,
+                "scopes": {
+                    "config_path": str(scopes_path),
+                    "scopes": [{"name": "depth", "focus": "Detail", "allocated_iterations": 3}],
+                    "total_iterations": 3,
+                },
+            }
+            (run_dir / "run.json").write_text(json.dumps(meta))
+            args = argparse.Namespace(
+                run_dir=run_dir, scope="depth", role="engineering",
+                stance="contrarian", artifact_root=tmp_path,
+            )
+            inject_context(args)
+            return (run_dir / "context--engineering--depth--contrarian.md").read_text()
+
+        assert "Default to deletion" in _run("deliverables")
+        assert "Default to deletion" not in _run("questions")
+
     def test_inject_context_missing_run_dir(self, tmp_path):
         """inject-context raises on missing run directory."""
         import argparse

--- a/studio/tests/test_scopes.py
+++ b/studio/tests/test_scopes.py
@@ -6,13 +6,59 @@ from pathlib import Path
 import pytest
 
 from scopes import (
+    CONTRARIAN_MANDATE,
     ScopeConfig,
     ScopesConfig,
     VALID_DEBATE_MODES,
     allocate_iterations,
     generate_scope_instructions,
+    generate_scope_prompt,
     load_scopes_config,
 )
+
+
+def _scope_prompt(stance, scope_index=1, question_mode=False):
+    scope = ScopeConfig(name="depth", focus="Full analysis", max_iterations=2)
+    return generate_scope_prompt(
+        scope=scope,
+        scope_index=scope_index,
+        role_title="Engineering",
+        stance=stance,
+        run_dir="output/studio/run_x",
+        advocate_focus="Build it",
+        contrarian_focus="Break it",
+        deliverables=["A spec"],
+        user_text="A cozy farming sim",
+        decisions_md_exists=False,
+        question_mode=question_mode,
+    )
+
+
+def test_scope_prompt_contrarian_has_editor_mandate():
+    """Contrarian scope prompts carry the always-on editor mandate."""
+    prompt = _scope_prompt("contrarian")
+    assert "Contrarian Mandate" in prompt
+    assert "Default to deletion" in prompt
+    # Mandate constant is fully rendered.
+    for line in CONTRARIAN_MANDATE:
+        if line:
+            assert line in prompt
+
+
+def test_scope_prompt_advocate_has_no_editor_mandate():
+    """The editor mandate must not leak into advocate prompts."""
+    prompt = _scope_prompt("advocate")
+    assert "Contrarian Mandate" not in prompt
+    assert "Default to deletion" not in prompt
+
+
+def test_scope_prompt_contrarian_omits_mandate_in_question_mode():
+    """In question-surfacing runs the contrarian must not get the cut-bias mandate."""
+    prompt = _scope_prompt("contrarian", question_mode=True)
+    assert "Contrarian Mandate" not in prompt
+    assert "Default to deletion" not in prompt
+    # Still produces a contrarian scope prompt (verdict line remains).
+    assert "VERDICT" in prompt
 
 
 def test_scope_config_validation():


### PR DESCRIPTION
## Why

Studio runs were overengineering tasks — even the *contrarian* piled on caveats and complexity instead of cutting it, and runs tended to silently assume answers rather than surface what was unsettled. This makes the contrarian an **editor by default** and stops runs from assuming.

## What changed

### Contrarian = editor, always on
- New shared `CONTRARIAN_MANDATE` (`scopes.py`) injected into **every deliverable-producing contrarian prompt** — single-phase, flat studio, and scoped studio (`generate_scope_prompt`). Bias toward removal / merge / simplification *on top of* flaw-hunting: default to deletion, name the cut specifically, simpler beats more complete, guard the essence.
- The four `PHASE_DETAILS` contrarians reframed as editors (e.g. *Scope-Creep Police & Editor*).
- Appended after the persona line, so it survives `.studio/personas.toml` overrides — genuinely always-on.

### Deliberately OFF in `--mode questions`
- Cutting questions during question-surfacing is exactly backwards. Gated at **both** injection sites: `build_instruction_doc` (`is_qmode`) and `generate_scope_prompt` (new `question_mode` param, threaded through `inject_context` from `output_type`). The scoped path needed its own gate because studio question-mode runs keep scopes active (`_resolve_scopes` only checks `--no-scopes`) — caught in code review.
- `question_mode.py` step 5 now judges question **relevance**, with an explicit guard against dropping genuinely-open questions.

### Open-Questions Pre-Flight (Step 0)
- Every deliverable run now opens by surfacing what's unsettled, pausing on P0 blockers, and recording answers (which raise the clarity score, so later passes only re-ask what's still open) before the iteration loop. Reuses existing decision/clarity machinery — no new module.
- The Decision Point Protocol now states explicitly that every later pass keeps raising new questions.

## Docs
`CLAUDE.md`, `CLAUDE_CODE_USAGE.md`, and both changelogs updated (documentation contract). Also folds in pending `/unstale` doc reconciliation (changelog entries, `INDEX.md` links, setup wizard help strings) that was intermingled in shared files.

## Tests
539 → **546** passing. New coverage: mandate present for contrarian / absent for advocate and question mode at both unit (`test_scopes.py`) and `inject_context` integration level (`test_scoped_debate.py`); pre-flight section renders; question mode omits both mandate and pre-flight (`test_run_phase.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)