### PR TITLE
Slack digest: include run summary body + final-doc pointer

### DIFF
--- a/studio/docs/INTEGRATIONS.md
+++ b/studio/docs/INTEGRATIONS.md
@@ -50,8 +50,12 @@ printed but never breaks finalize. With no target enabled, finalize is unchanged
 ## Payloads
 
 - **Slack** — Block Kit message: a header, a two-column field section
-  (status / verdict / phase / run id), a divider, and a context footer. A
-  top-level `text` fallback is always included (required by Slack).
+  (status / verdict / phase / run id), the run summary body (markdown converted
+  to Slack `mrkdwn` and truncated to ~2700 chars), a pointer to the full final
+  doc, and a context footer. A top-level `text` fallback is always included
+  (required by Slack). The body prefers a short plain-language `digest.md` (or
+  `summary_human.md`) when the run authored one, falling back to `summary.md`;
+  the "Final doc" pointer always targets the full `summary.md`.
 - **n8n** — flat JSON addressable downstream as `$json.body.<field>`:
   `source`, `event` (`"run.completed"`), `phase`, `run_id`, `status`,
   `verdict`, `iterations_run`, `summary_path`, `summary_text` (truncated),

--- a/studio/integrations/slack_digest.py
+++ b/studio/integrations/slack_digest.py
@@ -284,6 +284,23 @@ def _read_summary_text(run_dir: Path, meta: Dict) -> str:
     return ""
 
 
+# The Slack body prefers a short, plain-language digest when the run authored
+# one — the full summary.md is often dense/technical and gets truncated. The
+# "Final doc" pointer always targets the full summary regardless.
+_DIGEST_CANDIDATES = ("digest.md", "summary_human.md")
+
+
+def _read_digest_text(run_dir: Path, meta: Dict) -> str:
+    """Prefer a plain-language ``digest.md`` for the Slack body; else the summary."""
+    for name in _DIGEST_CANDIDATES:
+        candidate = run_dir / name
+        if candidate.is_file():
+            text = candidate.read_text(encoding="utf-8").strip()
+            if text:
+                return text
+    return _read_summary_text(run_dir, meta)
+
+
 def notify_run(
     run_dir: Path,
     config: Dict,
@@ -306,13 +323,13 @@ def notify_run(
 
     slack_cfg = config.get("slack", {})
     if slack_cfg.get("enabled"):
-        summary_text = _read_summary_text(run_dir, meta)
+        body_text = _read_digest_text(run_dir, meta)
         results.append(
             _dispatch(
                 "slack",
                 _resolve_secret(slack_cfg, "webhook_url"),
                 build_slack_blocks(
-                    meta, summary_text, _summary_doc_path(run_dir, meta)
+                    meta, body_text, _summary_doc_path(run_dir, meta)
                 ),
                 headers=None,
                 dry_run=dry_run,

--- a/studio/tests/test_slack_digest.py
+++ b/studio/tests/test_slack_digest.py
@@ -110,6 +110,40 @@ def test_build_slack_blocks_shape():
     assert "APPROVED" in field_text and "design" in field_text
 
 
+def test_build_slack_blocks_includes_body_and_doc():
+    meta = {"phase": "design", "run_id": "r1", "status": "COMPLETED", "verdict": "APPROVED"}
+    payload = sd.build_slack_blocks(meta, "# Heading\n- a bullet", "/runs/r1/summary.md")
+    types = [b["type"] for b in payload["blocks"]]
+    # header, fields, divider, body, doc pointer, divider, context
+    assert types == ["header", "section", "divider", "section", "section", "divider", "context"]
+    body = payload["blocks"][3]["text"]["text"]
+    assert "*Heading*" in body and "• a bullet" in body
+    assert "/runs/r1/summary.md" in payload["blocks"][4]["text"]["text"]
+
+
+def test_md_to_slack_conversions():
+    out = sd._md_to_slack("## Title\n* item\n- item2\nsome **bold** text")
+    assert "*Title*" in out
+    assert "• item" in out and "• item2" in out
+    assert "*bold*" in out and "**bold**" not in out
+
+
+def test_md_to_slack_truncates():
+    out = sd._md_to_slack("x" * 5000, max_chars=100)
+    assert len(out) <= 100 + len("\n\n_… truncated — see the full doc below._")
+    assert "truncated" in out
+
+
+def test_read_digest_prefers_digest_md(run_dir):
+    (run_dir / "digest.md").write_text("plain language digest", encoding="utf-8")
+    assert sd._read_digest_text(run_dir, {"summary_path": "summary.md"}) == "plain language digest"
+
+
+def test_read_digest_falls_back_to_summary(run_dir):
+    text = sd._read_digest_text(run_dir, {"summary_path": "summary.md"})
+    assert "cozy farming sim" in text
+
+
 def test_build_n8n_payload_is_flat():
     meta = {"phase": "tech", "run_id": "r2", "status": "COMPLETED", "verdict": "REJECTED"}
     payload = sd.build_n8n_payload(meta, "x" * 5000)


### PR DESCRIPTION
## Summary
Enriches the Slack run digest beyond the bare status/verdict fields:
- Adds the run **summary body**, converting markdown → Slack `mrkdwn` (headings → bold, `-`/`*` bullets → `•`, `**x**` → `*x*`) and truncating to ~2700 chars (Slack's 3000-char section cap with headroom).
- Adds a **"Final doc" pointer** to the full `summary.md`.
- Body prefers a short plain-language `digest.md` / `summary_human.md` when the run authored one, falling back to `summary.md`; the pointer always targets the full summary.

## Tests
- 5 new tests covering `_md_to_slack` conversion + truncation, the body/doc blocks, and `digest.md` preference vs summary fallback.
- Full suite: **582 passed**.

## Docs
- INTEGRATIONS.md updated per the documentation contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)