### PR TITLE
Fix installer omitting integrations/ package (breaks every command in installed projects)

### DIFF
--- a/studio/install.py
+++ b/studio/install.py
@@ -44,6 +44,8 @@ SOURCE_FILES = [
     "validators/__init__.py",
     "validators/document_validator.py",
     "validators/code_validator.py",
+    "integrations/__init__.py",
+    "integrations/slack_digest.py",
     "config/scopes.toml",
     "config/studio_settings.toml",
     "docs/STUDIO_BRIDGE_TEMPLATE.md",


### PR DESCRIPTION
## Problem

`studio/run_phase.py` imports `integrations.slack_digest` at module top level:

```python
from integrations.slack_digest import load_integrations_config, notify_run
```

…but `install.py`'s `SOURCE_FILES` never listed the `integrations/` package. So a cross-repo install (`init`/`update`) copies `run_phase.py` without its dependency, and the installed `.studio/source/run_phase.py` crashes on import with:

```
ModuleNotFoundError: No module named 'integrations'
```

Because the import is at the top level, this breaks **every** subcommand in an installed project (not just `notify`) — so all `/run-phase` and `/run-studio-phase` slash commands are unusable after `init`.

## Fix

Add the two `integrations/` files to `SOURCE_FILES`:

```
integrations/__init__.py
integrations/slack_digest.py
```

## Verification

- Reproduced: a fresh `init --target <dir>` produced a `.studio/source/` with no `integrations/`, and `python .studio/source/run_phase.py show-clarity` crashed on import.
- After the fix, a throwaway `init --target` copies `integrations/` and `show-clarity` (and `notify --help`) run cleanly with no import error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)