### PR TITLE
docs: unstale after Slack/n8n integration + n8n activation ticket

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ All source lives under `studio/`. `run_phase.py` is the sole entrypoint using on
 
 ### Core modules (all in `studio/`)
 
-- **`run_phase.py`** — Primary entrypoint: `prepare`, `finalize`, `validate`, `cleanup`, decision, clarity, metrics, install, setup, and offload subcommands.
+- **`run_phase.py`** — Primary entrypoint: `prepare`, `finalize`, `validate`, `cleanup`, decision, clarity, metrics, install, setup, offload, and notify subcommands.
 - **`run_phase_roles.py`** — Role system: loads `studio.manifest.json`, resolves role packs, applies project-local overrides, builds per-role file naming (`advocate--<role>--NN.md`).
 - **`role_overrides.py`** — Project-local role customization: loads `.studio/roles/*.json` overlays, validates structure, shallow-merges with manifest roles.
 - **`persona_overrides.py`** — Project-local single-phase persona overrides: loads `.studio/personas.toml`, validates structure, per-phase shallow-merges over the shipped `PHASE_DETAILS` defaults (advocate/contrarian/notes/implementer/integrator).

--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ python studio/run_phase.py setup --target . --defaults
 # Offload analysis (analyze CLAUDE.md for offload opportunities)
 python studio/run_phase.py offload --target .
 python studio/run_phase.py offload --target . --apply
+
+# Outbound run digest (Slack / n8n webhooks — see studio/docs/INTEGRATIONS.md)
+python studio/run_phase.py notify --run-dir <run_dir>            # post digest to enabled webhooks
+python studio/run_phase.py notify --run-dir <run_dir> --dry-run  # print payloads without posting
 ```
 
 ---
@@ -297,7 +301,7 @@ Configure in `config/studio_settings.toml`. Use `--skip-cleanup` to bypass.
 
 ```
 studio/
-  run_phase.py              # CLI entrypoint: prepare, finalize, validate, cleanup, decision, clarity, metrics, install, setup, offload
+  run_phase.py              # CLI entrypoint: prepare, finalize, validate, cleanup, decision, clarity, metrics, install, setup, offload, notify
   run_phase_roles.py        # Role system: manifest, packs, dependencies, file naming
   role_overrides.py         # Project-local role customization (.studio/roles/*.json)
   persona_overrides.py      # Project-local phase persona overrides (.studio/personas.toml)
@@ -311,13 +315,14 @@ studio/
   cleanup.py                # TTL + budget-based artifact cleanup + loose file removal
   rerun.py                  # Rejection context injection for iterate-on-failure
   verdict.py                # APPROVED/REJECTED extraction
+  integrations/             # Outbound run-digest webhooks (slack_digest.py → Slack/n8n)
   validators/               # DocumentValidator + CodeValidator
   studio.manifest.json      # Role definitions (13 disciplines)
   role_packs/*.json          # Curated role sets (studio_core, etc.)
   config/scopes.toml         # Default scope configuration
   config/studio_settings.toml # Cleanup settings
   docs/                     # Guides, role prompts, architecture
-  tests/                    # 539 tests (pytest)
+  tests/                    # 563 tests (pytest)
 ```
 
 ---
@@ -328,7 +333,7 @@ studio/
 cd studio && python -m pytest tests/ -v
 ```
 
-539 tests covering: prepare/finalize lifecycle, role resolution with dependency injection, TTL/budget cleanup with boundary conditions, loose file cleanup, scope allocation, rerun detection, fresh-run/cross-phase context reset, verdict extraction, document validation, code validation, decision point parsing, clarity scoring, role overrides, phase persona overrides, cross-repo artifact routing, install/update workflows, CLAUDE.md principles injection, agent metrics tracking, CLAUDE.md offload analysis, unstale audit configuration, and setup wizard configuration.
+563 tests covering: prepare/finalize lifecycle, role resolution with dependency injection, TTL/budget cleanup with boundary conditions, loose file cleanup, scope allocation, rerun detection, fresh-run/cross-phase context reset, verdict extraction, document validation, code validation, decision point parsing, clarity scoring, role overrides, phase persona overrides, cross-repo artifact routing, install/update workflows, CLAUDE.md principles injection, agent metrics tracking, CLAUDE.md offload analysis, unstale audit configuration, setup wizard configuration, and Slack/n8n run-digest webhooks.
 
 Python 3.10+ required. stdlib only, plus `tomli` on Python 3.10 (see `pyproject.toml`).
 

--- a/studio/CHANGELOG.md
+++ b/studio/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to Studio will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Slack / n8n run-digest integration** — first `studio/integrations/` subpackage (`slack_digest.py`). Posts a finalized run's status/verdict/summary to a Slack Incoming Webhook (Block Kit) and/or an n8n Webhook node (flat JSON), stdlib `urllib` only. New `notify` CLI subcommand (`--run-dir`, `--dry-run`); auto-fires on `finalize` when a target is enabled (default-disabled, soft-fail). Config in `.studio/integrations.toml`; webhook URLs/auth resolved strictly from env vars named by `*_env` keys (no literal fallback — secrets never committed). Companion doc `studio/docs/INTEGRATIONS.md`.
+- **CI: Phase-1 PR triage gate** — `.github/workflows/pr-triage.yml` (No-Merge-Conflicts + triage checks).
 - **Contrarian editor mandate** (always on) — a shared `CONTRARIAN_MANDATE` (`scopes.py`) injected into every deliverable-producing contrarian prompt (single-phase, flat studio, and scoped studio). The contrarian now carries a bias toward removal/merge/simplification alongside flaw-hunting; the four `PHASE_DETAILS` contrarians are reframed as editors. Deliberately omitted in `--mode questions`, where the contrarian instead judges question *relevance* and must not drop genuinely-open questions.
 - **Open-Questions Pre-Flight** (Step 0) — every deliverable run now opens with a required questions pass that surfaces what is unsettled, pauses on P0 blockers, and records answers (raising the clarity score) before the iteration loop. Reuses the existing decision/clarity machinery — no new module. The Decision Point Protocol now states explicitly that every later pass must keep raising new questions.
 - Project-overridable single-phase personas via `.studio/personas.toml` (`persona_overrides.py`) — per-phase shallow-merge over the shipped `PHASE_DETAILS` defaults; setup wizard `persona_customization` step (`CURRENT_SETUP_VERSION` 2) with stack-sniffing suggestions.
 - Stack-agnostic `/unstale` — the command self-detects the stack (Rust/Unity/Node/Python/Go) from marker files, with an optional per-repo `.studio/unstale.toml` override (`[snapshot]` commands + `[audit]` globs). Setup wizard `unstale_config` step (`CURRENT_SETUP_VERSION` 3) with `suggest_unstale_from_stack` sniffing; shared `_toml_quote` helper.
-- 14 Python modules in `studio/` (added `persona_overrides.py`); 546 tests.
+- 14 top-level Python modules in `studio/` plus the new `integrations/` subpackage (`slack_digest.py`); 563 tests.
 
 ### Fixed
 - Stack-neutral phase personas — removed hardcoded "Three.js / WebGL" and "Steam hook" wording from `PHASE_DETAILS`.

--- a/studio/docs/API.md
+++ b/studio/docs/API.md
@@ -32,6 +32,7 @@ Supported commands:
 | `check-install` | Checks if installed Studio is up to date. |
 | `update` | Updates installed Studio from source. |
 | `setup` | Configure Studio for a project — role pack selection, role + phase-persona customization (`.studio/personas.toml`), unstale audit config (`.studio/unstale.toml`), scope tuning, cleanup settings. Supports `--status`, `--defaults`, `--answers`, `--role-pack`. |
+| `notify` | Posts a run digest to enabled Slack/n8n webhooks (config in `.studio/integrations.toml`). Auto-fires on `finalize` when a target is enabled (soft-fail). Supports `--run-dir`, `--dry-run`, `--artifact-root`. |
 
 ---
 

--- a/studio/docs/ARCHITECTURE.md
+++ b/studio/docs/ARCHITECTURE.md
@@ -28,7 +28,7 @@ All intelligence lives inside the assistant’s execution. Studio’s job is to 
 
 | Component | Purpose |
 | --- | --- |
-| `run_phase.py` | CLI entrypoint: `prepare`, `finalize`, `validate`, `cleanup`, clarity, install, decision, metrics, setup, and offload subcommands. |
+| `run_phase.py` | CLI entrypoint: `prepare`, `finalize`, `validate`, `cleanup`, clarity, install, decision, metrics, setup, offload, and `notify` subcommands. |
 | `run_phase_roles.py` | Loads `studio.manifest.json`, applies role packs with dependency injection, applies project-local overrides, and normalizes per-role filenames. |
 | `role_overrides.py` | Project-local role customization: loads `.studio/roles/*.json` overlays, validates structure, shallow-merges with manifest roles. |
 | `persona_overrides.py` | Project-local single-phase persona overrides: loads `.studio/personas.toml`, per-phase shallow-merges over the shipped `PHASE_DETAILS` defaults. |
@@ -43,12 +43,14 @@ All intelligence lives inside the assistant’s execution. Studio’s job is to 
 | `offload.py` | CLAUDE.md analyzer: classifies sections, detects embedded constraints, scores pointer strength, generates offload reports, manages canary tokens. |
 | `setup.py` | Setup wizard: project configuration after install. Tracks setup state in `.studio/SETUP.json`, generates role overrides, scopes, and cleanup config with incremental versioned steps. |
 | `validators/` | `DocumentValidator` and `CodeValidator` for post-run quality checks. |
+| `integrations/slack_digest.py` | Outbound run-digest notifier. Posts a finalized run's status/verdict/summary to a Slack Incoming Webhook (Block Kit) and/or an n8n Webhook node (flat JSON), stdlib `urllib` only. Config from `.studio/integrations.toml`; fires via the `notify` subcommand and auto-fires on `finalize` (soft-fail). |
 | `studio.manifest.json` | Declarative description of phase-level personas, Studio role definitions, and role dependencies. |
 | `role_packs/*.json` | Curated sets of Studio roles (e.g., `studio_core`). Operators pick a pack, then add/remove roles with CLI flags. |
 | `config/scopes.toml` | Default scope configuration for studio phase runs. |
 | `.studio/roles/*.json` | Project-local role overrides. Shallow-merge with manifest roles (override keys replace base, unspecified keys inherit). |
 | `.studio/personas.toml` | Project-local single-phase persona overrides. Per-phase shallow-merge over the shipped `PHASE_DETAILS` defaults (loaded by `persona_overrides.py`, authored by the setup wizard). |
 | `.studio/unstale.toml` | Optional per-repo override for the `/unstale` audit (`[snapshot]` commands + `[audit]` globs). Read by the `/unstale` command; absent it self-detects the stack. Authored by the setup wizard. |
+| `.studio/integrations.toml` | Optional outbound-webhook config for run digests. `[slack]` and `[n8n]` tables, each with `enabled` and `webhook_url_env` (env var holding the secret URL); `[n8n]` also takes optional `auth_header`/`auth_value_env` for Header Auth. Loaded by `integrations/slack_digest.py`. |
 | `docs/role_prompts/*.md` | Long-form prompts for each role. Instructions link to these files rather than inlining pages of text. |
 | Active output root (`output/` or `.studio/output/`) | Run folders containing instructions, advocate/contrarian artifacts, integrator plans, summaries, and metadata. |
 | Active knowledge log (`knowledge/run_log.md` or `.studio/knowledge/run_log.md`) | Append-only log of finalized runs for easy reference across repos. |

--- a/studio/docs/INDEX.md
+++ b/studio/docs/INDEX.md
@@ -18,6 +18,7 @@
 - **[STORAGE_MANAGEMENT.md](./STORAGE_MANAGEMENT.md)** - Cleanup, TTL, and storage budgets
 
 ## Integration
+- **[INTEGRATIONS.md](./INTEGRATIONS.md)** - Slack / n8n run-digest webhooks (config, payloads, security)
 - **[INTEGRATION_GUIDE.md](./INTEGRATION_GUIDE.md)** - Using Studio from other repos
 - **[STUDIO_BRIDGE_TEMPLATE.md](./STUDIO_BRIDGE_TEMPLATE.md)** - Bridge doc template for downstream repos
 - **[BRIDGE_COMMANDS_TEMPLATE.md](./BRIDGE_COMMANDS_TEMPLATE.md)** - Slash command files to copy into a downstream repo's `.claude/commands/`

--- a/studio/docs/tickets/TICKET-n8n-activation.md
+++ b/studio/docs/tickets/TICKET-n8n-activation.md
@@ -1,0 +1,72 @@
+# TICKET: Activate the n8n run-digest target
+
+**Type:** Task (ops + verification) · **Component:** `studio/integrations/slack_digest.py` (n8n path) · **Priority:** P3
+**Status:** Open · **Author:** Adriano Valle · **Date:** 2026-06-25
+**Follows:** `TICKET-slack-n8n-digest.md` (code shipped, PR #21)
+
+> **Decisions (locked):** n8n Webhook node uses **Header Auth** (`X-API-Key`), no instance
+> stood up yet. Local config pre-wired in `studio/.studio/integrations.toml` `[n8n]` block,
+> currently `enabled = false`.
+
+## Summary
+
+The n8n code path already shipped with PR #21 — `build_n8n_payload()`, the optional auth
+header, and `notify_run()` all support n8n, and the `[n8n]` config block is wired (disabled).
+What remains is **operational**: stand up an n8n instance, build the receiving workflow,
+supply the secrets, flip the target on, and verify a live POST end to end. No application
+code is required for basic activation; the follow-ups below are optional polish.
+
+## Already done (PR #21)
+
+- `studio/integrations/slack_digest.py` — `build_n8n_payload()` (flat JSON), optional
+  `auth_header`/`auth_value_env` Header Auth, `notify_run()` posts to n8n when `[n8n].enabled`.
+- `studio/.studio/integrations.toml` — `[n8n]` block present, `enabled = false`,
+  `webhook_url_env = "N8N_WEBHOOK_URL"`, `auth_header = "X-API-Key"`,
+  `auth_value_env = "N8N_WEBHOOK_KEY"`.
+- Tests: `test_notify_run_posts_to_enabled_targets` asserts the n8n payload + `X-API-Key`
+  header are sent. Dry-run preview confirmed the payload shape.
+
+## Remaining work
+
+### A. Stand up n8n + receiving workflow (n8n side)
+1. Provision an n8n instance (cloud or self-hosted behind HTTPS).
+2. New workflow → **Webhook** trigger node: HTTP method **POST**; note the **Production URL**
+   (`https://<host>/webhook/<path>`).
+3. Set node **Authentication = Header Auth**; create a Header Auth credential named
+   **`X-API-Key`** with a secret value (this becomes `N8N_WEBHOOK_KEY`).
+4. Add downstream fan-out nodes consuming `$json.body.*`
+   (`verdict`, `phase`, `run_id`, `status`, `summary_text`, `timestamp`) — e.g. a Slack node,
+   Gmail, or a DB insert.
+5. **Activate** the workflow (production URL 404s while inactive).
+
+### B. Activate locally (Studio side)
+6. Export both secrets and persist in `~/.zshrc` (as done for Slack):
+   `N8N_WEBHOOK_URL`, `N8N_WEBHOOK_KEY`.
+7. Flip `[n8n].enabled` → `true` in `studio/.studio/integrations.toml`.
+
+### C. Verify end to end
+8. `python studio/run_phase.py notify --run-dir <run> --artifact-root studio`
+   → expect `n8n: ok (HTTP 200 ...)` and the workflow firing in n8n.
+9. Confirm a real `finalize` auto-posts to both Slack and n8n.
+
+### D. Optional follow-ups (only if needed)
+- Add a "receiving workflow" example (node layout + sample `$json.body` mapping) to
+  `studio/docs/INTEGRATIONS.md`.
+- Consider stricter n8n success detection (currently any 2xx is success; n8n's default
+  "Immediately" response returns `200 {"message":"Workflow got started"}`). Only worth it if
+  a "Respond to Webhook" node returns a meaningful status to act on.
+
+## Acceptance criteria
+
+- [ ] n8n workflow active, Webhook node on Header Auth (`X-API-Key`).
+- [ ] `N8N_WEBHOOK_URL` + `N8N_WEBHOOK_KEY` exported and persisted; `[n8n].enabled = true`.
+- [ ] `notify` against a real run returns `n8n: ok` and the workflow runs in n8n.
+- [ ] `finalize` auto-posts to both targets.
+- [ ] (If touched) `INTEGRATIONS.md` updated; all tests still pass.
+
+## References
+
+- Local config: `studio/.studio/integrations.toml` (gitignored) — `[n8n]` block.
+- Setup steps: `studio/docs/INTEGRATIONS.md`.
+- n8n Webhook node: https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.webhook/
+- n8n Webhook credentials (Header Auth): https://docs.n8n.io/integrations/builtin/credentials/webhook/

--- a/studio/docs/tickets/TICKET-slack-n8n-digest.md
+++ b/studio/docs/tickets/TICKET-slack-n8n-digest.md
@@ -1,7 +1,9 @@
 # TICKET: Slack / n8n webhook digest for completed runs
 
 **Type:** Feature · **Component:** `studio/integrations/` (new) · **Priority:** P2
-**Status:** Proposed · **Author:** Adriano Valle · **Date:** 2026-06-25
+**Status:** ✅ Shipped — PR #21 (merged 2026-06-25). Slack target verified live (HTTP 200).
+n8n target: code shipped; activation tracked in `TICKET-n8n-activation.md`.
+**Author:** Adriano Valle · **Date:** 2026-06-25
 
 > **Decisions (locked):** `notify` CLI is the primary trigger; auto-fire-on-finalize
 > ships in the same PR but **default-disabled**. Both **Slack + n8n** targets in v1.


### PR DESCRIPTION
## What

Documentation staleness pass (`/unstale`) after the Slack/n8n run-digest integration (#21), plus a ticket scoping the remaining n8n work. **Docs only — no code changes; 563 tests still pass.**

## Staleness fixes
- **Test counts:** `539`/`546` → **563** (README ×2, CHANGELOG).
- **`notify` command** added to every CLI reference that listed the others: README CLI Reference, `CLAUDE.md`, `studio/docs/API.md`, `studio/docs/ARCHITECTURE.md`.
- **`integrations/` subpackage** documented: `integrations/slack_digest.py` + `.studio/integrations.toml` rows in `ARCHITECTURE.md`; `integrations/` line in the README project structure.
- **`INTEGRATIONS.md`** linked from `studio/docs/INDEX.md`.
- **CHANGELOG:** recorded the Slack/n8n integration and the CI PR-triage gate (#22) under `[Unreleased]`.

## n8n ticket
- New **`TICKET-n8n-activation.md`** — the n8n code shipped in #21; what remains is operational (stand up n8n, build the Header-Auth Webhook workflow, export secrets, flip `[n8n].enabled = true`, live-verify). Includes acceptance criteria.
- **`TICKET-slack-n8n-digest.md`** marked ✅ Shipped, pointing to the activation ticket.

## Audit notes
- 5-agent parallel audit (docs / code comments / memory / cross-ref / GitHub issues).
- Code comments & docstrings: clean.
- Left intentionally: `project_contrarian_editor_preflight.md` "544 tests" is a point-in-time historical record, not a current-status claim.
- GitHub issue #20 is a valid live bug — left open, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)