### PR TITLE
feat: implementation writer/editor loop (spec + workflow + /studio-implement)

### DIFF
--- a/.claude/commands/studio-implement.md
+++ b/.claude/commands/studio-implement.md
@@ -1,0 +1,102 @@
+# Studio Implement (Writer/Editor Loop)
+
+Build one MVI unit through the implementation writer/editor loop: a writer agent builds a
+complete, usable unit and commits its passing state; a fresh editor agent (carrying the
+`CONTRARIAN_MANDATE`) cuts/refines it, reverting if an edit breaks green; then it's delivered.
+See `studio/docs/IMPLEMENTATION_LOOP_SPEC.md` for the full design.
+
+This command is the **authorized, unequivocal trigger** for the loop. Invoking it is explicit
+opt-in to run the `implementation-loop` workflow (which spawns multiple agents). When the user
+asks in natural language to "implement X with the loop" / "run the writer-editor loop on X",
+treat that as an invocation of this command.
+
+## Arguments
+
+- `$ARGUMENTS` — Required. Free-text description of the ONE unit to build. Should describe a
+  complete, usable interaction (MVI), not a partial component.
+- Optional `--branch <name>` — branch to run on (default: derive `impl/<unit_id>`).
+- Optional `--test "<cmd>"` — override the inferred test command.
+- Optional `--plan` — echo the parsed plan and STOP (dry run); do not run the loop.
+
+## Instructions
+
+Run behavior is **echo-plan-then-run**: print the plan, then immediately run the loop (no
+separate confirmation step — the slash invocation is the authorization). `--plan` is the only
+thing that stops before running.
+
+### Step 1 — Parse the request into a unit object
+
+From `$ARGUMENTS`, construct the workflow `args`:
+
+- `unit_id` — a short snake_case slug derived from the request (e.g. `profile_create_view`).
+- `title` — a one-line MVI-framed statement of the usable outcome ("X can do Y …"). If the
+  request describes a partial component ("add a data model", "define the schema"), reframe it as
+  the smallest usable interaction, or stop and say it isn't an MVI unit.
+- `instructions` — concrete build steps: what files to create/modify, what tests to write. Keep
+  it to this one unit; no speculative scope.
+- `test_command` — infer from the repo's stack unless `--test` is given. Detect from marker files:
+  - Python (`pyproject.toml`/`pytest`): `python -m pytest <path> -q` (in this repo: `cd studio && python -m pytest tests/<file> -q`).
+  - Node (`package.json`): `npm test` or the project's test script.
+  - Rust (`Cargo.toml`): `cargo test`.
+  - Unity / other: ask if you cannot infer a runnable command.
+- `static_check` — `ruff check <path>` for Python; the project linter otherwise; omit if none.
+
+### Step 2 — Pick the target branch (safety)
+
+The loop edits files in place and makes a real `git commit`, and the writer + editor stages must
+share one working tree. So:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+- If `--branch` was given, check it out (create if missing).
+- Else if on `main`/`master`, create and switch to `impl/<unit_id>`.
+- Else use the current branch (it's already a feature branch).
+
+If the working tree is dirty, stop and tell the user to commit/stash first — the loop's revert
+relies on a clean base.
+
+### Step 3 — Echo the plan
+
+Print a short block, then proceed (unless `--plan`):
+
+```
+/studio-implement
+  unit_id:  <slug>
+  title:    <MVI outcome>
+  branch:   <branch>
+  tests:    <test_command>
+  builds:   <1-line of what files/behavior>
+```
+
+If `--plan`, stop here.
+
+### Step 4 — Run the loop
+
+Call the **Workflow** tool with the `implementation-loop` workflow, passing the parsed unit as
+`args`:
+
+```
+Workflow({ name: "implementation-loop", args: {
+  unit_id, title, instructions, test_command, static_check
+}})
+```
+
+The workflow runs in the background and notifies on completion. Do not re-run it or poll;
+wait for the completion notification.
+
+### Step 5 — Report the result
+
+The workflow returns `{ delivered, flagged, editorRan, finalVersion, writer, editor }`. Summarize
+for the user:
+
+- **What was built** + final test status (`editor.tests` / `writer.tests`).
+- **What the editor changed** (`editor.edits`) — the cuts/merges/restructures, or "nothing to cut".
+- **MVI verdict** (`editor.mvi_verdict`) — and call out explicitly if the editor *overturned* the
+  writer's `mvi_claimed` (unit not actually usable → it's flagged, not silently shipped).
+- **Reverted?** (`editor.reverted`) — if an edit broke green and was rolled back to `writer_sha`.
+- Point to the handoff records under `.studio/output/impl_loop/<unit_id>/`.
+
+If `flagged` is true, make clear the unit did NOT pass the full gate (delivered for inspection,
+not as a clean green/usable unit).

--- a/.claude/workflows/implementation-loop.js
+++ b/.claude/workflows/implementation-loop.js
@@ -1,0 +1,194 @@
+export const meta = {
+  name: 'implementation-loop',
+  description: 'Writer/editor implementation loop — one agent builds an MVI unit, a fresh editor cuts/refines it, gated on tests-green. See studio/docs/IMPLEMENTATION_LOOP_SPEC.md',
+  whenToUse: 'Build a single MVI unit with a structurally-guaranteed contrarian-editor pass. Pass the unit via args; defaults to building studio/impl_loop.py (the spec\'s own Phase 2).',
+  phases: [
+    { title: 'Writer', detail: 'build one complete MVI unit; commit passing state; declare done' },
+    { title: 'Edit', detail: 'fresh editor cuts/refines against writer_sha; revert if it breaks green' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Default target unit = Phase 2 of the spec: the config loader, dogfooded.
+// Override by passing `args` (same shape) to the Workflow tool.
+// ---------------------------------------------------------------------------
+const DEFAULT_UNIT = {
+  unit_id: 'unit_impl_loop_config',
+  title: 'Studio can load implementation_loop.toml into a LoopConfig (with project-local override)',
+  // Run from repo root; tests live under studio/.
+  test_command: 'cd studio && python -m pytest tests/test_impl_loop.py -q',
+  static_check: 'cd studio && ruff check impl_loop.py',
+  instructions: [
+    'Build studio/impl_loop.py mirroring the ScopeConfig / load_scopes_config() pattern in studio/scopes.py:',
+    '  - a `LoopConfig` dataclass for the [loop]/[gate]/[editor] tables documented in',
+    '    studio/docs/IMPLEMENTATION_LOOP_SPEC.md §4 (deliver_on_gate_fail, test_command, static_checks,',
+    '    require_mutation_check, mandate, read_scope, output_budget).',
+    '  - `load_loop_config(path)` using the tomllib/tomli fallback already used in scopes.py / cleanup.py.',
+    '  - resolution chain: explicit path -> .studio/implementation_loop.toml -> config/implementation_loop.toml -> defaults.',
+    'Ship config/implementation_loop.toml as the shipped default (copy the §4 example from the spec).',
+    'Write tests in studio/tests/test_impl_loop.py: valid file parses; missing file -> defaults;',
+    '  malformed TOML -> clear error; .studio override beats shipped default. Mirror the scopes loader tests.',
+    'This is one complete MVI unit: when done, Studio can actually load the loop config end-to-end.',
+  ].join('\n'),
+}
+
+const runDir = (u) => `.studio/output/impl_loop/${u.unit_id}`
+
+// ---------------------------------------------------------------------------
+// Handoff schemas — the portable baton (spec §1). Plain, serializable fields.
+// ---------------------------------------------------------------------------
+const WRITER_HANDOFF = {
+  type: 'object',
+  required: ['unit_id', 'writer_sha', 'files_touched', 'tests', 'mvi_claimed', 'stage'],
+  additionalProperties: false,
+  properties: {
+    unit_id: { type: 'string' },
+    title: { type: 'string' },
+    writer_sha: { type: 'string', description: 'commit of the writer\'s passing state — diff base + revert point' },
+    files_touched: { type: 'array', items: { type: 'string' } },
+    tests: {
+      type: 'object',
+      required: ['command', 'passed', 'exit_code'],
+      additionalProperties: false,
+      properties: {
+        command: { type: 'string' },
+        passed: { type: 'boolean' },
+        exit_code: { type: 'integer' },
+      },
+    },
+    static_ok: { type: 'boolean', description: 'ruff (or configured static check) clean' },
+    mvi_claimed: { type: 'boolean', description: 'writer\'s DECLARATION it finished a complete thought — a trigger, not a verdict' },
+    mutation_check: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        performed: { type: 'boolean' },
+        assertions_broken: { type: 'integer' },
+        caught: { type: 'boolean' },
+      },
+    },
+    load_bearing: { type: 'array', items: { type: 'string' }, description: 'looks cuttable but is not — off-limits to the editor without escalation' },
+    stage: { type: 'string', enum: ['writer'] },
+  },
+}
+
+const EDITOR_HANDOFF = {
+  type: 'object',
+  required: ['unit_id', 'tests', 'mvi_verdict', 'edits', 'reverted', 'stage'],
+  additionalProperties: false,
+  properties: {
+    unit_id: { type: 'string' },
+    files_touched: { type: 'array', items: { type: 'string' } },
+    tests: {
+      type: 'object',
+      required: ['command', 'passed', 'exit_code'],
+      additionalProperties: false,
+      properties: {
+        command: { type: 'string' },
+        passed: { type: 'boolean' },
+        exit_code: { type: 'integer' },
+      },
+    },
+    mvi_verdict: { type: 'boolean', description: 'AUTHORITATIVE: could someone use this unit? Overturns writer.mvi_claimed.' },
+    edits: { type: 'string', description: 'what was cut / merged / renamed, and what (if anything) was lost' },
+    reverted: { type: 'boolean', description: 'true if the editor reset to writer_sha because an edit broke green or hit a load_bearing item' },
+    stage: { type: 'string', enum: ['editor'] },
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Prompts. The script is orchestration only — all behavior lives in these
+// strings + the gate logic below, so a port rewrites only this shell.
+// ---------------------------------------------------------------------------
+function writerPrompt(u) {
+  return [
+    `You are the WRITER in an implementation writer/editor loop. Build ONE complete MVI unit, then declare done.`,
+    ``,
+    `UNIT: ${u.title}`,
+    ``,
+    u.instructions,
+    ``,
+    `Discipline:`,
+    `- Build a usable interaction, not a partial component (MVI). No speculative scope beyond the unit.`,
+    `- Hold AI-TDD: write the tests, run them, and do a mutation check — break 2-3 critical assertions,`,
+    `  confirm the tests FAIL, then restore. Report it in mutation_check.`,
+    `- Run the unit tests: \`${u.test_command}\`  and the static check: \`${u.static_check}\`.`,
+    `- When (and only when) tests pass, COMMIT the passing state on the current branch`,
+    `  (\`git add -A && git commit -m "writer: ${u.unit_id}"\`) and capture the short SHA — that is writer_sha.`,
+    `- Persist your handoff: \`mkdir -p ${runDir(u)}\` then write it to ${runDir(u)}/impl--${u.unit_id}--writer.json.`,
+    `- Set mvi_claimed=true ONLY if you believe the unit is a complete, usable thought. This is a trigger you`,
+    `  pull, not a verdict — the editor renders the authoritative MVI verdict next.`,
+    `- List anything load_bearing (looks cuttable but is not, with the reason).`,
+    `Return the writer handoff object.`,
+  ].join('\n')
+}
+
+function editorPrompt(u, writer) {
+  return [
+    `You are the EDITOR in an implementation writer/editor loop — a fresh agent reviewing the writer's unit.`,
+    ``,
+    `Your mandate IS the CONTRARIAN_MANDATE defined in studio/scopes.py (read lines ~27-37 and adopt it),`,
+    `applied to code: default to deletion, name the specific cut, collapse don't accumulate, guard the essence.`,
+    ``,
+    `Scope of review: \`git diff ${writer.writer_sha}..\` — these are the writer's changes. Read the touched`,
+    `files (${(writer.files_touched || []).join(', ') || 'see the diff'}) and their direct importers. Do not`,
+    `wander beyond that read scope.`,
+    ``,
+    `Hard bounds:`,
+    `- BEHAVIOR PRESERVATION: you may restructure and delete freely ONLY as long as the unit's tests stay green.`,
+    `  After editing, re-run: \`${u.test_command}\`.`,
+    `- Do NOT remove a load_bearing item (${JSON.stringify(writer.load_bearing || [])}) without escalating.`,
+    `- If an edit breaks tests, or you must touch a load_bearing item, REVERT: \`git reset --hard ${writer.writer_sha}\``,
+    `  and set reverted=true. Never deliver red code from an edit.`,
+    ``,
+    `Then render mvi_verdict: AUTHORITATIVELY judge "if we stopped here, could someone use this unit?" against`,
+    `the title "${u.title}". This can overturn the writer's claim.`,
+    `Persist your handoff to ${runDir(u)}/impl--${u.unit_id}--editor.json, and return the editor handoff object.`,
+  ].join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration: writer -> entry gate -> editor -> exit gate (revert) -> deliver
+// ---------------------------------------------------------------------------
+const unit = (args && args.unit_id) ? args : DEFAULT_UNIT
+
+phase('Writer')
+const writer = await agent(writerPrompt(unit), { schema: WRITER_HANDOFF, label: `writer:${unit.unit_id}`, phase: 'Writer' })
+
+// Entry gate — purely mechanical: writer declared done AND machine checks pass.
+const entryGate = !!(writer && writer.mvi_claimed && writer.tests && writer.tests.passed && writer.static_ok !== false)
+if (!writer) {
+  log('Writer agent failed to return a handoff — aborting.')
+  return { delivered: false, reason: 'writer_failed' }
+}
+if (!entryGate) {
+  // deliver_on_gate_fail: do not spin. Leave the writer's state, flag it.
+  log(`Entry gate failed (mvi_claimed=${writer.mvi_claimed}, tests.passed=${writer.tests?.passed}). Delivering flagged, no editor pass.`)
+  return { delivered: true, flagged: true, editorRan: false, writer }
+}
+
+phase('Edit')
+const editor = await agent(editorPrompt(unit, writer), { schema: EDITOR_HANDOFF, label: `editor:${unit.unit_id}`, phase: 'Edit' })
+
+// Exit gate — edit must hold (tests green) AND authoritative MVI verdict.
+const editHeld = !!(editor && editor.tests && editor.tests.passed && !editor.reverted)
+const exitGate = !!(editor && editor.tests && editor.tests.passed && editor.mvi_verdict)
+
+// Safety net: if the editor broke green but did not revert itself, force the revert.
+if (editor && editor.tests && editor.tests.passed === false && !editor.reverted) {
+  log(`Editor left red code without reverting — forcing reset to ${writer.writer_sha}.`)
+  await agent(
+    `Run \`git reset --hard ${writer.writer_sha}\` to restore the writer's passing state for ${unit.unit_id}, then confirm \`${unit.test_command}\` passes. Return a one-line confirmation.`,
+    { label: `revert:${unit.unit_id}`, phase: 'Edit' },
+  )
+}
+
+log(`Done. editorRan=${!!editor} editHeld=${editHeld} mvi_verdict=${editor?.mvi_verdict} reverted=${editor?.reverted}`)
+return {
+  delivered: true,
+  flagged: !exitGate,                // delivered, but editor couldn't confirm a usable green unit
+  editorRan: true,
+  finalVersion: editHeld ? 'editor' : 'writer',
+  writer,
+  editor,
+}

--- a/.claude/workflows/implementation-loop.js
+++ b/.claude/workflows/implementation-loop.js
@@ -74,11 +74,12 @@ const WRITER_HANDOFF = {
 
 const EDITOR_HANDOFF = {
   type: 'object',
-  required: ['unit_id', 'tests', 'mvi_verdict', 'edits', 'reverted', 'stage'],
+  required: ['unit_id', 'tests', 'mvi_verdict', 'edits', 'reverted', 'committed', 'stage'],
   additionalProperties: false,
   properties: {
     unit_id: { type: 'string' },
     files_touched: { type: 'array', items: { type: 'string' } },
+    committed: { type: 'boolean', description: 'true if the editor committed its kept edits; false if it reverted (writer_sha already holds the state)' },
     tests: {
       type: 'object',
       required: ['command', 'passed', 'exit_code'],
@@ -143,6 +144,9 @@ function editorPrompt(u, writer) {
     ``,
     `Then render mvi_verdict: AUTHORITATIVELY judge "if we stopped here, could someone use this unit?" against`,
     `the title "${u.title}". This can overturn the writer's claim.`,
+    ``,
+    `Deliver: if you KEPT your edits (tests green, not reverted), commit them — \`git commit -am "editor: ${u.unit_id}"\``,
+    `— and set committed=true. If you reverted, do NOT commit (writer_sha already holds the delivered state); set committed=false.`,
     `Persist your handoff to ${runDir(u)}/impl--${u.unit_id}--editor.json, and return the editor handoff object.`,
   ].join('\n')
 }
@@ -150,7 +154,12 @@ function editorPrompt(u, writer) {
 // ---------------------------------------------------------------------------
 // Orchestration: writer -> entry gate -> editor -> exit gate (revert) -> deliver
 // ---------------------------------------------------------------------------
-const unit = (args && args.unit_id) ? args : DEFAULT_UNIT
+// Merge any provided args over the default unit field-by-field: provided keys win,
+// unspecified keys fall back to DEFAULT_UNIT (so partial args are safe). The log
+// makes the resolved unit visible — if args didn't arrive, this shows the default.
+const overrides = (args && typeof args === 'object' && !Array.isArray(args)) ? args : {}
+const unit = { ...DEFAULT_UNIT, ...overrides }
+log(`Unit: ${unit.unit_id} — ${unit.title}`)
 
 phase('Writer')
 const writer = await agent(writerPrompt(unit), { schema: WRITER_HANDOFF, label: `writer:${unit.unit_id}`, phase: 'Writer' })
@@ -183,7 +192,16 @@ if (editor && editor.tests && editor.tests.passed === false && !editor.reverted)
   )
 }
 
-log(`Done. editorRan=${!!editor} editHeld=${editHeld} mvi_verdict=${editor?.mvi_verdict} reverted=${editor?.reverted}`)
+// Safety net: if the editor kept its edits but didn't commit them, commit now so delivery is complete.
+if (editHeld && editor && !editor.committed) {
+  log(`Editor kept edits but did not commit — committing now.`)
+  await agent(
+    `Run \`git commit -am "editor: ${unit.unit_id}"\` to commit the editor's kept changes for ${unit.unit_id}. If git reports nothing to commit, say so. Return a one-line confirmation.`,
+    { label: `commit:${unit.unit_id}`, phase: 'Edit' },
+  )
+}
+
+log(`Done. editorRan=${!!editor} editHeld=${editHeld} mvi_verdict=${editor?.mvi_verdict} reverted=${editor?.reverted} committed=${editor?.committed}`)
 return {
   delivered: true,
   flagged: !exitGate,                // delivered, but editor couldn't confirm a usable green unit

--- a/.claude/workflows/implementation-loop.js
+++ b/.claude/workflows/implementation-loop.js
@@ -190,15 +190,22 @@ if (editor && editor.tests && editor.tests.passed === false && !editor.reverted)
     `Run \`git reset --hard ${writer.writer_sha}\` to restore the writer's passing state for ${unit.unit_id}, then confirm \`${unit.test_command}\` passes. Return a one-line confirmation.`,
     { label: `revert:${unit.unit_id}`, phase: 'Edit' },
   )
+  // The tree is now back at writer_sha; reflect that in the payload so the log/return don't misreport.
+  editor.reverted = true
 }
 
 // Safety net: if the editor kept its edits but didn't commit them, commit now so delivery is complete.
+// NOTE: `git commit -am` stages only tracked, modified files — intentional. The editor's contract is to
+// refine/cut EXISTING files; a new file is out-of-contract, so it's left uncommitted to surface (not
+// silently swept in via `git add -A`). Widen this only if editors are ever allowed to create files.
 if (editHeld && editor && !editor.committed) {
   log(`Editor kept edits but did not commit — committing now.`)
   await agent(
     `Run \`git commit -am "editor: ${unit.unit_id}"\` to commit the editor's kept changes for ${unit.unit_id}. If git reports nothing to commit, say so. Return a one-line confirmation.`,
     { label: `commit:${unit.unit_id}`, phase: 'Edit' },
   )
+  // Reflect the safety-net commit in the payload.
+  editor.committed = true
 }
 
 log(`Done. editorRan=${!!editor} editHeld=${editHeld} mvi_verdict=${editor?.mvi_verdict} reverted=${editor?.reverted} committed=${editor?.committed}`)

--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,10 @@ studio/output/
 .studio/
 studio/.studio/
 
-# Claude Code local config/memory (keep slash commands tracked)
+# Claude Code local config/memory (keep slash commands + workflows tracked)
 .claude/*
 !.claude/commands/
+!.claude/workflows/
 
 # Studio input files (may contain sensitive analysis)
 studio/input/

--- a/studio/config/implementation_loop.toml
+++ b/studio/config/implementation_loop.toml
@@ -1,0 +1,17 @@
+# Default configuration for the implementation writer/editor loop.
+#
+# Follows the scopes.toml pattern: shipped default, overridable by
+# .studio/implementation_loop.toml. See studio/docs/IMPLEMENTATION_LOOP_SPEC.md §4.
+
+[loop]
+deliver_on_gate_fail = true   # if the writer can't reach green, deliver flagged (uncommitted) rather than spin
+
+[gate]
+test_command = "pytest -q"    # per-repo; the only stack-specific knob. Runs the unit-scoped tests.
+static_checks = ["ruff"]      # CodeValidator static/lint half (mypy opt-in, off by default)
+require_mutation_check = true # records the attested mutation signal; not machine-enforced yet
+
+[editor]
+mandate = "contrarian"        # reuse CONTRARIAN_MANDATE; "off" disables the editor pass
+read_scope = "touched+importers"  # bound the editor's reads: diff + files_touched + direct importers
+output_budget = 400           # word cap on the editor's rationale (matches scope output budgets)

--- a/studio/docs/IMPLEMENTATION_LOOP_SPEC.md
+++ b/studio/docs/IMPLEMENTATION_LOOP_SPEC.md
@@ -1,0 +1,310 @@
+# Implementation Writer/Editor Loop — Spec
+
+> **Status: design, not yet built.** This document specifies a feature. Nothing here is wired
+> into `run_phase.py` or shipped as config yet. It exists so the design can be reviewed before
+> any code is written. The "Build phases" section at the end is the implementation path.
+>
+> Refined once via a Product + Engineering role pass (see "Refinement log").
+
+## Why
+
+Studio already runs an advocate/contrarian debate at the **planning** level: the advocate piles
+on, and the contrarian-as-editor carves the proposal down to its essence (`CONTRARIAN_MANDATE`,
+`studio/scopes.py:27`). That writer→editor dynamic is the thing that produces tight output.
+
+Implementation has no equivalent. Code is written in one pass by one agent, and whatever sprawl,
+duplication, or dead scaffolding accumulates ships as-is. This spec brings the same cadence to
+implementation: **one agent builds a complete unit of work; a second agent reviews it and
+*applies* edits — cut, collapse, rename, restructure — then the unit is delivered.**
+
+The goal is not more review for its own sake. It is a structurally-guaranteed second pass by a
+fresh agent whose entire mandate is to remove what doesn't earn its keep, run at a cadence coarse
+enough that the pass is worth its cost — and held to a measurable bar that decides whether the
+pass stays on at all (see "Success / kill metric").
+
+## Design principles
+
+These were settled deliberately; each rejects a plausible alternative.
+
+- **Pipeline, not debate.** In planning, advocate and contrarian genuinely disagree and an
+  integrator resolves the tension — disagreement *is* the value. In code, two agents arguing
+  about an implementation thrashes. So the editor **applies its edits directly** and does not
+  hand the work back to the writer. There is no ping-pong, and there is **no re-run loop** — the
+  writer runs once, the editor runs once, the unit is delivered. The only branch is a one-shot
+  **revert** when an edit can't hold (see escalation).
+
+- **Coarse cadence — fire at a checkpoint, not per edit.** The editor must re-read the unit plus
+  a *bounded* slice of surrounding code (see read-scope) to edit safely. That re-read is the
+  dominant cost of the loop, so it must buy enough to be worth it. The checkpoint is **one
+  complete MVI unit AND tests green** — not "every N edits," not "every file."
+
+- **Native executor, portable core.** The first executor is a Claude Code **Workflow** — it
+  enforces the gates with real control flow and doubles as the cadence lab. The
+  expensive-to-design parts — prompts, gate criteria, cadence params, the handoff shape — live as
+  **data**, not baked into the workflow script, so a port rewrites only the thin shell.
+
+- **In-memory handoff, anchored to a commit.** The writer→editor baton is an in-memory metadata
+  object the orchestrator passes between stages (the natural shape in every agent runtime). It
+  carries a `writer_sha` — the commit of the writer's passing state — which is what makes the
+  diff base, the unit boundary, and the revert restore-point all deterministic.
+
+- **Editor diffs against `writer_sha`, then reads from disk.** The handoff carries metadata only.
+  The editor computes `git diff <writer_sha>..` for an unambiguous picture of what the writer
+  changed (no conflation with pre-existing uncommitted work, no bleed between sequential units in
+  one tree), then reads the touched files directly.
+
+## The portable core (provider-neutral data)
+
+Everything in this section is runtime-agnostic. It is the asset; the executor is throwaway.
+
+### 1. The handoff object
+
+The object the writer stage returns and the editor stage consumes. Serializable by construction
+(plain fields, no closures or methods), so the same object doubles as the per-unit record
+persisted to the run directory.
+
+```jsonc
+{
+  "unit_id": "unit_01",
+  "title": "Users can create and view a profile (hardcoded storage)",
+  "writer_sha": "a1b2c3d",          // commit of the writer's passing state — diff base + revert point
+  "files_touched": ["src/profile.py", "tests/test_profile.py"],
+  "tests": {
+    "command": "pytest tests/test_profile.py -q",   // unit-scoped, fast — run at the gate
+    "passed": true,
+    "exit_code": 0
+  },
+  "mvi_claimed": true,              // writer's DECLARATION that the unit is a complete thought — the handoff trigger
+  "mutation_check": { "performed": true, "assertions_broken": 2, "caught": true },  // attested
+  "load_bearing": ["the retry in save_profile guards a real race; do not cut"],
+  "stage": "writer"   // "writer" | "editor"
+}
+```
+
+The **editor** returns the same shape with `stage: "editor"`, its own `writer_sha` no-op (it
+diffs against the writer's), updated `tests` (re-run after its edits), an `edits` summary of what
+was cut / merged / renamed (and what, if anything, was lost), and `mvi_verdict` — its
+**authoritative** judgment of whether the unit is a usable interaction, which can overturn the
+writer's `mvi_claimed`. It does **not** carry a
+separate `behavior_preserved` flag: "tests stay green" plus the `load_bearing` escalation already
+encode that invariant, so a third self-attested boolean was cut as redundant.
+
+`load_bearing` is the writer's signal: these choices look cuttable but aren't. The editor must
+not remove a `load_bearing` item without escalating (below).
+
+### 2. The gate — "MVI unit complete AND tests green"
+
+The gate is the checkpoint, and it has **two distinct moments**, not one rule applied twice:
+
+- **Entry gate (after the writer) — purely mechanical.** Admits the unit to the editor when the
+  writer has *declared done* (`mvi_claimed`) **and** the machine checks pass (tests green + ruff).
+  The writer's declaration is only a trigger — the writer is the one agent that knows when it has
+  finished a complete thought, so it must be the one to say "hand it off." It is *not* a trusted
+  MVI verdict.
+- **Exit gate (after the editor) — adds the authoritative judgment.** The edit must hold (tests
+  still green) **and** the editor renders its `mvi_verdict`. The editor — the fresh, skeptical
+  second agent — can overturn the writer's claim. If it judges the unit *not* a usable interaction,
+  that is a surfaced finding (deliver flagged / escalate), never a silent pass.
+
+So the writer never has to "define MVI" to hand off; it only has to declare it believes it's done.
+The editor owns the verdict the gate actually trusts. Be honest about what is *machine-enforced*
+versus *agent-attested* — conflating the two would manufacture exactly the false confidence the
+"Tests green" criterion warns against.
+
+**Machine-enforced (deterministic — the orchestrator branches on these):**
+
+| Component | Criterion | Source |
+| --- | --- | --- |
+| Tests green | `tests.command` (unit-scoped) exits 0, run by the agent and recorded in the handoff. | `TEST_DRIVEN_GUIDE.md` |
+| Static checks | `ruff` clean via `CodeValidator`. (mypy is **out** of the gate — `mypy . --strict` blocks virtually any real repo; opt-in only.) | `code_validator.py` |
+| Full suite at delivery | The complete test suite runs once before the unit is delivered, not on every gate check (keeps the inner loop fast). | — |
+
+**Agent-attested (recorded signals, not enforcement — judged by the *editor*, the fresh agent,
+not the writer about its own work):**
+
+| Component | Criterion | Source |
+| --- | --- | --- |
+| MVI complete | Editor's exit-gate `mvi_verdict` — *"If we stopped here, could someone use what we've built?"* judged against the unit's `title`. Overturns the writer's `mvi_claimed`. | `MVI_METHODOLOGY.md` |
+| Mutation verified | Break 2–3 critical assertions; if tests still pass → reject and redo. | `AI_TDD_METHODOLOGY.md` |
+| No anti-patterns | No self-mocking tests, hallucinated assertions, green-checkmark traps. | `AI_TDD_METHODOLOGY.md` |
+
+What's genuinely reused from `CodeValidator`: its subprocess runner and `ruff`/`pytest`
+invocation. The gate still needs **net-new glue** to aggregate `List[CheckResult]` → bool, run the
+unit-scoped `tests.command`, and capture the attested signals. The mutation check has no
+deterministic enforcer today, which is why it sits in the attested half — until one exists,
+calling it "non-negotiable" would overstate it.
+
+### 3. The mandates (prompts as data)
+
+Authored the same way personas and roles already are — shipped defaults that a project-local file
+shallow-merges over (mirrors `persona_overrides.py` and `role_overrides.py`).
+
+- **Editor mandate** = the existing `CONTRARIAN_MANDATE` (`studio/scopes.py:27`), pointed at code:
+  default to deletion, name the specific cut (not "this is complex"), collapse rather than
+  accumulate, guard the essence. With one code-specific bound: **behavior preservation** — the
+  editor may restructure and delete freely *as long as tests stay green*, and may not touch a
+  `load_bearing` item without escalating. The editor also renders the authoritative `mvi_verdict`
+  at the exit gate, which can overturn the writer's claim.
+
+- **Writer mandate** = build exactly one complete MVI unit — a usable interaction, not a partial
+  component (`MVI_METHODOLOGY.md`). No speculative scope. When it believes the unit is a complete
+  thought, **declare done** (`mvi_claimed`) — that declaration is the handoff trigger, not a
+  verdict. Commit the passing state (this is `writer_sha`). Declare `load_bearing` choices so the
+  editor knows what looks cuttable but isn't.
+
+- **Escalation + revert (the only branch):** if the editor wants to cut a `load_bearing` item, or
+  an edit can't keep tests green, it does **not** silently override. Revert is mechanical: the
+  writer committed its passing state (`writer_sha`), so the orchestrator restores it with
+  `git reset --hard <writer_sha>` (or `git checkout <writer_sha> -- <files_touched>`) and records
+  the disagreement in `edits`. Without that commit there is nothing to revert to — the snapshot
+  is what makes "keep the writer's version" executable at all.
+
+### 4. Config — `implementation_loop.toml`
+
+Follows the `scopes.toml` + `ScopeConfig` pattern exactly: same `[table]` shape, same
+tomllib/tomli loader, same resolution chain (CLI flag → `.studio/` override → shipped default →
+disabled). A `LoopConfig` dataclass + `load_loop_config()` would live in a new
+`studio/impl_loop.py`, co-located like `ScopeConfig`/`load_scopes_config()` in `scopes.py`.
+
+```toml
+[loop]
+deliver_on_gate_fail = true   # if the writer can't reach green, deliver flagged (uncommitted) rather than spin
+
+[gate]
+test_command = "pytest -q"    # per-repo; the only stack-specific knob. Runs the unit-scoped tests.
+static_checks = ["ruff"]      # CodeValidator static/lint half (mypy opt-in, off by default)
+require_mutation_check = true # records the attested mutation signal; not machine-enforced yet
+
+[editor]
+mandate = "contrarian"        # reuse CONTRARIAN_MANDATE; "off" disables the editor pass
+read_scope = "touched+importers"  # bound the editor's reads: diff + files_touched + direct importers
+output_budget = 400           # word cap on the editor's rationale (matches scope output budgets)
+```
+
+Notes on what was cut vs the first draft:
+
+- **`max_unit_iterations` removed.** The pipeline is one-way with a single revert branch; there is
+  at most one editor pass, so the knob could only ever be 1 — configurability for a loop the
+  design forbids.
+- **`test_command` is now the single source of truth for running tests.** The first draft also had
+  `validator_checks = ["pytest", ...]`, duplicating the test run and implying `CodeValidator`
+  consumes `test_command` (it does not — `run_pytest` hardcodes `pytest -v` + a path). Tests run
+  via `test_command`; `static_checks` is lint/static only.
+- **`read_scope` added** because the real cost driver is the editor's *input* context, and the
+  only prior knob (`output_budget`) caps *output*. Bounding reads is also what makes the
+  cadence-lab token numbers meaningful.
+- **`deliver_on_gate_fail`** must leave red code **uncommitted** and tag the failure in the unit's
+  `impl--unit_NN--*.json` record, so a delivered-but-failing unit is never mistaken for a passing
+  one.
+
+## The executor shell (Claude-specific, disposable)
+
+A thin Claude Code Workflow script — **orchestration only**. Every prompt, gate criterion, and
+parameter is read from the config above; nothing about the loop's logic is hardcoded. Per MVI
+unit:
+
+```js
+writer = agent(writer_prompt(unit, config), { schema: HANDOFF })   // build unit; commit passing state -> writer_sha
+if (gate(writer)) {                                                 // tests green + ruff + attested MVI/mutation
+  editor = agent(editor_prompt(writer, CONTRARIAN_MANDATE),         // diff writer_sha.., apply edits, re-run tests
+                 { schema: HANDOFF })
+  if (!gate(editor)) revertTo(writer.writer_sha)                    // edit broke green / hit load_bearing -> reset
+}
+runFullSuite()                                                      // delivery-time check
+deliver(unit)                                                       // if gate failed: leave uncommitted + flag
+```
+
+- The handoff is passed **in-memory** between stages. Running tests, `git commit`, `git diff
+  <writer_sha>..`, and the revert are delegated to the agents' / orchestrator's Bash tool (the
+  workflow script is pure JS).
+- Each unit's final handoff object is written to the run directory as
+  `impl--unit_NN--writer.json` / `impl--unit_NN--editor.json`, matching the existing artifact
+  naming convention (`advocate--<role>--NN.md`).
+
+A native workflow's edge over an honor-system executor is **enforcement** — the gate provably
+fires — not token savings. The cost is that enforcement only holds while the workflow is the
+executor; that trade is acceptable because the workflow is also where the cadence gets tuned.
+
+**Portability:** the config, handoff, mandates, and tuned cadence are plain data, so a port to
+another runtime (LangGraph, Google ADK, OpenAI Agents SDK) rewrites only the ~40-line
+orchestration shell — those frameworks all express the same "sequential stages + conditional
+branch + shared state" shape.
+
+## Success / kill metric
+
+The cadence lab needs a terminating verdict, or it runs forever and the feature has no measurable
+outcome. Before tuning anything, capture a **no-editor baseline** (writer-only) so cut-per-token
+has something to compare against. Then the editor pass earns its place only if, across a sample of
+units, it delivers:
+
+- **≥ one substantive simplification per unit** (a real cut/merge/restructure, not cosmetic), or a
+  measurable reduction in delivered LOC / duplication over baseline, **and**
+- at an editor-pass token cost **≤ ~50% of the writer pass** (tunable, but a stated ceiling).
+
+Below that bar, the editor defaults to `mandate = "off"` — the loop ships dormant rather than
+doubling per-unit cost for marginal gain. This is the kill switch.
+
+## Cadence lab
+
+The one parameter that needs empirical tuning rather than design is **gate granularity**: editor
+pass per *MVI unit* (the default), per *file*, or per *feature*. Run real work through the
+executor and watch:
+
+1. **Cut-per-token** at each granularity (the success-metric numerator over editor token cost).
+   Too little cut → the cadence is too fine and the re-read isn't earning its keep.
+2. Whether `read_scope` is capturing enough context to edit safely without ballooning input.
+
+Lock the granularity that maximizes cut-per-token into `implementation_loop.toml`. Because that
+value lives in config, the tuning result survives any later port.
+
+## Build phases
+
+Each phase must end in something usable (the feature's own MVI rule applies to its build). Each is
+gated on reviewing the one before it.
+
+1. **Runnable loop on one unit** — the Claude Workflow shell + the minimum gate glue (run
+   `test_command`, `ruff`, aggregate to bool, writer commit + revert), driving one small real MVI
+   unit end-to-end. Config may be inlined/minimal here. **This is the first deliverable** because a
+   config no executor reads is a wheel, not a skateboard — and the core hypothesis (is the editor
+   pass worth its cost?) can't be tested without a running loop.
+2. **Extract config + harden** — pull the inlined settings into
+   `studio/config/implementation_loop.toml` + `studio/impl_loop.py` (`LoopConfig` +
+   `load_loop_config()`), patterned on `scopes.py`, with loader tests mirroring the scopes tests
+   (valid parses, missing → defaults, bad TOML → clear error, `.studio/` overrides default).
+3. **Cadence lab** — capture the no-editor baseline, run real units, tune granularity against the
+   success/kill metric, write the result back into config.
+
+When the loop ships, the documentation contract applies: update `CLAUDE.md` (Architecture) and
+`CLAUDE_CODE_USAGE.md` alongside it.
+
+## Refinement log
+
+One Product + Engineering role iteration applied to the first draft:
+
+- **Eng (P0):** defined the revert mechanism (writer commit → `writer_sha` → `git reset`), which
+  was previously non-executable; added `writer_sha` to the handoff as the diff base + unit
+  boundary + revert point.
+- **Product (P0):** reordered build phases so the first milestone is a runnable loop, not a
+  config-only artifact that violates MVI.
+- **Product (P0):** added the Success / kill metric + no-editor baseline so the cadence lab can
+  terminate.
+- **Both:** relabeled the gate into machine-enforced vs agent-attested (mutation/MVI are attested,
+  not enforced). Split the gate into an **entry** moment (writer *declares done* + machine checks →
+  triggers the editor) and an **exit** moment (editor's authoritative `mvi_verdict` can overturn
+  the writer's claim) — so the writer hands off without having to "define MVI" itself.
+- **Both / Simplicity:** cut mypy from the gate, cut `max_unit_iterations`, removed the
+  `test_command`/`validator_checks` redundancy, dropped `behavior_preserved`, trimmed the
+  three-framework portability table to one sentence.
+- **Eng (P1):** added `read_scope` to bound the editor's input context (the real cost driver);
+  `deliver_on_gate_fail` must leave red code uncommitted + flagged.
+
+## References
+
+- `studio/scopes.py:27` — `CONTRARIAN_MANDATE` (the editor mandate, reused verbatim).
+- `studio/validators/code_validator.py` — `CodeValidator.validate_implementation()` returns
+  `List[CheckResult]`; `run_pytest` is `pytest -v` + path, `run_ruff` is `ruff check .`,
+  `run_mypy` is `mypy . --strict`. Gate reuses the runner + ruff/pytest; aggregation is net-new.
+- `studio/scopes.py` — `ScopeConfig` / `load_scopes_config()` (the config pattern to mirror).
+- `studio/persona_overrides.py`, `studio/role_overrides.py` — the shallow-merge override pattern
+  for prompts-as-data.
+- `MVI_METHODOLOGY.md`, `AI_TDD_METHODOLOGY.md`, `TEST_DRIVEN_GUIDE.md` — the gate criteria.

--- a/studio/impl_loop.py
+++ b/studio/impl_loop.py
@@ -84,21 +84,9 @@ def load_loop_config(path: Path | None = None, studio_root: Path | None = None) 
     explicit or end-of-chain) yields the default LoopConfig rather than an error —
     the loop ships with a working default, so absence is not a failure.
 
-    Expected format (all tables/keys optional; unspecified keys inherit defaults):
-    ```toml
-    [loop]
-    deliver_on_gate_fail = true
-
-    [gate]
-    test_command = "pytest -q"
-    static_checks = ["ruff"]
-    require_mutation_check = true
-
-    [editor]
-    mandate = "contrarian"
-    read_scope = "touched+importers"
-    output_budget = 400
-    ```
+    All tables/keys are optional; unspecified keys inherit the LoopConfig defaults.
+    See config/implementation_loop.toml (the shipped default) and SPEC §4 for the
+    canonical table shape.
 
     Args:
         path: Explicit path to a .toml config. When None, the resolution chain runs.

--- a/studio/impl_loop.py
+++ b/studio/impl_loop.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Configuration for the implementation writer/editor loop.
+
+Mirrors the ScopeConfig / load_scopes_config() pattern in scopes.py: a dataclass
+for the shipped config tables plus a loader with the tomllib/tomli fallback and a
+resolution chain (explicit path → .studio/ override → shipped default → defaults).
+
+See studio/docs/IMPLEMENTATION_LOOP_SPEC.md §4 for the table shape.
+"""
+from __future__ import annotations
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redefine]  # Python 3.10 fallback
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+
+
+STUDIO_ROOT = Path(__file__).resolve().parent
+
+VALID_MANDATES = {"contrarian", "off"}
+
+
+@dataclass
+class LoopConfig:
+    """Configuration for the implementation writer/editor loop.
+
+    Field defaults are the shipped defaults from the spec §4, so an absent or
+    empty config yields a fully usable LoopConfig.
+    """
+    # [loop]
+    deliver_on_gate_fail: bool = True
+    # [gate]
+    test_command: str = "pytest -q"
+    static_checks: List[str] = field(default_factory=lambda: ["ruff"])
+    require_mutation_check: bool = True
+    # [editor]
+    mandate: str = "contrarian"
+    read_scope: str = "touched+importers"
+    output_budget: int = 400
+
+    def __post_init__(self):
+        if self.mandate not in VALID_MANDATES:
+            raise ValueError(
+                f"editor.mandate must be one of {VALID_MANDATES}, got '{self.mandate}'"
+            )
+        if not isinstance(self.static_checks, list):
+            raise ValueError("gate.static_checks must be a list")
+        if not isinstance(self.output_budget, int) or isinstance(self.output_budget, bool):
+            raise ValueError("editor.output_budget must be an integer")
+
+    @property
+    def editor_enabled(self) -> bool:
+        """Whether the editor pass runs (mandate other than 'off')."""
+        return self.mandate != "off"
+
+
+def _resolve_config_path(path: Path | None, studio_root: Path) -> Path | None:
+    """Resolve the config path via the resolution chain.
+
+    explicit path → .studio/implementation_loop.toml → config/implementation_loop.toml.
+    Returns None when nothing in the chain exists (caller falls back to defaults).
+    """
+    if path is not None:
+        return Path(path)
+    local = studio_root / ".studio" / "implementation_loop.toml"
+    if local.exists():
+        return local
+    shipped = studio_root / "config" / "implementation_loop.toml"
+    if shipped.exists():
+        return shipped
+    return None
+
+
+def load_loop_config(path: Path | None = None, studio_root: Path | None = None) -> LoopConfig:
+    """
+    Load loop configuration from TOML, mirroring load_scopes_config().
+
+    Resolution chain: explicit ``path`` → ``.studio/implementation_loop.toml`` →
+    ``config/implementation_loop.toml`` → built-in defaults. A missing file (whether
+    explicit or end-of-chain) yields the default LoopConfig rather than an error —
+    the loop ships with a working default, so absence is not a failure.
+
+    Expected format (all tables/keys optional; unspecified keys inherit defaults):
+    ```toml
+    [loop]
+    deliver_on_gate_fail = true
+
+    [gate]
+    test_command = "pytest -q"
+    static_checks = ["ruff"]
+    require_mutation_check = true
+
+    [editor]
+    mandate = "contrarian"
+    read_scope = "touched+importers"
+    output_budget = 400
+    ```
+
+    Args:
+        path: Explicit path to a .toml config. When None, the resolution chain runs.
+        studio_root: Base for the resolution chain (defaults to the studio package
+            dir). Exposed for testing.
+
+    Returns:
+        LoopConfig with parsed values merged over defaults.
+
+    Raises:
+        ValueError: If the resolved file has invalid TOML or invalid field values.
+    """
+    root = studio_root if studio_root is not None else STUDIO_ROOT
+    config_path = _resolve_config_path(path, root)
+
+    if config_path is None or not config_path.exists():
+        return LoopConfig()
+
+    try:
+        with open(config_path, "rb") as f:
+            data = tomllib.load(f)
+    except tomllib.TOMLDecodeError as e:
+        raise ValueError(f"Invalid TOML in {config_path}: {e}") from e
+
+    loop = data.get("loop", {})
+    gate = data.get("gate", {})
+    editor = data.get("editor", {})
+    for name, table in (("loop", loop), ("gate", gate), ("editor", editor)):
+        if not isinstance(table, dict):
+            raise ValueError(f"'{name}' must be a table/dict: {config_path}")
+
+    defaults = LoopConfig()
+    return LoopConfig(
+        deliver_on_gate_fail=loop.get("deliver_on_gate_fail", defaults.deliver_on_gate_fail),
+        test_command=gate.get("test_command", defaults.test_command),
+        static_checks=gate.get("static_checks", list(defaults.static_checks)),
+        require_mutation_check=gate.get("require_mutation_check", defaults.require_mutation_check),
+        mandate=editor.get("mandate", defaults.mandate),
+        read_scope=editor.get("read_scope", defaults.read_scope),
+        output_budget=editor.get("output_budget", defaults.output_budget),
+    )

--- a/studio/impl_loop.py
+++ b/studio/impl_loop.py
@@ -23,6 +23,8 @@ STUDIO_ROOT = Path(__file__).resolve().parent
 
 VALID_MANDATES = {"contrarian", "off"}
 
+VALID_READ_SCOPES = {"touched", "touched+importers"}
+
 
 @dataclass
 class LoopConfig:
@@ -51,6 +53,16 @@ class LoopConfig:
             raise ValueError("gate.static_checks must be a list")
         if not isinstance(self.output_budget, int) or isinstance(self.output_budget, bool):
             raise ValueError("editor.output_budget must be an integer")
+        if self.read_scope not in VALID_READ_SCOPES:
+            raise ValueError(
+                f"editor.read_scope must be one of {VALID_READ_SCOPES}, got '{self.read_scope}'"
+            )
+        if not isinstance(self.test_command, str):
+            raise ValueError("gate.test_command must be a string")
+        if not isinstance(self.deliver_on_gate_fail, bool):
+            raise ValueError("loop.deliver_on_gate_fail must be a boolean")
+        if not isinstance(self.require_mutation_check, bool):
+            raise ValueError("gate.require_mutation_check must be a boolean")
 
     @property
     def editor_enabled(self) -> bool:
@@ -80,9 +92,11 @@ def load_loop_config(path: Path | None = None, studio_root: Path | None = None) 
     Load loop configuration from TOML, mirroring load_scopes_config().
 
     Resolution chain: explicit ``path`` → ``.studio/implementation_loop.toml`` →
-    ``config/implementation_loop.toml`` → built-in defaults. A missing file (whether
-    explicit or end-of-chain) yields the default LoopConfig rather than an error —
-    the loop ships with a working default, so absence is not a failure.
+    ``config/implementation_loop.toml`` → built-in defaults. An end-of-chain miss
+    (no ``path`` given and nothing found) yields the default LoopConfig — the loop
+    ships with a working default, so absence is not a failure. But an explicit
+    ``path`` that does not exist raises FileNotFoundError: a typo'd config path is an
+    error, not a silent request for defaults.
 
     All tables/keys are optional; unspecified keys inherit the LoopConfig defaults.
     See config/implementation_loop.toml (the shipped default) and SPEC §4 for the
@@ -97,8 +111,12 @@ def load_loop_config(path: Path | None = None, studio_root: Path | None = None) 
         LoopConfig with parsed values merged over defaults.
 
     Raises:
+        FileNotFoundError: If an explicit ``path`` is given but does not exist.
         ValueError: If the resolved file has invalid TOML or invalid field values.
     """
+    if path is not None and not Path(path).exists():
+        raise FileNotFoundError(f"Loop config not found at explicit path: {path}")
+
     root = studio_root if studio_root is not None else STUDIO_ROOT
     config_path = _resolve_config_path(path, root)
 

--- a/studio/tests/test_impl_loop.py
+++ b/studio/tests/test_impl_loop.py
@@ -8,6 +8,7 @@ import pytest
 from impl_loop import (
     LoopConfig,
     VALID_MANDATES,
+    VALID_READ_SCOPES,
     load_loop_config,
 )
 
@@ -59,6 +60,21 @@ def test_loop_config_invalid_static_checks_type():
         LoopConfig(static_checks="ruff")  # type: ignore[arg-type]
 
 
+def test_loop_config_invalid_read_scope():
+    """read_scope must be one of the known values, not an arbitrary string."""
+    with pytest.raises(ValueError, match="read_scope"):
+        LoopConfig(read_scope="everything")
+    assert "touched+importers" in VALID_READ_SCOPES
+
+
+def test_loop_config_invalid_bool_fields():
+    """The boolean knobs reject non-bool values (e.g. a stray TOML string)."""
+    with pytest.raises(ValueError, match="deliver_on_gate_fail"):
+        LoopConfig(deliver_on_gate_fail="yes")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="require_mutation_check"):
+        LoopConfig(require_mutation_check="no")  # type: ignore[arg-type]
+
+
 def test_load_loop_config_valid():
     """A valid TOML file parses into a LoopConfig."""
     config_path = _write_toml("""
@@ -107,10 +123,13 @@ output_budget = 999
         config_path.unlink()
 
 
-def test_load_loop_config_missing_file_returns_defaults():
-    """A missing file yields defaults, not an error (unlike scopes)."""
-    config = load_loop_config(Path("/nonexistent/implementation_loop.toml"))
-    assert config == LoopConfig()
+def test_load_loop_config_explicit_missing_path_raises():
+    """An explicit path that doesn't exist is an error (a typo), not a silent default.
+
+    End-of-chain absence still yields defaults — see the no_config_anywhere test below.
+    """
+    with pytest.raises(FileNotFoundError):
+        load_loop_config(Path("/nonexistent/implementation_loop.toml"))
 
 
 def test_load_loop_config_no_config_anywhere_returns_defaults():

--- a/studio/tests/test_impl_loop.py
+++ b/studio/tests/test_impl_loop.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Tests for the implementation writer/editor loop config loader."""
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from impl_loop import (
+    LoopConfig,
+    VALID_MANDATES,
+    load_loop_config,
+)
+
+
+def _write_toml(text: str) -> Path:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write(text)
+        return Path(f.name)
+
+
+def test_loop_config_defaults_match_spec():
+    """A bare LoopConfig carries the shipped defaults from spec §4."""
+    config = LoopConfig()
+    assert config.deliver_on_gate_fail is True
+    assert config.test_command == "pytest -q"
+    assert config.static_checks == ["ruff"]
+    assert config.require_mutation_check is True
+    assert config.mandate == "contrarian"
+    assert config.read_scope == "touched+importers"
+    assert config.output_budget == 400
+    assert config.editor_enabled is True
+
+
+def test_loop_config_off_mandate_disables_editor():
+    """mandate = 'off' disables the editor pass."""
+    config = LoopConfig(mandate="off")
+    assert config.editor_enabled is False
+
+
+def test_loop_config_invalid_mandate():
+    """LoopConfig rejects an unknown mandate."""
+    with pytest.raises(ValueError, match="mandate"):
+        LoopConfig(mandate="bogus")
+    assert "contrarian" in VALID_MANDATES
+    assert "off" in VALID_MANDATES
+
+
+def test_loop_config_invalid_output_budget_type():
+    """output_budget must be an integer (and not a bool)."""
+    with pytest.raises(ValueError, match="output_budget"):
+        LoopConfig(output_budget="lots")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="output_budget"):
+        LoopConfig(output_budget=True)  # type: ignore[arg-type]
+
+
+def test_loop_config_invalid_static_checks_type():
+    """static_checks must be a list."""
+    with pytest.raises(ValueError, match="static_checks"):
+        LoopConfig(static_checks="ruff")  # type: ignore[arg-type]
+
+
+def test_load_loop_config_valid():
+    """A valid TOML file parses into a LoopConfig."""
+    config_path = _write_toml("""
+[loop]
+deliver_on_gate_fail = false
+
+[gate]
+test_command = "python -m pytest tests/ -q"
+static_checks = ["ruff", "mypy"]
+require_mutation_check = false
+
+[editor]
+mandate = "off"
+read_scope = "touched"
+output_budget = 250
+""")
+    try:
+        config = load_loop_config(config_path)
+        assert config.deliver_on_gate_fail is False
+        assert config.test_command == "python -m pytest tests/ -q"
+        assert config.static_checks == ["ruff", "mypy"]
+        assert config.require_mutation_check is False
+        assert config.mandate == "off"
+        assert config.read_scope == "touched"
+        assert config.output_budget == 250
+    finally:
+        config_path.unlink()
+
+
+def test_load_loop_config_partial_inherits_defaults():
+    """Unspecified keys inherit the shipped defaults (shallow merge)."""
+    config_path = _write_toml("""
+[editor]
+output_budget = 999
+""")
+    try:
+        config = load_loop_config(config_path)
+        # Overridden
+        assert config.output_budget == 999
+        # Inherited defaults
+        assert config.test_command == "pytest -q"
+        assert config.static_checks == ["ruff"]
+        assert config.mandate == "contrarian"
+        assert config.deliver_on_gate_fail is True
+    finally:
+        config_path.unlink()
+
+
+def test_load_loop_config_missing_file_returns_defaults():
+    """A missing file yields defaults, not an error (unlike scopes)."""
+    config = load_loop_config(Path("/nonexistent/implementation_loop.toml"))
+    assert config == LoopConfig()
+
+
+def test_load_loop_config_no_config_anywhere_returns_defaults():
+    """When the resolution chain finds nothing, defaults are returned."""
+    with tempfile.TemporaryDirectory() as tmp:
+        # Empty studio_root: no .studio/ and no config/ files exist.
+        config = load_loop_config(studio_root=Path(tmp))
+        assert config == LoopConfig()
+
+
+def test_load_loop_config_invalid_toml():
+    """Malformed TOML raises a clear ValueError."""
+    config_path = _write_toml("invalid toml [[[")
+    try:
+        with pytest.raises(ValueError, match="Invalid TOML"):
+            load_loop_config(config_path)
+    finally:
+        config_path.unlink()
+
+
+def test_load_loop_config_studio_override_beats_shipped_default():
+    """.studio/implementation_loop.toml wins over config/implementation_loop.toml."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / ".studio").mkdir()
+        (root / "config").mkdir()
+        (root / "config" / "implementation_loop.toml").write_text(
+            '[editor]\noutput_budget = 400\n'
+        )
+        (root / ".studio" / "implementation_loop.toml").write_text(
+            '[editor]\noutput_budget = 123\n'
+        )
+        config = load_loop_config(studio_root=root)
+        assert config.output_budget == 123
+
+
+def test_load_loop_config_falls_back_to_shipped_default():
+    """With no .studio override, the shipped config/ default is used."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "config").mkdir()
+        (root / "config" / "implementation_loop.toml").write_text(
+            '[editor]\nmandate = "off"\n'
+        )
+        config = load_loop_config(studio_root=root)
+        assert config.mandate == "off"
+
+
+def test_explicit_path_beats_resolution_chain():
+    """An explicit path takes priority over the .studio/config chain."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / ".studio").mkdir()
+        (root / ".studio" / "implementation_loop.toml").write_text(
+            '[editor]\noutput_budget = 50\n'
+        )
+        explicit = _write_toml('[editor]\noutput_budget = 777\n')
+        try:
+            config = load_loop_config(explicit, studio_root=root)
+            assert config.output_budget == 777
+        finally:
+            explicit.unlink()
+
+
+def test_load_default_loop_config():
+    """The shipped default implementation_loop.toml loads correctly."""
+    default_path = Path(__file__).resolve().parents[1] / "config" / "implementation_loop.toml"
+    if not default_path.exists():
+        pytest.skip("Default implementation_loop.toml not found")
+
+    config = load_loop_config(default_path)
+    assert config.deliver_on_gate_fail is True
+    assert config.test_command == "pytest -q"
+    assert config.static_checks == ["ruff"]
+    assert config.require_mutation_check is True
+    assert config.mandate == "contrarian"
+    assert config.read_scope == "touched+importers"
+    assert config.output_budget == 400


### PR DESCRIPTION
## What

Brings the advocate/contrarian (writer/editor) cadence into **implementation**. A writer agent builds one complete MVI unit and commits its passing state; a fresh editor agent (reusing `CONTRARIAN_MANDATE`) cuts/refines it against the writer's diff, reverting if an edit breaks green; then the unit is delivered.

**Pipeline, not debate** — the editor applies edits directly (no ping-pong); the only branch is a one-shot revert.

## Files

| File | Role |
|---|---|
| `studio/docs/IMPLEMENTATION_LOOP_SPEC.md` | The design spec |
| `.claude/workflows/implementation-loop.js` | Orchestration shell (built, **not yet run**) |
| `.claude/commands/studio-implement.md` | `/studio-implement` — the authorized trigger |
| `.gitignore` | Track `.claude/workflows/` so the workflow ships with its command |

## Design highlights

- **Gate split** into an *entry* moment (writer **declares done** + tests green + ruff → triggers the editor) and an *exit* moment (editor's authoritative `mvi_verdict` can overturn the writer's claim). This resolves the circularity of "who defines MVI."
- **In-memory handoff anchored to `writer_sha`** — the commit of the writer's passing state serves as the diff base, the unit boundary, and the revert restore-point.
- **Portable core:** prompts, gate criteria, cadence params, and handoff shape are data; a port to another runtime (LangGraph / ADK / OpenAI) rewrites only the ~40-line shell.
- Gate reuses the existing `CodeValidator`; mutation/MVI checks are honestly labeled **agent-attested**, not machine-enforced.

Refined once via a **Product + Engineering** role pass (see the spec's Refinement log).

## Status / scope

- **Spec + shell + trigger only.** The loop has **not been run**. First run (default target: building its own config loader, `studio/impl_loop.py`) is also the first cadence-lab data point.
- Future build phases (in the spec): runnable loop on one unit → extract `implementation_loop.toml` + `impl_loop.py` → cadence lab.
- Command is local to this repo (not wired into the cross-repo installer yet).

## Note for reviewers

Running `/studio-implement` spawns multiple agents, edits files in place, and makes a real git commit — that's why it's gated behind an explicit command. It refuses to run on a dirty tree and branches off `main` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)