### PR TITLE
fix(workflow): parse args when forwarded as a JSON string

### DIFF
--- a/.claude/workflows/implementation-loop.js
+++ b/.claude/workflows/implementation-loop.js
@@ -157,7 +157,13 @@ function editorPrompt(u, writer) {
 // Merge any provided args over the default unit field-by-field: provided keys win,
 // unspecified keys fall back to DEFAULT_UNIT (so partial args are safe). The log
 // makes the resolved unit visible — if args didn't arrive, this shows the default.
-const overrides = (args && typeof args === 'object' && !Array.isArray(args)) ? args : {}
+// NOTE: args arrives as a JSON-encoded STRING (the runtime serializes it when forwarding),
+// not a parsed object — normalize before merging, else everything falls back to DEFAULT_UNIT.
+let parsedArgs = args
+if (typeof parsedArgs === 'string') {
+  try { parsedArgs = JSON.parse(parsedArgs) } catch { parsedArgs = {} }
+}
+const overrides = (parsedArgs && typeof parsedArgs === 'object' && !Array.isArray(parsedArgs)) ? parsedArgs : {}
 const unit = { ...DEFAULT_UNIT, ...overrides }
 log(`Unit: ${unit.unit_id} — ${unit.title}`)
 


### PR DESCRIPTION
## Root cause

The implementation-loop workflow silently ignored custom units passed via `/studio-implement` — both real runs fell back to `DEFAULT_UNIT` (building the already-merged config loader, doing nothing).

A no-agent probe nailed it: the runtime forwards the Workflow `args` to the script as a **JSON-encoded string**, not a parsed object —

```json
{"received":"{\"hello\": \"world\", ...}","type":"string"}
```

So `args.unit_id` was `undefined` and the `typeof args === 'object'` merge (from an earlier fix attempt) rejected the string → fallback to defaults every time.

## Fix

`JSON.parse` when `args` is a string (fallback to `{}` on parse failure), then merge over `DEFAULT_UNIT` as before. Custom units now actually drive the loop.

This is the real fix for the args plumbing flagged across #30/#31. Verified the failure mode and the string→object normalization; the next loop run with explicit args will confirm end-to-end (the `Unit:` log line will show the passed unit_id instead of the default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)