### PR TITLE
feat: impl_loop config loader (LoopConfig + load_loop_config) — first writer/editor loop output

### DIFF
--- a/studio/config/implementation_loop.toml
+++ b/studio/config/implementation_loop.toml
@@ -1,0 +1,17 @@
+# Default configuration for the implementation writer/editor loop.
+#
+# Follows the scopes.toml pattern: shipped default, overridable by
+# .studio/implementation_loop.toml. See studio/docs/IMPLEMENTATION_LOOP_SPEC.md §4.
+
+[loop]
+deliver_on_gate_fail = true   # if the writer can't reach green, deliver flagged (uncommitted) rather than spin
+
+[gate]
+test_command = "pytest -q"    # per-repo; the only stack-specific knob. Runs the unit-scoped tests.
+static_checks = ["ruff"]      # CodeValidator static/lint half (mypy opt-in, off by default)
+require_mutation_check = true # records the attested mutation signal; not machine-enforced yet
+
+[editor]
+mandate = "contrarian"        # reuse CONTRARIAN_MANDATE; "off" disables the editor pass
+read_scope = "touched+importers"  # bound the editor's reads: diff + files_touched + direct importers
+output_budget = 400           # word cap on the editor's rationale (matches scope output budgets)

--- a/studio/impl_loop.py
+++ b/studio/impl_loop.py
@@ -84,21 +84,9 @@ def load_loop_config(path: Path | None = None, studio_root: Path | None = None) 
     explicit or end-of-chain) yields the default LoopConfig rather than an error —
     the loop ships with a working default, so absence is not a failure.
 
-    Expected format (all tables/keys optional; unspecified keys inherit defaults):
-    ```toml
-    [loop]
-    deliver_on_gate_fail = true
-
-    [gate]
-    test_command = "pytest -q"
-    static_checks = ["ruff"]
-    require_mutation_check = true
-
-    [editor]
-    mandate = "contrarian"
-    read_scope = "touched+importers"
-    output_budget = 400
-    ```
+    All tables/keys are optional; unspecified keys inherit the LoopConfig defaults.
+    See config/implementation_loop.toml (the shipped default) and SPEC §4 for the
+    canonical table shape.
 
     Args:
         path: Explicit path to a .toml config. When None, the resolution chain runs.

--- a/studio/impl_loop.py
+++ b/studio/impl_loop.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Configuration for the implementation writer/editor loop.
+
+Mirrors the ScopeConfig / load_scopes_config() pattern in scopes.py: a dataclass
+for the shipped config tables plus a loader with the tomllib/tomli fallback and a
+resolution chain (explicit path → .studio/ override → shipped default → defaults).
+
+See studio/docs/IMPLEMENTATION_LOOP_SPEC.md §4 for the table shape.
+"""
+from __future__ import annotations
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redefine]  # Python 3.10 fallback
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+
+
+STUDIO_ROOT = Path(__file__).resolve().parent
+
+VALID_MANDATES = {"contrarian", "off"}
+
+
+@dataclass
+class LoopConfig:
+    """Configuration for the implementation writer/editor loop.
+
+    Field defaults are the shipped defaults from the spec §4, so an absent or
+    empty config yields a fully usable LoopConfig.
+    """
+    # [loop]
+    deliver_on_gate_fail: bool = True
+    # [gate]
+    test_command: str = "pytest -q"
+    static_checks: List[str] = field(default_factory=lambda: ["ruff"])
+    require_mutation_check: bool = True
+    # [editor]
+    mandate: str = "contrarian"
+    read_scope: str = "touched+importers"
+    output_budget: int = 400
+
+    def __post_init__(self):
+        if self.mandate not in VALID_MANDATES:
+            raise ValueError(
+                f"editor.mandate must be one of {VALID_MANDATES}, got '{self.mandate}'"
+            )
+        if not isinstance(self.static_checks, list):
+            raise ValueError("gate.static_checks must be a list")
+        if not isinstance(self.output_budget, int) or isinstance(self.output_budget, bool):
+            raise ValueError("editor.output_budget must be an integer")
+
+    @property
+    def editor_enabled(self) -> bool:
+        """Whether the editor pass runs (mandate other than 'off')."""
+        return self.mandate != "off"
+
+
+def _resolve_config_path(path: Path | None, studio_root: Path) -> Path | None:
+    """Resolve the config path via the resolution chain.
+
+    explicit path → .studio/implementation_loop.toml → config/implementation_loop.toml.
+    Returns None when nothing in the chain exists (caller falls back to defaults).
+    """
+    if path is not None:
+        return Path(path)
+    local = studio_root / ".studio" / "implementation_loop.toml"
+    if local.exists():
+        return local
+    shipped = studio_root / "config" / "implementation_loop.toml"
+    if shipped.exists():
+        return shipped
+    return None
+
+
+def load_loop_config(path: Path | None = None, studio_root: Path | None = None) -> LoopConfig:
+    """
+    Load loop configuration from TOML, mirroring load_scopes_config().
+
+    Resolution chain: explicit ``path`` → ``.studio/implementation_loop.toml`` →
+    ``config/implementation_loop.toml`` → built-in defaults. A missing file (whether
+    explicit or end-of-chain) yields the default LoopConfig rather than an error —
+    the loop ships with a working default, so absence is not a failure.
+
+    Expected format (all tables/keys optional; unspecified keys inherit defaults):
+    ```toml
+    [loop]
+    deliver_on_gate_fail = true
+
+    [gate]
+    test_command = "pytest -q"
+    static_checks = ["ruff"]
+    require_mutation_check = true
+
+    [editor]
+    mandate = "contrarian"
+    read_scope = "touched+importers"
+    output_budget = 400
+    ```
+
+    Args:
+        path: Explicit path to a .toml config. When None, the resolution chain runs.
+        studio_root: Base for the resolution chain (defaults to the studio package
+            dir). Exposed for testing.
+
+    Returns:
+        LoopConfig with parsed values merged over defaults.
+
+    Raises:
+        ValueError: If the resolved file has invalid TOML or invalid field values.
+    """
+    root = studio_root if studio_root is not None else STUDIO_ROOT
+    config_path = _resolve_config_path(path, root)
+
+    if config_path is None or not config_path.exists():
+        return LoopConfig()
+
+    try:
+        with open(config_path, "rb") as f:
+            data = tomllib.load(f)
+    except tomllib.TOMLDecodeError as e:
+        raise ValueError(f"Invalid TOML in {config_path}: {e}") from e
+
+    loop = data.get("loop", {})
+    gate = data.get("gate", {})
+    editor = data.get("editor", {})
+    for name, table in (("loop", loop), ("gate", gate), ("editor", editor)):
+        if not isinstance(table, dict):
+            raise ValueError(f"'{name}' must be a table/dict: {config_path}")
+
+    defaults = LoopConfig()
+    return LoopConfig(
+        deliver_on_gate_fail=loop.get("deliver_on_gate_fail", defaults.deliver_on_gate_fail),
+        test_command=gate.get("test_command", defaults.test_command),
+        static_checks=gate.get("static_checks", list(defaults.static_checks)),
+        require_mutation_check=gate.get("require_mutation_check", defaults.require_mutation_check),
+        mandate=editor.get("mandate", defaults.mandate),
+        read_scope=editor.get("read_scope", defaults.read_scope),
+        output_budget=editor.get("output_budget", defaults.output_budget),
+    )

--- a/studio/impl_loop.py
+++ b/studio/impl_loop.py
@@ -23,6 +23,8 @@ STUDIO_ROOT = Path(__file__).resolve().parent
 
 VALID_MANDATES = {"contrarian", "off"}
 
+VALID_READ_SCOPES = {"touched", "touched+importers"}
+
 
 @dataclass
 class LoopConfig:
@@ -51,6 +53,16 @@ class LoopConfig:
             raise ValueError("gate.static_checks must be a list")
         if not isinstance(self.output_budget, int) or isinstance(self.output_budget, bool):
             raise ValueError("editor.output_budget must be an integer")
+        if self.read_scope not in VALID_READ_SCOPES:
+            raise ValueError(
+                f"editor.read_scope must be one of {VALID_READ_SCOPES}, got '{self.read_scope}'"
+            )
+        if not isinstance(self.test_command, str):
+            raise ValueError("gate.test_command must be a string")
+        if not isinstance(self.deliver_on_gate_fail, bool):
+            raise ValueError("loop.deliver_on_gate_fail must be a boolean")
+        if not isinstance(self.require_mutation_check, bool):
+            raise ValueError("gate.require_mutation_check must be a boolean")
 
     @property
     def editor_enabled(self) -> bool:
@@ -80,9 +92,11 @@ def load_loop_config(path: Path | None = None, studio_root: Path | None = None) 
     Load loop configuration from TOML, mirroring load_scopes_config().
 
     Resolution chain: explicit ``path`` → ``.studio/implementation_loop.toml`` →
-    ``config/implementation_loop.toml`` → built-in defaults. A missing file (whether
-    explicit or end-of-chain) yields the default LoopConfig rather than an error —
-    the loop ships with a working default, so absence is not a failure.
+    ``config/implementation_loop.toml`` → built-in defaults. An end-of-chain miss
+    (no ``path`` given and nothing found) yields the default LoopConfig — the loop
+    ships with a working default, so absence is not a failure. But an explicit
+    ``path`` that does not exist raises FileNotFoundError: a typo'd config path is an
+    error, not a silent request for defaults.
 
     All tables/keys are optional; unspecified keys inherit the LoopConfig defaults.
     See config/implementation_loop.toml (the shipped default) and SPEC §4 for the
@@ -97,8 +111,12 @@ def load_loop_config(path: Path | None = None, studio_root: Path | None = None) 
         LoopConfig with parsed values merged over defaults.
 
     Raises:
+        FileNotFoundError: If an explicit ``path`` is given but does not exist.
         ValueError: If the resolved file has invalid TOML or invalid field values.
     """
+    if path is not None and not Path(path).exists():
+        raise FileNotFoundError(f"Loop config not found at explicit path: {path}")
+
     root = studio_root if studio_root is not None else STUDIO_ROOT
     config_path = _resolve_config_path(path, root)
 

--- a/studio/tests/test_impl_loop.py
+++ b/studio/tests/test_impl_loop.py
@@ -8,6 +8,7 @@ import pytest
 from impl_loop import (
     LoopConfig,
     VALID_MANDATES,
+    VALID_READ_SCOPES,
     load_loop_config,
 )
 
@@ -59,6 +60,21 @@ def test_loop_config_invalid_static_checks_type():
         LoopConfig(static_checks="ruff")  # type: ignore[arg-type]
 
 
+def test_loop_config_invalid_read_scope():
+    """read_scope must be one of the known values, not an arbitrary string."""
+    with pytest.raises(ValueError, match="read_scope"):
+        LoopConfig(read_scope="everything")
+    assert "touched+importers" in VALID_READ_SCOPES
+
+
+def test_loop_config_invalid_bool_fields():
+    """The boolean knobs reject non-bool values (e.g. a stray TOML string)."""
+    with pytest.raises(ValueError, match="deliver_on_gate_fail"):
+        LoopConfig(deliver_on_gate_fail="yes")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="require_mutation_check"):
+        LoopConfig(require_mutation_check="no")  # type: ignore[arg-type]
+
+
 def test_load_loop_config_valid():
     """A valid TOML file parses into a LoopConfig."""
     config_path = _write_toml("""
@@ -107,10 +123,13 @@ output_budget = 999
         config_path.unlink()
 
 
-def test_load_loop_config_missing_file_returns_defaults():
-    """A missing file yields defaults, not an error (unlike scopes)."""
-    config = load_loop_config(Path("/nonexistent/implementation_loop.toml"))
-    assert config == LoopConfig()
+def test_load_loop_config_explicit_missing_path_raises():
+    """An explicit path that doesn't exist is an error (a typo), not a silent default.
+
+    End-of-chain absence still yields defaults — see the no_config_anywhere test below.
+    """
+    with pytest.raises(FileNotFoundError):
+        load_loop_config(Path("/nonexistent/implementation_loop.toml"))
 
 
 def test_load_loop_config_no_config_anywhere_returns_defaults():

--- a/studio/tests/test_impl_loop.py
+++ b/studio/tests/test_impl_loop.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Tests for the implementation writer/editor loop config loader."""
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from impl_loop import (
+    LoopConfig,
+    VALID_MANDATES,
+    load_loop_config,
+)
+
+
+def _write_toml(text: str) -> Path:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write(text)
+        return Path(f.name)
+
+
+def test_loop_config_defaults_match_spec():
+    """A bare LoopConfig carries the shipped defaults from spec §4."""
+    config = LoopConfig()
+    assert config.deliver_on_gate_fail is True
+    assert config.test_command == "pytest -q"
+    assert config.static_checks == ["ruff"]
+    assert config.require_mutation_check is True
+    assert config.mandate == "contrarian"
+    assert config.read_scope == "touched+importers"
+    assert config.output_budget == 400
+    assert config.editor_enabled is True
+
+
+def test_loop_config_off_mandate_disables_editor():
+    """mandate = 'off' disables the editor pass."""
+    config = LoopConfig(mandate="off")
+    assert config.editor_enabled is False
+
+
+def test_loop_config_invalid_mandate():
+    """LoopConfig rejects an unknown mandate."""
+    with pytest.raises(ValueError, match="mandate"):
+        LoopConfig(mandate="bogus")
+    assert "contrarian" in VALID_MANDATES
+    assert "off" in VALID_MANDATES
+
+
+def test_loop_config_invalid_output_budget_type():
+    """output_budget must be an integer (and not a bool)."""
+    with pytest.raises(ValueError, match="output_budget"):
+        LoopConfig(output_budget="lots")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="output_budget"):
+        LoopConfig(output_budget=True)  # type: ignore[arg-type]
+
+
+def test_loop_config_invalid_static_checks_type():
+    """static_checks must be a list."""
+    with pytest.raises(ValueError, match="static_checks"):
+        LoopConfig(static_checks="ruff")  # type: ignore[arg-type]
+
+
+def test_load_loop_config_valid():
+    """A valid TOML file parses into a LoopConfig."""
+    config_path = _write_toml("""
+[loop]
+deliver_on_gate_fail = false
+
+[gate]
+test_command = "python -m pytest tests/ -q"
+static_checks = ["ruff", "mypy"]
+require_mutation_check = false
+
+[editor]
+mandate = "off"
+read_scope = "touched"
+output_budget = 250
+""")
+    try:
+        config = load_loop_config(config_path)
+        assert config.deliver_on_gate_fail is False
+        assert config.test_command == "python -m pytest tests/ -q"
+        assert config.static_checks == ["ruff", "mypy"]
+        assert config.require_mutation_check is False
+        assert config.mandate == "off"
+        assert config.read_scope == "touched"
+        assert config.output_budget == 250
+    finally:
+        config_path.unlink()
+
+
+def test_load_loop_config_partial_inherits_defaults():
+    """Unspecified keys inherit the shipped defaults (shallow merge)."""
+    config_path = _write_toml("""
+[editor]
+output_budget = 999
+""")
+    try:
+        config = load_loop_config(config_path)
+        # Overridden
+        assert config.output_budget == 999
+        # Inherited defaults
+        assert config.test_command == "pytest -q"
+        assert config.static_checks == ["ruff"]
+        assert config.mandate == "contrarian"
+        assert config.deliver_on_gate_fail is True
+    finally:
+        config_path.unlink()
+
+
+def test_load_loop_config_missing_file_returns_defaults():
+    """A missing file yields defaults, not an error (unlike scopes)."""
+    config = load_loop_config(Path("/nonexistent/implementation_loop.toml"))
+    assert config == LoopConfig()
+
+
+def test_load_loop_config_no_config_anywhere_returns_defaults():
+    """When the resolution chain finds nothing, defaults are returned."""
+    with tempfile.TemporaryDirectory() as tmp:
+        # Empty studio_root: no .studio/ and no config/ files exist.
+        config = load_loop_config(studio_root=Path(tmp))
+        assert config == LoopConfig()
+
+
+def test_load_loop_config_invalid_toml():
+    """Malformed TOML raises a clear ValueError."""
+    config_path = _write_toml("invalid toml [[[")
+    try:
+        with pytest.raises(ValueError, match="Invalid TOML"):
+            load_loop_config(config_path)
+    finally:
+        config_path.unlink()
+
+
+def test_load_loop_config_studio_override_beats_shipped_default():
+    """.studio/implementation_loop.toml wins over config/implementation_loop.toml."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / ".studio").mkdir()
+        (root / "config").mkdir()
+        (root / "config" / "implementation_loop.toml").write_text(
+            '[editor]\noutput_budget = 400\n'
+        )
+        (root / ".studio" / "implementation_loop.toml").write_text(
+            '[editor]\noutput_budget = 123\n'
+        )
+        config = load_loop_config(studio_root=root)
+        assert config.output_budget == 123
+
+
+def test_load_loop_config_falls_back_to_shipped_default():
+    """With no .studio override, the shipped config/ default is used."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "config").mkdir()
+        (root / "config" / "implementation_loop.toml").write_text(
+            '[editor]\nmandate = "off"\n'
+        )
+        config = load_loop_config(studio_root=root)
+        assert config.mandate == "off"
+
+
+def test_explicit_path_beats_resolution_chain():
+    """An explicit path takes priority over the .studio/config chain."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / ".studio").mkdir()
+        (root / ".studio" / "implementation_loop.toml").write_text(
+            '[editor]\noutput_budget = 50\n'
+        )
+        explicit = _write_toml('[editor]\noutput_budget = 777\n')
+        try:
+            config = load_loop_config(explicit, studio_root=root)
+            assert config.output_budget == 777
+        finally:
+            explicit.unlink()
+
+
+def test_load_default_loop_config():
+    """The shipped default implementation_loop.toml loads correctly."""
+    default_path = Path(__file__).resolve().parents[1] / "config" / "implementation_loop.toml"
+    if not default_path.exists():
+        pytest.skip("Default implementation_loop.toml not found")
+
+    config = load_loop_config(default_path)
+    assert config.deliver_on_gate_fail is True
+    assert config.test_command == "pytest -q"
+    assert config.static_checks == ["ruff"]
+    assert config.require_mutation_check is True
+    assert config.mandate == "contrarian"
+    assert config.read_scope == "touched+importers"
+    assert config.output_budget == 400


### PR DESCRIPTION
## What

The implementation writer/editor loop's **Phase 2**: a config loader for `implementation_loop.toml`. Notably, this unit was **built by the loop itself** (`/studio-implement`) — the first real end-to-end run, dogfooded on Studio.

Stacked on #30 (base: `feat/implementation-loop`).

## Files

- `studio/impl_loop.py` — `LoopConfig` dataclass + `load_loop_config()`, mirroring `scopes.py` (tomllib/tomli fallback, resolution chain explicit → `.studio/` → shipped → defaults, `__post_init__` validation, `editor_enabled` property).
- `studio/config/implementation_loop.toml` — shipped default (spec §4 tables).
- `studio/tests/test_impl_loop.py` — **14 tests**: valid parse, missing→defaults, malformed TOML→clear error, `.studio` override beats shipped default.

## How it was produced (loop trace)

| Stage | Result |
|---|---|
| **Writer** | Built the unit; 14 tests green; mutation check (3 assertions broken, all caught); flagged 3 `load_bearing` items (e.g. the `bool`-subclasses-`int` guard on `output_budget`). Committed at `e346a53`. |
| **Editor** (CONTRARIAN_MANDATE) | One substantive cut — collapsed the TOML schema that was triplicated across docstring/config/spec down to a pointer (the drift `/unstale` guards against). `mvi_verdict: true`, nothing reverted. Respected all 3 load_bearing flags. Committed at `50e02b0`. |

## Cadence-lab data point (first run)

- 2 agents, ~88k tokens, ~4.5 min. Yield: 1 substantive cut on a clean ~130-line unit — clears the success metric, but thinly. Signal: editor yield is low on small well-written units; expect more value on larger/messier ones.
- Two loop bugs this run surfaced (args plumbing + editor not committing) are fixed in #30 (`d1aeaac`). They were worked around manually for this unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)