### PR TITLE
feat: Slack/n8n run-digest webhook integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,10 @@ python studio/run_phase.py show-metrics --run-dir <path>
 python studio/run_phase.py cleanup --dry-run
 python studio/run_phase.py cleanup
 
+# Outbound notifications (Slack / n8n run digest — see studio/docs/INTEGRATIONS.md)
+python studio/run_phase.py notify --run-dir <run_dir>            # post digest to enabled webhooks
+python studio/run_phase.py notify --run-dir <run_dir> --dry-run  # print payloads without posting
+
 # Cross-repo install (installs slash commands + source into any project)
 python studio/run_phase.py init --target /path/to/project
 python studio/run_phase.py check-install --target /path/to/project
@@ -174,6 +178,7 @@ All source lives under `studio/`. `run_phase.py` is the sole entrypoint using on
 - **`offload.py`** — CLAUDE.md analyzer: classifies sections, detects embedded constraints, scores pointer strength, generates offload reports and manages canary tokens.
 - **`setup.py`** — Setup wizard: project configuration after install. Tracks setup state in `.studio/SETUP.json`, generates role overrides, scopes, and cleanup config. Supports incremental re-configuration when new features are added.
 - **`validators/`** — `DocumentValidator` (including `validate_question_mode()`) and `CodeValidator` for post-run quality checks.
+- **`integrations/slack_digest.py`** — Outbound run-digest notifier. Posts a finalized run's status/verdict/summary to a Slack Incoming Webhook (Block Kit) and/or an n8n Webhook node (flat JSON), stdlib `urllib` only. Config from `.studio/integrations.toml`; webhook URLs resolved from env vars (secrets never committed). Fires via the `notify` subcommand and, when enabled, auto-fires on `finalize` (soft-fail). See `studio/docs/INTEGRATIONS.md`.
 
 ### Configuration files
 
@@ -185,6 +190,7 @@ All source lives under `studio/`. `run_phase.py` is the sole entrypoint using on
 - **`.studio/validation.toml`** — Validation configuration.
 - **`.studio/roles/*.json`** — Project-local role overrides. Shallow-merge with manifest roles (override keys replace base, unspecified keys inherit).
 - **`.studio/personas.toml`** — Project-local single-phase persona overrides (market/design/tech/studio advocate, contrarian, notes, implementer, integrator). Per-phase shallow merge over the shipped `PHASE_DETAILS` defaults; loaded via `persona_overrides.py`, authored by the setup wizard.
+- **`.studio/integrations.toml`** — Optional outbound-webhook config for run digests. `[slack]` and `[n8n]` tables, each with `enabled` and `webhook_url_env` (env var holding the secret URL); `[n8n]` also takes optional `auth_header`/`auth_value_env` for Header Auth. Absent or no target `enabled` → notifications are off. Loaded by `integrations/slack_digest.py`.
 - **`.studio/unstale.toml`** — Optional per-repo override for the `/unstale` staleness audit: `[snapshot]` commands (`test_count`, `module_inventory`, `cli_help`) and `[audit]` globs (`doc_globs`, `source_globs`, `cross_refs`). When absent, `/unstale` self-detects the stack (Rust/Unity/Node/Python/Go) from marker files. Read directly by the `/unstale` command, not Python code.
 
 ### Artifact structure

--- a/studio/docs/INTEGRATIONS.md
+++ b/studio/docs/INTEGRATIONS.md
@@ -1,0 +1,73 @@
+# Integrations: Slack / n8n run digests
+
+Studio can post a short **run digest** (phase, run id, status, verdict, summary)
+to an HTTP webhook when a run finishes. The same code targets either a **Slack
+Incoming Webhook** directly or an **n8n Webhook node** (which can then fan out to
+Slack, email, a database, etc.) — both are just "HTTP POST a JSON body to a URL".
+
+Implementation: `studio/integrations/slack_digest.py` (stdlib `urllib` only).
+Disabled by default; nothing is sent until you enable a target.
+
+## Quick start
+
+1. **Create a webhook URL.**
+   - *Slack:* api.slack.com/apps → your app → **Incoming Webhooks** → *Add New
+     Webhook to Workspace* → pick a channel → copy the
+     `https://hooks.slack.com/services/T.../B.../...` URL.
+   - *n8n:* add a **Webhook** trigger node, copy its **Production URL**
+     (`https://<host>/webhook/<path>`), and activate the workflow.
+
+2. **Put the URL in an environment variable** (it is a secret — never commit it):
+   ```bash
+   export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/T000/B000/XXXX"
+   ```
+
+3. **Enable the target** in `.studio/integrations.toml`:
+   ```toml
+   [slack]
+   enabled = true
+   webhook_url_env = "SLACK_WEBHOOK_URL"   # env var name, not the URL itself
+
+   [n8n]
+   enabled = false
+   webhook_url_env = "N8N_WEBHOOK_URL"
+   auth_header = "X-API-Key"               # optional (n8n Header Auth)
+   auth_value_env = "N8N_WEBHOOK_KEY"      # optional secret for that header
+   ```
+
+4. **Send a digest:**
+   ```bash
+   python studio/run_phase.py notify --run-dir output/design/run_design_... --dry-run  # preview
+   python studio/run_phase.py notify --run-dir output/design/run_design_...            # post
+   ```
+
+## Auto-fire on finalize
+
+When `[slack].enabled` or `[n8n].enabled` is true, `finalize` posts the digest
+automatically after writing `run.json`. It is **soft-fail**: a webhook error is
+printed but never breaks finalize. With no target enabled, finalize is unchanged.
+
+## Payloads
+
+- **Slack** — Block Kit message: a header, a two-column field section
+  (status / verdict / phase / run id), a divider, and a context footer. A
+  top-level `text` fallback is always included (required by Slack).
+- **n8n** — flat JSON addressable downstream as `$json.body.<field>`:
+  `source`, `event` (`"run.completed"`), `phase`, `run_id`, `status`,
+  `verdict`, `iterations_run`, `summary_path`, `summary_text` (truncated),
+  `timestamp`.
+
+## Security
+
+The webhook URL **is** the credential (especially for Slack — it has no separate
+auth). Keep it in an environment variable or an untracked file; never commit it
+or log it in full. If a Slack URL leaks, delete the webhook in the Slack app to
+invalidate it. For n8n, prefer **Header Auth** and store the header value via
+`auth_value_env`.
+
+## References
+
+- Slack Incoming Webhooks: https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks
+- Slack Block Kit (section/header/context): https://docs.slack.dev/reference/block-kit/blocks/section-block
+- n8n Webhook node: https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.webhook/
+- n8n Webhook credentials (auth): https://docs.n8n.io/integrations/builtin/credentials/webhook/

--- a/studio/docs/tickets/TICKET-slack-n8n-digest.md
+++ b/studio/docs/tickets/TICKET-slack-n8n-digest.md
@@ -1,0 +1,150 @@
+# TICKET: Slack / n8n webhook digest for completed runs
+
+**Type:** Feature · **Component:** `studio/integrations/` (new) · **Priority:** P2
+**Status:** Proposed · **Author:** Adriano Valle · **Date:** 2026-06-25
+
+> **Decisions (locked):** `notify` CLI is the primary trigger; auto-fire-on-finalize
+> ships in the same PR but **default-disabled**. Both **Slack + n8n** targets in v1.
+
+## Summary
+
+Add a small, stdlib-only outbound webhook integration that posts a **run digest**
+(phase, run id, status, verdict, short summary, link) to a configurable HTTP
+endpoint when a run is finalized. The same transport targets either a **Slack
+Incoming Webhook** directly or an **n8n Webhook node** (which can then fan out to
+Slack, email, a database, etc.).
+
+Concretely: a new module `studio/integrations/slack_digest.py`, a `notify`
+CLI subcommand (`python studio/run_phase.py notify --run-dir ...`), an optional
+auto-fire at the end of `finalize`, and config via `.studio/integrations.toml`
+(+ env-var secrets).
+
+## Motivation
+
+- Studio runs currently terminate silently — the operator must check
+  `output/index.md` / `knowledge/run_log.md` to learn a run finished.
+- A post-finalize digest gives teams a passive "run X finished, verdict
+  APPROVED" feed in Slack, and an n8n target turns Studio into a node any
+  automation can build on.
+- It is the first **outbound integration** in the repo and establishes the
+  `studio/integrations/` pattern.
+
+## Goals / Non-goals
+
+**Goals**
+- One small module, stdlib only (`urllib.request` + `json` + `tomllib`/`tomli`).
+- Works against a Slack Incoming Webhook URL *and* an n8n Webhook URL with the
+  same code path; payload schema differs per target, transport is identical.
+- Config-driven, secrets never committed. Disabled by default.
+- Failures are **soft** — a notification error must never fail a run or finalize.
+- Tested with `urllib` mocked (no real network in CI).
+
+**Non-goals**
+- No Slack OAuth app / bot tokens / interactivity — Incoming Webhooks only.
+- No inbound webhooks / no server. Outbound POST only.
+- No new third-party dependencies. No retry queue / persistence beyond a single
+  inline retry on HTTP 429.
+
+## Design
+
+### Module: `studio/integrations/slack_digest.py`
+Separate **transport** from **payload** (the one thing that genuinely differs
+between Slack and n8n):
+
+```python
+def post_json(url, payload, headers=None, timeout=10.0, max_retries=2) -> bool
+    # urllib POST; treat 2xx as success; honor 429 Retry-After; never raises.
+
+def build_slack_blocks(meta: dict) -> dict          # Block Kit: header + fields + context
+def build_n8n_payload(meta: dict, summary_text: str) -> dict   # flat run-digest JSON
+
+def notify_run(run_dir: Path, config: dict) -> list[str]
+    # reads run.json + summary.md, builds per-target payloads, posts to each
+    # enabled target, returns a list of human-readable result strings.
+```
+
+### Config: `.studio/integrations.toml` (loaded with the existing tomllib pattern, cf. `persona_overrides.py:66`)
+```toml
+[slack]
+enabled = true
+# URL is a secret — read from env, NOT stored here:
+webhook_url_env = "SLACK_WEBHOOK_URL"
+
+[n8n]
+enabled = false
+webhook_url_env = "N8N_WEBHOOK_URL"
+auth_header = "X-API-Key"          # optional; n8n Header Auth
+auth_value_env = "N8N_WEBHOOK_KEY" # optional; secret via env
+```
+The webhook URL is the credential (Slack) — keep it in an env var, never in the
+repo. n8n optionally needs a custom auth header (Header Auth recommended).
+
+### Payloads
+- **Slack**: top-level `text` (fallback, required) + `blocks` (header, a
+  `section` with `fields` for status/verdict/phase/run id, divider, context
+  footer). Success = HTTP 200, body `ok`.
+- **n8n**: flat JSON — `source`, `event="run.completed"`, `phase`, `run_id`,
+  `status`, `verdict`, `summary_path`, `summary_text` (short), `timestamp`.
+  Success = any 2xx (default node returns `{"message":"Workflow got started"}`).
+
+### CLI: `notify` subcommand (mirror the `show-clarity` pattern, `run_phase.py:1703`/`2240`/`2481`; add to `SUBCOMMANDS` at `run_phase.py:201`)
+```
+python studio/run_phase.py notify --run-dir output/studio/run_studio_... [--dry-run]
+```
+`--dry-run` prints the payloads without posting (useful for Block Kit preview).
+
+### Auto-fire on finalize (optional, behind config)
+After `write_json(meta_path, meta)` in `finalize_run` (`run_phase.py:1301`),
+if `[slack].enabled`/`[n8n].enabled`, call `notify_run(run_dir, cfg)` inside a
+try/except so a webhook failure only logs and never breaks finalize.
+
+## Build order
+
+Each step is independently verifiable; land them in this order.
+
+1. **`studio/integrations/__init__.py` + `slack_digest.py`** — `post_json()`
+   (urllib POST, 2xx=success, 429+Retry-After, never raises), `build_slack_blocks()`,
+   `build_n8n_payload()`, `notify_run(run_dir, config)`.
+   *Verify:* unit-test the payload builders; `import studio.integrations.slack_digest` clean.
+2. **Config loader** for `.studio/integrations.toml` (reuse `persona_overrides.py:66`
+   tomllib pattern); URLs/secrets resolved from env vars named in the toml.
+   *Verify:* missing file → disabled no-op; env-var indirection resolves.
+3. **`notify` subcommand** (`--run-dir`, `--dry-run`), mirroring `show-clarity`
+   (parser `:1703`, handler `:2240`, dispatch `:2481`, `SUBCOMMANDS` `:201`).
+   *Verify:* `--dry-run` prints both payloads for a seeded run.
+4. **Auto-fire on finalize** behind `enabled` flags, after `write_json` at
+   `run_phase.py:1301`, wrapped in try/except.
+   *Verify:* simulated webhook failure logs but finalize still succeeds.
+5. **`studio/tests/test_slack_digest.py`** with `urllib` mocked — payload build,
+   success, HTTP error, timeout, 429 retry, disabled/no-config no-op.
+   *Verify:* `cd studio && python -m pytest tests/ -v` green.
+6. **Docs** — `CLAUDE.md` CLI list + short `studio/docs/INTEGRATIONS.md`.
+   *Verify:* docs match shipped flags/behavior (MVI docs gate).
+
+## Acceptance criteria
+
+- [ ] `studio/integrations/__init__.py` + `slack_digest.py` exist; stdlib-only imports.
+- [ ] `notify` subcommand prepares + posts digest for a finalized run; `--dry-run` prints payloads.
+- [ ] Slack payload renders as a Block Kit digest (verified in Block Kit Builder).
+- [ ] n8n payload is flat JSON addressable as `$json.body.<field>`; optional auth header sent when configured.
+- [ ] Webhook failure / timeout / 429 is handled soft (logged, returns False, no exception escapes).
+- [ ] No secret in repo: URL read from env var named in `.studio/integrations.toml`.
+- [ ] `studio/tests/test_slack_digest.py` covers: payload build, success, HTTP error, timeout, 429 retry, disabled/no-config no-op — all with `urllib` mocked.
+- [ ] Docs updated: `CLAUDE.md` CLI list + a short `studio/docs/INTEGRATIONS.md`.
+- [ ] All existing tests still pass (`cd studio && python -m pytest tests/ -v`).
+
+## References
+
+- Slack Incoming Webhooks (payload, success/error bodies): https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks
+- Slack Block Kit — header / section(fields) / context blocks: https://docs.slack.dev/reference/block-kit/blocks/section-block
+- Slack rate limits (1/sec, 429 + Retry-After): https://docs.slack.dev/apis/web-api/rate-limits
+- n8n Webhook node (URLs, methods, `$json.body`, auth, response): https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.webhook/
+- n8n Webhook credentials (Header/Basic/JWT auth): https://docs.n8n.io/integrations/builtin/credentials/webhook/
+
+## Codebase anchors
+
+- `run.json` builder: `studio/run_phase.py:1097` (`_build_run_meta`)
+- `finalize_run` + hook point: `studio/run_phase.py:1262`, write-back at `:1301`
+- CLI subcommand pattern: parser `:1703`, handler `:2240`, dispatch `:2481`, `SUBCOMMANDS` `:201`
+- TOML config pattern: `studio/persona_overrides.py:66`, `studio/cleanup.py:78`
+- Test conventions + fixtures: `studio/tests/conftest.py` (`studio_root`, `make_finalize_args`)

--- a/studio/integrations/__init__.py
+++ b/studio/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Outbound integrations for Studio (Slack / n8n run digests)."""

--- a/studio/integrations/slack_digest.py
+++ b/studio/integrations/slack_digest.py
@@ -81,19 +81,17 @@ def load_integrations_config(project_root: Path) -> Dict[str, Dict]:
 
 
 def _resolve_secret(target_cfg: Dict, key: str) -> Optional[str]:
-    """Resolve a secret from ``<key>_env`` (env var) or a literal ``<key>``.
+    """Resolve a secret strictly from the ``<key>_env`` env-var indirection.
 
-    Prefers the env-var indirection so secrets stay out of the repo.
+    Secrets (webhook URLs, auth values) must never live in the committed config,
+    so there is deliberately no literal ``<key>`` fallback — only the named
+    environment variable is read. Returns None if unset/empty.
     """
     env_name = target_cfg.get(f"{key}_env")
-    if env_name:
-        value = os.environ.get(env_name)
-        if value:
-            return value.strip()
-    literal = target_cfg.get(key)
-    if isinstance(literal, str) and literal.strip():
-        return literal.strip()
-    return None
+    if not env_name:
+        return None
+    value = os.environ.get(env_name)
+    return value.strip() if value and value.strip() else None
 
 
 # --------------------------------------------------------------------------- #

--- a/studio/integrations/slack_digest.py
+++ b/studio/integrations/slack_digest.py
@@ -1,0 +1,299 @@
+"""
+Post a run digest to a Slack Incoming Webhook and/or an n8n Webhook node.
+
+Both targets are "HTTP POST a JSON body to a URL", so a single stdlib
+``urllib`` transport (:func:`post_json`) serves both; only the payload schema
+and auth differ. Slack gets a Block Kit message (:func:`build_slack_blocks`);
+n8n gets a flat run-digest JSON (:func:`build_n8n_payload`) it can fan out from.
+
+Configuration lives in ``.studio/integrations.toml`` (loaded with the same
+tomllib pattern as ``persona_overrides.py``). Webhook URLs are secrets and are
+resolved from environment variables named in the config — never stored in the
+repo. The integration is disabled unless a target is explicitly enabled.
+
+File schema (all tables/keys optional; absent → that target is off)::
+
+    [slack]
+    enabled = true
+    webhook_url_env = "SLACK_WEBHOOK_URL"   # env var holding the secret URL
+
+    [n8n]
+    enabled = false
+    webhook_url_env = "N8N_WEBHOOK_URL"
+    auth_header = "X-API-Key"               # optional (n8n Header Auth)
+    auth_value_env = "N8N_WEBHOOK_KEY"      # optional secret for that header
+
+Notification failures are soft: :func:`post_json` never raises and
+:func:`notify_run` only returns human-readable result strings, so a webhook
+problem can never break the run it is reporting on.
+"""
+from __future__ import annotations
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redefine]  # Python 3.10 fallback
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+INTEGRATIONS_FILENAME = "integrations.toml"
+_SUMMARY_MAX_CHARS = 600
+_USER_AGENT = "TheGameStudio-digest/1.0"
+
+
+class IntegrationsConfigError(RuntimeError):
+    """Raised when ``.studio/integrations.toml`` is present but invalid."""
+
+
+# --------------------------------------------------------------------------- #
+# Config
+# --------------------------------------------------------------------------- #
+def load_integrations_config(project_root: Path) -> Dict[str, Dict]:
+    """Load ``<project_root>/.studio/integrations.toml``.
+
+    Returns an empty dict when the file is absent. Raises
+    :class:`IntegrationsConfigError` on malformed TOML.
+    """
+    path = Path(project_root) / ".studio" / INTEGRATIONS_FILENAME
+    if not path.is_file():
+        return {}
+
+    try:
+        with path.open("rb") as fh:
+            data = tomllib.load(fh)
+    except tomllib.TOMLDecodeError as exc:
+        raise IntegrationsConfigError(
+            f"Integrations config at {path} is not valid TOML: {exc}"
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise IntegrationsConfigError(
+            f"Integrations config at {path} must be a table."
+        )
+    return data
+
+
+def _resolve_secret(target_cfg: Dict, key: str) -> Optional[str]:
+    """Resolve a secret from ``<key>_env`` (env var) or a literal ``<key>``.
+
+    Prefers the env-var indirection so secrets stay out of the repo.
+    """
+    env_name = target_cfg.get(f"{key}_env")
+    if env_name:
+        value = os.environ.get(env_name)
+        if value:
+            return value.strip()
+    literal = target_cfg.get(key)
+    if isinstance(literal, str) and literal.strip():
+        return literal.strip()
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Transport
+# --------------------------------------------------------------------------- #
+def post_json(
+    url: str,
+    payload: Dict,
+    *,
+    headers: Optional[Dict[str, str]] = None,
+    timeout: float = 10.0,
+    max_retries: int = 2,
+) -> Tuple[bool, str]:
+    """POST ``payload`` as JSON to ``url``. Never raises.
+
+    Returns ``(ok, detail)`` where ``ok`` is True for any 2xx response.
+    Honors HTTP 429 by sleeping ``Retry-After`` seconds and retrying.
+    """
+    data = json.dumps(payload).encode("utf-8")
+    base_headers = {"Content-Type": "application/json", "User-Agent": _USER_AGENT}
+    if headers:
+        base_headers.update(headers)
+
+    for attempt in range(max_retries + 1):
+        req = urllib.request.Request(
+            url, data=data, headers=base_headers, method="POST"
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                body = resp.read().decode("utf-8", "replace").strip()
+                ok = 200 <= resp.status < 300
+                return ok, f"HTTP {resp.status} {body[:120]!r}"
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", "replace").strip()
+            if exc.code == 429 and attempt < max_retries:
+                retry_after = _retry_after_seconds(exc)
+                time.sleep(retry_after)
+                continue
+            return False, f"HTTP {exc.code} {body[:120]!r}"
+        except (urllib.error.URLError, TimeoutError) as exc:
+            return False, f"unreachable: {exc}"
+
+    return False, "exhausted retries"
+
+
+def _retry_after_seconds(exc: urllib.error.HTTPError) -> int:
+    raw = exc.headers.get("Retry-After", "1") if exc.headers else "1"
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return 1
+
+
+# --------------------------------------------------------------------------- #
+# Payload builders
+# --------------------------------------------------------------------------- #
+def _status_icon(status: str) -> str:
+    return ":white_check_mark:" if status.upper() == "COMPLETED" else ":warning:"
+
+
+def build_slack_blocks(meta: Dict) -> Dict:
+    """Build a Slack Block Kit digest payload from a run.json ``meta`` dict.
+
+    Includes a top-level ``text`` fallback (required by Slack) plus a header,
+    a two-column field section, and a context footer.
+    """
+    phase = str(meta.get("phase", "?"))
+    run_id = str(meta.get("run_id", "?"))
+    status = str(meta.get("status", "?"))
+    verdict = str(meta.get("verdict") or "N/A")
+    when = str(meta.get("updated_iso") or meta.get("created_display") or "")
+    iterations = meta.get("iterations_run")
+
+    footer = "TheGameStudio digest"
+    if iterations is not None:
+        footer += f" · {iterations} iteration(s)"
+    if when:
+        footer += f" · {when}"
+
+    return {
+        "text": f"Studio run summary — {phase} — {verdict}",
+        "blocks": [
+            {
+                "type": "header",
+                "text": {"type": "plain_text", "text": "Run Summary", "emoji": True},
+            },
+            {
+                "type": "section",
+                "fields": [
+                    {"type": "mrkdwn", "text": f"*Status:*\n{_status_icon(status)} {status}"},
+                    {"type": "mrkdwn", "text": f"*Verdict:*\n{verdict}"},
+                    {"type": "mrkdwn", "text": f"*Phase:*\n{phase}"},
+                    {"type": "mrkdwn", "text": f"*Run ID:*\n`{run_id}`"},
+                ],
+            },
+            {"type": "divider"},
+            {"type": "context", "elements": [{"type": "mrkdwn", "text": footer}]},
+        ],
+    }
+
+
+def build_n8n_payload(meta: Dict, summary_text: str = "") -> Dict:
+    """Build a flat run-digest payload for an n8n Webhook node.
+
+    Flat keys are addressable downstream as ``$json.body.<field>``.
+    """
+    return {
+        "source": "TheGameStudio",
+        "event": "run.completed",
+        "phase": meta.get("phase"),
+        "run_id": meta.get("run_id"),
+        "status": meta.get("status"),
+        "verdict": meta.get("verdict") or "N/A",
+        "iterations_run": meta.get("iterations_run"),
+        "summary_path": meta.get("summary_path"),
+        "summary_text": summary_text[:_SUMMARY_MAX_CHARS],
+        "timestamp": meta.get("updated_iso") or meta.get("created_iso"),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+def _read_summary_text(run_dir: Path, meta: Dict) -> str:
+    name = meta.get("summary_path") or "summary.md"
+    summary_path = Path(name)
+    if not summary_path.is_absolute():
+        summary_path = run_dir / summary_path.name
+    if summary_path.is_file():
+        return summary_path.read_text(encoding="utf-8").strip()
+    return ""
+
+
+def notify_run(
+    run_dir: Path,
+    config: Dict,
+    *,
+    dry_run: bool = False,
+) -> List[str]:
+    """Post the run digest to every enabled target. Returns result strings.
+
+    Reads ``run.json`` from ``run_dir``. Each enabled target is posted
+    independently; a failure on one is reported but does not affect the other.
+    With ``dry_run=True`` the payloads are built and reported but not sent.
+    """
+    run_dir = Path(run_dir)
+    meta_path = run_dir / "run.json"
+    if not meta_path.is_file():
+        raise FileNotFoundError(f"No run.json at {meta_path}")
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+
+    results: List[str] = []
+
+    slack_cfg = config.get("slack", {})
+    if slack_cfg.get("enabled"):
+        results.append(
+            _dispatch(
+                "slack",
+                _resolve_secret(slack_cfg, "webhook_url"),
+                build_slack_blocks(meta),
+                headers=None,
+                dry_run=dry_run,
+            )
+        )
+
+    n8n_cfg = config.get("n8n", {})
+    if n8n_cfg.get("enabled"):
+        headers = None
+        auth_header = n8n_cfg.get("auth_header")
+        if auth_header:
+            auth_value = _resolve_secret(n8n_cfg, "auth_value")
+            if auth_value:
+                headers = {auth_header: auth_value}
+        results.append(
+            _dispatch(
+                "n8n",
+                _resolve_secret(n8n_cfg, "webhook_url"),
+                build_n8n_payload(meta, _read_summary_text(run_dir, meta)),
+                headers=headers,
+                dry_run=dry_run,
+            )
+        )
+
+    if not results:
+        results.append("no targets enabled (see .studio/integrations.toml)")
+    return results
+
+
+def _dispatch(
+    name: str,
+    url: Optional[str],
+    payload: Dict,
+    *,
+    headers: Optional[Dict[str, str]],
+    dry_run: bool,
+) -> str:
+    if not url:
+        return f"{name}: skipped (no webhook URL configured)"
+    if dry_run:
+        return f"{name}: dry-run → {json.dumps(payload)}"
+    ok, detail = post_json(url, payload, headers=headers)
+    status = "ok" if ok else "FAILED"
+    return f"{name}: {status} ({detail})"

--- a/studio/run_phase.py
+++ b/studio/run_phase.py
@@ -70,6 +70,7 @@ from rerun import (
 from validators.code_validator import CodeValidator
 
 import clarity
+from integrations.slack_digest import load_integrations_config, notify_run
 
 try:
     import tomllib  # Python 3.11+
@@ -200,6 +201,7 @@ SUBCOMMANDS = {
     "init", "check-install", "update",
     "show-clarity", "set-clarity", "recompute-clarity",
     "record-metrics", "show-metrics", "offload", "setup",
+    "notify",
 }
 
 
@@ -1301,6 +1303,7 @@ def finalize_run(args: argparse.Namespace) -> None:
     write_json(meta_path, meta)
     rebuild_index()
     _append_run_log(meta)
+    _maybe_notify(run_dir)
 
     if metrics_entries:
         total_tokens = meta["metrics"]["total_tokens"]
@@ -1351,6 +1354,26 @@ def finalize_run(args: argparse.Namespace) -> None:
         print(f"   1. Review rejection reasons in contrarian files")
         print(f"   2. Prepare a rerun with revised approach")
         print(f"   3. Rerun will automatically inject failure context")
+
+
+def _maybe_notify(run_dir: Path) -> None:
+    """Auto-fire the run digest on finalize if a webhook target is enabled.
+
+    Default-disabled: no-op unless ``.studio/integrations.toml`` enables a
+    target. Soft-fail — any error is reported but never breaks finalize.
+    """
+    try:
+        config = load_integrations_config(get_artifact_root())
+    except Exception as exc:  # malformed config shouldn't break finalize
+        print(f"Notify skipped (config error): {exc}", file=sys.stderr)
+        return
+    if not any(config.get(t, {}).get("enabled") for t in ("slack", "n8n")):
+        return
+    try:
+        for line in notify_run(run_dir, config):
+            print(f"Notify: {line}")
+    except Exception as exc:
+        print(f"Notify failed: {exc}", file=sys.stderr)
 
 
 def rebuild_index() -> None:
@@ -1746,6 +1769,17 @@ def build_parser() -> argparse.ArgumentParser:
         "show-metrics", help="Display token usage summary for a run."
     )
     show_metrics_parser.add_argument("--run-dir", type=Path, required=True, help="Path to the run directory.")
+
+    # --- Outbound notification (Slack / n8n run digest) ---
+    notify_parser = subparsers.add_parser(
+        "notify", help="Post a run digest to configured Slack/n8n webhooks."
+    )
+    notify_parser.add_argument("--run-dir", type=Path, required=True, help="Path to the run directory.")
+    notify_parser.add_argument("--dry-run", action="store_true", help="Build and print payloads without posting.")
+    notify_parser.add_argument(
+        "--artifact-root", type=Path, default=None,
+        help="Override artifact root directory (where .studio/integrations.toml lives).",
+    )
 
     offload_parser = subparsers.add_parser(
         "offload", help="Analyze CLAUDE.md for offload opportunities."
@@ -2237,6 +2271,14 @@ def inject_context(args: argparse.Namespace) -> None:
         print(f"No prior context for {scope_name} {role} {stance} — starting fresh.", file=sys.stderr)
 
 
+def notify(args: argparse.Namespace) -> None:
+    """Post a run digest to configured Slack/n8n webhooks."""
+    root = Path(args.artifact_root).resolve() if args.artifact_root else get_artifact_root()
+    config = load_integrations_config(root)
+    for line in notify_run(args.run_dir, config, dry_run=args.dry_run):
+        print(line)
+
+
 def show_clarity(args: argparse.Namespace) -> None:
     """Display current project clarity scores."""
     root = Path(args.artifact_root).resolve() if args.artifact_root else get_artifact_root()
@@ -2488,6 +2530,8 @@ def main() -> None:
         record_metrics(args)
     elif args.command == "show-metrics":
         show_metrics(args)
+    elif args.command == "notify":
+        notify(args)
     elif args.command == "offload":
         do_offload(args)
     elif args.command == "setup":

--- a/studio/tests/test_slack_digest.py
+++ b/studio/tests/test_slack_digest.py
@@ -79,16 +79,22 @@ def test_load_config_invalid_toml_raises(tmp_path):
         sd.load_integrations_config(tmp_path)
 
 
-def test_resolve_secret_prefers_env(monkeypatch):
+def test_resolve_secret_reads_env(monkeypatch):
     monkeypatch.setenv("MY_HOOK", "https://hooks.slack.com/services/x")
-    cfg = {"webhook_url_env": "MY_HOOK", "webhook_url": "literal"}
+    cfg = {"webhook_url_env": "MY_HOOK"}
     assert sd._resolve_secret(cfg, "webhook_url").endswith("/x")
 
 
-def test_resolve_secret_falls_back_to_literal(monkeypatch):
+def test_resolve_secret_no_literal_fallback(monkeypatch):
+    # A literal URL in config must NOT be honored — secrets are env-only.
     monkeypatch.delenv("MY_HOOK", raising=False)
-    cfg = {"webhook_url_env": "MY_HOOK", "webhook_url": "literal-url"}
-    assert sd._resolve_secret(cfg, "webhook_url") == "literal-url"
+    cfg = {"webhook_url_env": "MY_HOOK", "webhook_url": "https://hooks.slack.com/services/leaked"}
+    assert sd._resolve_secret(cfg, "webhook_url") is None
+
+
+def test_resolve_secret_no_env_key(monkeypatch):
+    # Without the *_env indirection there is no secret to resolve.
+    assert sd._resolve_secret({"webhook_url": "literal"}, "webhook_url") is None
 
 
 # --------------------------------------------------------------------------- #
@@ -186,6 +192,7 @@ def test_notify_run_dry_run_does_not_post(run_dir, monkeypatch):
 def test_notify_run_posts_to_enabled_targets(run_dir, monkeypatch):
     monkeypatch.setenv("SLACK_HOOK", "http://slack")
     monkeypatch.setenv("N8N_HOOK", "http://n8n")
+    monkeypatch.setenv("N8N_KEY", "sekret")
     sent = []
 
     def capture(req, *a, **k):
@@ -199,7 +206,7 @@ def test_notify_run_posts_to_enabled_targets(run_dir, monkeypatch):
             "enabled": True,
             "webhook_url_env": "N8N_HOOK",
             "auth_header": "X-API-Key",
-            "auth_value": "sekret",
+            "auth_value_env": "N8N_KEY",
         },
     }
     results = sd.notify_run(run_dir, cfg)

--- a/studio/tests/test_slack_digest.py
+++ b/studio/tests/test_slack_digest.py
@@ -1,0 +1,218 @@
+"""Tests for the Slack/n8n run-digest integration."""
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+
+import pytest
+
+from integrations import slack_digest as sd
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def run_dir(tmp_path):
+    """A run directory with a finalized run.json and summary.md."""
+    d = tmp_path / "run_design_20260625_1430"
+    d.mkdir()
+    (d / "run.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run_design_20260625_1430",
+                "phase": "design",
+                "status": "COMPLETED",
+                "verdict": "APPROVED",
+                "iterations_run": 3,
+                "updated_iso": "2026-06-25T14:30:00+00:00",
+                "summary_path": "summary.md",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (d / "summary.md").write_text("# Summary\nViable cozy farming sim.", encoding="utf-8")
+    return d
+
+
+class _FakeResp:
+    """Minimal context-manager stand-in for urllib's response."""
+
+    def __init__(self, status, body=b"ok"):
+        self.status = status
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self):
+        return self._body
+
+
+# --------------------------------------------------------------------------- #
+# Config loading
+# --------------------------------------------------------------------------- #
+def test_load_config_absent_returns_empty(tmp_path):
+    assert sd.load_integrations_config(tmp_path) == {}
+
+
+def test_load_config_reads_toml(tmp_path):
+    studio = tmp_path / ".studio"
+    studio.mkdir()
+    (studio / "integrations.toml").write_text(
+        '[slack]\nenabled = true\nwebhook_url_env = "SLACK_WEBHOOK_URL"\n',
+        encoding="utf-8",
+    )
+    cfg = sd.load_integrations_config(tmp_path)
+    assert cfg["slack"]["enabled"] is True
+
+
+def test_load_config_invalid_toml_raises(tmp_path):
+    studio = tmp_path / ".studio"
+    studio.mkdir()
+    (studio / "integrations.toml").write_text("not = = valid", encoding="utf-8")
+    with pytest.raises(sd.IntegrationsConfigError):
+        sd.load_integrations_config(tmp_path)
+
+
+def test_resolve_secret_prefers_env(monkeypatch):
+    monkeypatch.setenv("MY_HOOK", "https://hooks.slack.com/services/x")
+    cfg = {"webhook_url_env": "MY_HOOK", "webhook_url": "literal"}
+    assert sd._resolve_secret(cfg, "webhook_url").endswith("/x")
+
+
+def test_resolve_secret_falls_back_to_literal(monkeypatch):
+    monkeypatch.delenv("MY_HOOK", raising=False)
+    cfg = {"webhook_url_env": "MY_HOOK", "webhook_url": "literal-url"}
+    assert sd._resolve_secret(cfg, "webhook_url") == "literal-url"
+
+
+# --------------------------------------------------------------------------- #
+# Payload builders
+# --------------------------------------------------------------------------- #
+def test_build_slack_blocks_shape():
+    meta = {"phase": "design", "run_id": "r1", "status": "COMPLETED", "verdict": "APPROVED"}
+    payload = sd.build_slack_blocks(meta)
+    assert payload["text"]  # required fallback present
+    types = [b["type"] for b in payload["blocks"]]
+    assert types == ["header", "section", "divider", "context"]
+    field_text = " ".join(f["text"] for f in payload["blocks"][1]["fields"])
+    assert "APPROVED" in field_text and "design" in field_text
+
+
+def test_build_n8n_payload_is_flat():
+    meta = {"phase": "tech", "run_id": "r2", "status": "COMPLETED", "verdict": "REJECTED"}
+    payload = sd.build_n8n_payload(meta, "x" * 5000)
+    assert payload["source"] == "TheGameStudio"
+    assert payload["event"] == "run.completed"
+    assert payload["verdict"] == "REJECTED"
+    assert len(payload["summary_text"]) <= sd._SUMMARY_MAX_CHARS
+
+
+# --------------------------------------------------------------------------- #
+# Transport (urllib mocked)
+# --------------------------------------------------------------------------- #
+def test_post_json_success(monkeypatch):
+    monkeypatch.setattr(sd.urllib.request, "urlopen", lambda *a, **k: _FakeResp(200, b"ok"))
+    ok, detail = sd.post_json("http://x", {"a": 1})
+    assert ok and "200" in detail
+
+
+def test_post_json_http_error_is_soft(monkeypatch):
+    def boom(*a, **k):
+        raise urllib.error.HTTPError("http://x", 400, "Bad", {}, io.BytesIO(b"invalid_payload"))
+
+    monkeypatch.setattr(sd.urllib.request, "urlopen", boom)
+    ok, detail = sd.post_json("http://x", {"a": 1})
+    assert ok is False and "400" in detail
+
+
+def test_post_json_timeout_is_soft(monkeypatch):
+    def boom(*a, **k):
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr(sd.urllib.request, "urlopen", boom)
+    ok, detail = sd.post_json("http://x", {"a": 1})
+    assert ok is False and "unreachable" in detail
+
+
+def test_post_json_retries_on_429(monkeypatch):
+    calls = {"n": 0}
+
+    def flaky(*a, **k):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise urllib.error.HTTPError(
+                "http://x", 429, "Too Many", {"Retry-After": "0"}, io.BytesIO(b"rate_limited")
+            )
+        return _FakeResp(200, b"ok")
+
+    monkeypatch.setattr(sd.urllib.request, "urlopen", flaky)
+    monkeypatch.setattr(sd.time, "sleep", lambda s: None)
+    ok, _ = sd.post_json("http://x", {"a": 1})
+    assert ok is True and calls["n"] == 2
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+def test_notify_run_no_targets(run_dir):
+    results = sd.notify_run(run_dir, {})
+    assert results == ["no targets enabled (see .studio/integrations.toml)"]
+
+
+def test_notify_run_missing_run_json(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        sd.notify_run(tmp_path, {"slack": {"enabled": True}})
+
+
+def test_notify_run_dry_run_does_not_post(run_dir, monkeypatch):
+    monkeypatch.setenv("HOOK", "http://slack")
+    called = {"posted": False}
+    monkeypatch.setattr(
+        sd.urllib.request, "urlopen",
+        lambda *a, **k: called.__setitem__("posted", True),
+    )
+    cfg = {"slack": {"enabled": True, "webhook_url_env": "HOOK"}}
+    results = sd.notify_run(run_dir, cfg, dry_run=True)
+    assert called["posted"] is False
+    assert any("dry-run" in r for r in results)
+
+
+def test_notify_run_posts_to_enabled_targets(run_dir, monkeypatch):
+    monkeypatch.setenv("SLACK_HOOK", "http://slack")
+    monkeypatch.setenv("N8N_HOOK", "http://n8n")
+    sent = []
+
+    def capture(req, *a, **k):
+        sent.append((req.full_url, dict(req.header_items()), req.data))
+        return _FakeResp(200, b"ok")
+
+    monkeypatch.setattr(sd.urllib.request, "urlopen", capture)
+    cfg = {
+        "slack": {"enabled": True, "webhook_url_env": "SLACK_HOOK"},
+        "n8n": {
+            "enabled": True,
+            "webhook_url_env": "N8N_HOOK",
+            "auth_header": "X-API-Key",
+            "auth_value": "sekret",
+        },
+    }
+    results = sd.notify_run(run_dir, cfg)
+    assert all("ok" in r for r in results)
+    urls = [u for u, _, _ in sent]
+    assert "http://slack" in urls and "http://n8n" in urls
+    # n8n auth header is forwarded (urllib title-cases header names)
+    n8n_headers = next(h for u, h, _ in sent if u == "http://n8n")
+    assert n8n_headers.get("X-api-key") == "sekret"
+
+
+def test_notify_run_skips_target_without_url(run_dir, monkeypatch):
+    monkeypatch.delenv("MISSING", raising=False)
+    cfg = {"slack": {"enabled": True, "webhook_url_env": "MISSING"}}
+    results = sd.notify_run(run_dir, cfg)
+    assert results == ["slack: skipped (no webhook URL configured)"]


### PR DESCRIPTION
## What

Adds the first **outbound integration** to Studio: a run-digest notifier that posts a finalized run's status / verdict / summary to a **Slack Incoming Webhook** (Block Kit) and/or an **n8n Webhook node** (flat JSON). Both targets are "HTTP POST a JSON body to a URL", so a single stdlib `urllib` transport serves both — only the payload schema and auth differ.

New module: `studio/integrations/slack_digest.py` (stdlib only, no new deps).

## How it fires

- **`notify` CLI subcommand** is the primary trigger:
  ```bash
  python studio/run_phase.py notify --run-dir <run_dir>            # post to enabled webhooks
  python studio/run_phase.py notify --run-dir <run_dir> --dry-run  # print payloads, no post
  ```
- **Auto-fire on finalize** is wired in the same change but **default-disabled** — a no-op unless `[slack].enabled`/`[n8n].enabled` is set. Soft-fail: a webhook error is logged but never breaks `finalize`.

## Config

`.studio/integrations.toml` (absent → off). Webhook URLs are secrets, resolved from **env vars** named in the config — never committed:

```toml
[slack]
enabled = true
webhook_url_env = "SLACK_WEBHOOK_URL"

[n8n]
enabled = false
webhook_url_env = "N8N_WEBHOOK_URL"
auth_header = "X-API-Key"          # optional (n8n Header Auth)
auth_value_env = "N8N_WEBHOOK_KEY"
```

## Payloads

- **Slack** — Block Kit: header + two-column field section (status/verdict/phase/run id) + context footer, with the required top-level `text` fallback.
- **n8n** — flat JSON addressable as `$json.body.<field>`: `source`, `event`, `phase`, `run_id`, `status`, `verdict`, `iterations_run`, `summary_path`, `summary_text`, `timestamp`.

## Tests

`studio/tests/test_slack_digest.py` — 16 tests with `urllib` mocked (no network): config load/validate, secret resolution, payload builders, success / HTTP error / timeout / 429-retry transport, and orchestration (no targets, missing run.json, dry-run, multi-target post with auth header, skip-without-url).

- **Full suite: 562 passed** (was 546 → +16, zero regressions).

## Docs

- `CLAUDE.md` — CLI command, architecture module entry, config-file entry
- `studio/docs/INTEGRATIONS.md` — setup / usage / security companion doc
- `studio/docs/tickets/TICKET-slack-n8n-digest.md` — the originating ticket + build order

🤖 Generated with [Claude Code](https://claude.com/claude-code)