### PR TITLE
Fix check-install/update false 'up to date' via stale snapshot (#20)

### DIFF
--- a/studio/install.py
+++ b/studio/install.py
@@ -22,7 +22,7 @@ import shutil
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 # Files to copy from studio/ into .studio/source/
 SOURCE_FILES = [
@@ -102,6 +102,66 @@ def _git_info(studio_root: Path) -> dict:
     except (subprocess.TimeoutExpired, FileNotFoundError):
         pass
     return info
+
+
+def _resolve_source_dir(
+    target: Path, studio_dir: Optional[Path]
+) -> Tuple[Path, Optional[str]]:
+    """Resolve the live Studio source directory to compare/copy from.
+
+    When ``check``/``update`` is invoked through the *installed snapshot*
+    (``<target>/.studio/source/run_phase.py``), the default source root IS that
+    snapshot — so comparing it against the installed ``MANIFEST.json`` compares
+    the snapshot against itself and always reports "up to date", silently
+    masking real upstream changes (see issue #20).
+
+    To fix this, when the detected source root is the snapshot, fall back to the
+    upstream ``source_path`` recorded in ``VERSION`` so we compare against the
+    live source instead.
+
+    Returns ``(source_dir, warning)``. ``warning`` is non-None when the live
+    source could not be resolved, so the caller can surface it loudly instead of
+    silently trusting the (possibly stale) snapshot.
+    """
+    if studio_dir is not None:
+        # Explicit source (tests, or an upstream invocation that already knows
+        # where the live source is) — trust it.
+        return studio_dir, None
+
+    root = _get_studio_root()
+    snapshot = (target / ".studio" / "source").resolve()
+    if root.resolve() != snapshot:
+        # Running from a real upstream working copy, not the snapshot.
+        return root, None
+
+    upstream = (
+        "Re-run from the upstream repo instead: "
+        f"python studio/run_phase.py check-install --target {target}"
+    )
+    version_path = target / ".studio" / "VERSION"
+    try:
+        version = json.loads(version_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return root, (
+            "running from the installed snapshot and VERSION is unreadable; "
+            f"cannot compare against live source. {upstream}"
+        )
+
+    source_path = version.get("source_path")
+    if not source_path:
+        return root, (
+            "running from the installed snapshot and VERSION has no "
+            f"source_path; cannot compare against live source. {upstream}"
+        )
+
+    live = Path(source_path)
+    if live.resolve() == snapshot or not (live / "run_phase.py").is_file():
+        return root, (
+            "running from the installed snapshot and the recorded source_path "
+            f"({source_path}) is missing, moved, or points back to the "
+            f"snapshot; cannot compare against live source. {upstream}"
+        )
+    return live, None
 
 
 def _collect_source_files(studio_dir: Path) -> List[Path]:
@@ -280,17 +340,18 @@ def check_studio(target: Path, studio_dir: Optional[Path] = None) -> dict:
         changed: list[str] — files that differ
         missing: list[str] — files in source but not installed
         extra: list[str] — files installed but not in source
+        warning: str | None — set when the live source could not be resolved
+            (e.g. run from a stale snapshot), so the result may be unreliable
     """
-    if studio_dir is None:
-        studio_dir = _get_studio_root()
-
     target = Path(target).resolve()
     dot_studio = target / ".studio"
     version_path = dot_studio / "VERSION"
     manifest_path = dot_studio / "MANIFEST.json"
 
     if not version_path.exists():
-        return {"installed": False, "up_to_date": False, "changed": [], "missing": [], "extra": []}
+        return {"installed": False, "up_to_date": False, "changed": [], "missing": [], "extra": [], "warning": None}
+
+    studio_dir, warning = _resolve_source_dir(target, studio_dir)
 
     # Load installed manifest
     installed_manifest: Dict[str, str] = {}
@@ -328,6 +389,7 @@ def check_studio(target: Path, studio_dir: Optional[Path] = None) -> dict:
         "changed": changed,
         "missing": missing,
         "extra": extra,
+        "warning": warning,
     }
 
 
@@ -339,9 +401,6 @@ def update_studio(target: Path, studio_dir: Optional[Path] = None) -> dict:
 
     Returns dict with counts of updated/added/removed files.
     """
-    if studio_dir is None:
-        studio_dir = _get_studio_root()
-
     target = Path(target).resolve()
     dot_studio = target / ".studio"
 
@@ -350,17 +409,22 @@ def update_studio(target: Path, studio_dir: Optional[Path] = None) -> dict:
             f"Studio not installed at {target}. Run 'init' first."
         )
 
+    # Resolve the live source up front so both the check and the re-install copy
+    # from upstream — not from the (possibly stale) installed snapshot (#20).
+    source_dir, warning = _resolve_source_dir(target, studio_dir)
+
     # Check what needs updating
-    status = check_studio(target, studio_dir)
+    status = check_studio(target, source_dir)
 
     if status["up_to_date"]:
-        return {"updated": 0, "added": 0, "removed": 0}
+        return {"updated": 0, "added": 0, "removed": 0, "warning": warning}
 
     # Re-install (install_studio is idempotent and preserves user dirs)
-    install_studio(target, studio_dir)
+    install_studio(target, source_dir)
 
     return {
         "updated": len(status["changed"]),
         "added": len(status["missing"]),
         "removed": 0,  # We don't remove extra files
+        "warning": warning,
     }

--- a/studio/run_phase.py
+++ b/studio/run_phase.py
@@ -2715,6 +2715,8 @@ def _do_check_install(args: argparse.Namespace) -> None:
         print(f"Studio is NOT installed at {target}")
         print("Run: python run_phase.py init --target " + str(target))
         return
+    if status.get("warning"):
+        print(f"WARNING: {status['warning']}\n")
     if status["up_to_date"]:
         print(f"Studio at {target} is up to date.")
     else:
@@ -2731,6 +2733,8 @@ def _do_update(args: argparse.Namespace) -> None:
     from install import update_studio
     target = Path(args.target).resolve()
     result = update_studio(target)
+    if result.get("warning"):
+        print(f"WARNING: {result['warning']}\n")
     if result["updated"] == 0 and result["added"] == 0:
         print(f"Studio at {target} is already up to date.")
     else:

--- a/studio/tests/test_install.py
+++ b/studio/tests/test_install.py
@@ -207,6 +207,78 @@ class TestUpdateStudio:
         assert result["added"] == 0
 
 
+class TestSnapshotStaleDetection:
+    """Regression tests for #20: check/update run via the installed snapshot
+    must compare against live upstream source, not the snapshot itself."""
+
+    def _stale_install(self, target_dir, studio_dir):
+        """Install, then make the snapshot+manifest agree on a value that
+        DIFFERS from live source — i.e. a stale install that snapshot-vs-self
+        would wrongly call up to date."""
+        import hashlib
+
+        install_studio(target_dir, studio_dir)
+        snap_file = target_dir / ".studio" / "source" / "verdict.py"
+        snap_file.write_text("# stale snapshot", encoding="utf-8")
+        manifest_path = target_dir / ".studio" / "MANIFEST.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["verdict.py"] = hashlib.sha256(b"# stale snapshot").hexdigest()
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    def test_check_detects_stale_via_version_source_path(
+        self, target_dir, studio_dir, monkeypatch
+    ):
+        """check_studio (studio_dir=None) run from the snapshot resolves live
+        source from VERSION and detects the drift instead of trusting itself."""
+        import install
+
+        self._stale_install(target_dir, studio_dir)
+        snapshot = target_dir / ".studio" / "source"
+        # Simulate invocation through the installed snapshot.
+        monkeypatch.setattr(install, "_get_studio_root", lambda: snapshot)
+
+        status = check_studio(target_dir)  # default source resolution
+        assert status["up_to_date"] is False
+        assert "verdict.py" in status["changed"]
+        assert status["warning"] is None  # live source resolved cleanly
+
+    def test_update_refreshes_via_resolved_live_source(
+        self, target_dir, studio_dir, monkeypatch
+    ):
+        """update_studio run from the snapshot copies from live source and
+        restores the stale file."""
+        import install
+
+        self._stale_install(target_dir, studio_dir)
+        snapshot = target_dir / ".studio" / "source"
+        monkeypatch.setattr(install, "_get_studio_root", lambda: snapshot)
+
+        result = update_studio(target_dir)
+        assert result["updated"] >= 1
+        restored = (snapshot / "verdict.py").read_text()
+        assert restored != "# stale snapshot"
+
+    def test_warns_when_source_path_unresolvable(
+        self, target_dir, studio_dir, monkeypatch
+    ):
+        """If VERSION.source_path is gone, surface a warning rather than a
+        silent (and unreliable) 'up to date'."""
+        import install
+
+        install_studio(target_dir, studio_dir)
+        version_path = target_dir / ".studio" / "VERSION"
+        version = json.loads(version_path.read_text())
+        version["source_path"] = str(target_dir / "does_not_exist")
+        version_path.write_text(json.dumps(version), encoding="utf-8")
+
+        snapshot = target_dir / ".studio" / "source"
+        monkeypatch.setattr(install, "_get_studio_root", lambda: snapshot)
+
+        status = check_studio(target_dir)
+        assert status["warning"] is not None
+        assert "snapshot" in status["warning"]
+
+
 class TestSlashCommandsUseDirectPaths:
     """Verify slash commands use .studio/source/ paths directly (no rewriting needed)."""
 


### PR DESCRIPTION
Fixes #20.

## Problem
`/studio-update` invokes `check-install` through the **installed snapshot** at `<project>/.studio/source/run_phase.py`. The default source root resolved to that snapshot, so `check_studio` compared the snapshot against its own `MANIFEST.json` — always reporting **"up to date"**, silently blocking updates. `update_studio` shared the flaw: it re-installed from the snapshot onto itself, so it could never actually pull upstream changes.

Real-world: an install at commit `8ce5584` reported up-to-date against upstream `5c24c36` (6 changed, 2 missing files).

## Fix
New `_resolve_source_dir(target, studio_dir)`:
- Explicit `studio_dir` (tests / upstream invocation) → used as-is, unchanged.
- Default root that **is** the installed snapshot → resolve the live upstream from `VERSION.source_path` and compare/copy against that.
- Live source unresolvable (source_path missing, moved, or self-referential) → return a loud **WARNING** instead of a silent, unreliable "up to date".

Warning is threaded through `check_studio`/`update_studio` result dicts and printed by the `check-install`/`update` CLI handlers.

## Verification
- 3 regression tests (stale-snapshot detection, update-refreshes-from-live, warning-on-unresolvable). Full suite: **580 passed**.
- End-to-end via the snapshot CLI path: stale install now reports `Changed: docs/CODING_PRINCIPLES.md`, `update` restores it, and a broken `source_path` prints the WARNING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)