### PR TITLE
feat: wire loop config into the implementation loop (bridge + consumption + args fix)

### DIFF
--- a/.claude/commands/studio-implement.md
+++ b/.claude/commands/studio-implement.md
@@ -39,6 +39,7 @@ From `$ARGUMENTS`, construct the workflow `args`:
   - Node (`package.json`): `npm test` or the project's test script.
   - Rust (`Cargo.toml`): `cargo test`.
   - Unity / other: ask if you cannot infer a runnable command.
+  - If you cannot infer one, fall back to the config knob `test_command` from `python -m impl_loop` (Step 4).
 - `static_check` — `ruff check <path>` for Python; the project linter otherwise; omit if none.
 
 ### Step 2 — Pick the target branch (safety)
@@ -82,14 +83,21 @@ python -m impl_loop   # prints knobs JSON, e.g. {"editor_enabled": true, "read_s
 ```
 
 Then call the **Workflow** tool **by `scriptPath`** (NOT `name` — see Gotchas), merging the
-relevant knobs (`editor_enabled`, `read_scope`, `output_budget`) into the unit args:
+config knobs into the unit args:
 
 ```
 Workflow({ scriptPath: "<repo>/.claude/workflows/implementation-loop.js", args: {
-  unit_id, title, instructions, test_command, static_check,
-  editor_enabled, read_scope, output_budget   // from `python -m impl_loop`
+  unit_id, title, instructions, static_check,
+  test_command,            // per-unit inferred; if none, use the knob test_command
+  editor_enabled, read_scope, output_budget,           // from `python -m impl_loop`
+  static_checks, require_mutation_check                // from `python -m impl_loop`
 }})
 ```
+
+How the workflow consumes each knob: `editor_enabled=false` → skip the editor pass;
+`read_scope`/`output_budget` → shape the editor prompt; `require_mutation_check=false` → writer
+skips the mutation check; `static_checks=[]` → writer skips the static check and the entry gate
+doesn't require it. So passing all knobs makes `implementation_loop.toml` fully live.
 
 The workflow runs in the background and notifies on completion. Do not re-run it or poll;
 wait for the completion notification.

--- a/.claude/commands/studio-implement.md
+++ b/.claude/commands/studio-implement.md
@@ -72,19 +72,37 @@ Print a short block, then proceed (unless `--plan`):
 
 If `--plan`, stop here.
 
-### Step 4 — Run the loop
+### Step 4 — Load config knobs, then run the loop
 
-Call the **Workflow** tool with the `implementation-loop` workflow, passing the parsed unit as
-`args`:
+First read the loop config so the run honors `implementation_loop.toml` (run from the `studio/`
+package dir):
+
+```bash
+python -m impl_loop   # prints knobs JSON, e.g. {"editor_enabled": true, "read_scope": "touched+importers", "output_budget": 400, ...}
+```
+
+Then call the **Workflow** tool **by `scriptPath`** (NOT `name` — see Gotchas), merging the
+relevant knobs (`editor_enabled`, `read_scope`, `output_budget`) into the unit args:
 
 ```
-Workflow({ name: "implementation-loop", args: {
-  unit_id, title, instructions, test_command, static_check
+Workflow({ scriptPath: "<repo>/.claude/workflows/implementation-loop.js", args: {
+  unit_id, title, instructions, test_command, static_check,
+  editor_enabled, read_scope, output_budget   // from `python -m impl_loop`
 }})
 ```
 
 The workflow runs in the background and notifies on completion. Do not re-run it or poll;
 wait for the completion notification.
+
+#### Gotchas (learned the hard way — do not regress these)
+
+- **Invoke by `scriptPath`, never `name`.** `Workflow({name})` resolves a FROZEN registry snapshot
+  captured early in the session; it ignores on-disk edits to the workflow file. `scriptPath` (the
+  absolute path to `.claude/workflows/implementation-loop.js`) reads the live file.
+- **`args` reaches the workflow as a JSON string**, not an object — the workflow `JSON.parse`s it.
+  Pass args as a normal object here; just don't be surprised the workflow normalizes a string.
+- If `editor_enabled` is false (config `mandate = "off"`), the loop skips the editor pass and
+  delivers the writer's version (`editorRan: false`).
 
 ### Step 5 — Report the result
 

--- a/.claude/workflows/implementation-loop.js
+++ b/.claude/workflows/implementation-loop.js
@@ -171,7 +171,10 @@ phase('Writer')
 const writer = await agent(writerPrompt(unit), { schema: WRITER_HANDOFF, label: `writer:${unit.unit_id}`, phase: 'Writer' })
 
 // Entry gate — purely mechanical: writer declared done AND machine checks pass.
-// static check is required unless config disabled it (static_checks=[]).
+// NOTE the static-check duality: `static_checks` (config array) gates WHETHER static checking is
+// required; `static_check` (per-unit command string, used in writerPrompt) is WHAT runs. They
+// travel together today. If the schema ever consolidates on the array, drive the command off it
+// here and in writerPrompt too, so the two don't drift.
 const staticRequired = !(Array.isArray(unit.static_checks) && unit.static_checks.length === 0)
 const entryGate = !!(writer && writer.mvi_claimed && writer.tests && writer.tests.passed && (!staticRequired || writer.static_ok !== false))
 if (!writer) {

--- a/.claude/workflows/implementation-loop.js
+++ b/.claude/workflows/implementation-loop.js
@@ -132,8 +132,8 @@ function editorPrompt(u, writer) {
     `applied to code: default to deletion, name the specific cut, collapse don't accumulate, guard the essence.`,
     ``,
     `Scope of review: \`git diff ${writer.writer_sha}..\` — these are the writer's changes. Read the touched`,
-    `files (${(writer.files_touched || []).join(', ') || 'see the diff'}) and their direct importers. Do not`,
-    `wander beyond that read scope.`,
+    `files (${(writer.files_touched || []).join(', ') || 'see the diff'})${u.read_scope === 'touched' ? '' : ' and their direct importers'}.`,
+    `Do not wander beyond that read scope.`,
     ``,
     `Hard bounds:`,
     `- BEHAVIOR PRESERVATION: you may restructure and delete freely ONLY as long as the unit's tests stay green.`,
@@ -145,6 +145,7 @@ function editorPrompt(u, writer) {
     `Then render mvi_verdict: AUTHORITATIVELY judge "if we stopped here, could someone use this unit?" against`,
     `the title "${u.title}". This can overturn the writer's claim.`,
     ``,
+    `Keep your edits rationale under ${u.output_budget || 400} words.`,
     `Deliver: if you KEPT your edits (tests green, not reverted), commit them — \`git commit -am "editor: ${u.unit_id}"\``,
     `— and set committed=true. If you reverted, do NOT commit (writer_sha already holds the delivered state); set committed=false.`,
     `Persist your handoff to ${runDir(u)}/impl--${u.unit_id}--editor.json, and return the editor handoff object.`,
@@ -180,6 +181,13 @@ if (!entryGate) {
   // deliver_on_gate_fail: do not spin. Leave the writer's state, flag it.
   log(`Entry gate failed (mvi_claimed=${writer.mvi_claimed}, tests.passed=${writer.tests?.passed}). Delivering flagged, no editor pass.`)
   return { delivered: true, flagged: true, editorRan: false, writer }
+}
+
+// Config knob (editor.mandate="off" → editor_enabled=false, merged into args by /studio-implement):
+// skip the editor pass entirely and deliver the writer's version.
+if (unit.editor_enabled === false) {
+  log(`editor_enabled=false (mandate off) — delivering the writer's version, no editor pass.`)
+  return { delivered: true, flagged: false, editorRan: false, finalVersion: 'writer', writer }
 }
 
 phase('Edit')

--- a/.claude/workflows/implementation-loop.js
+++ b/.claude/workflows/implementation-loop.js
@@ -157,7 +157,13 @@ function editorPrompt(u, writer) {
 // Merge any provided args over the default unit field-by-field: provided keys win,
 // unspecified keys fall back to DEFAULT_UNIT (so partial args are safe). The log
 // makes the resolved unit visible — if args didn't arrive, this shows the default.
-const overrides = (args && typeof args === 'object' && !Array.isArray(args)) ? args : {}
+// NOTE: args arrives as a JSON-encoded STRING (the runtime serializes it when forwarding),
+// not a parsed object — normalize before merging, else everything falls back to DEFAULT_UNIT.
+let parsedArgs = args
+if (typeof parsedArgs === 'string') {
+  try { parsedArgs = JSON.parse(parsedArgs) } catch { parsedArgs = {} }
+}
+const overrides = (parsedArgs && typeof parsedArgs === 'object' && !Array.isArray(parsedArgs)) ? parsedArgs : {}
 const unit = { ...DEFAULT_UNIT, ...overrides }
 log(`Unit: ${unit.unit_id} — ${unit.title}`)
 

--- a/.claude/workflows/implementation-loop.js
+++ b/.claude/workflows/implementation-loop.js
@@ -111,9 +111,8 @@ function writerPrompt(u) {
     ``,
     `Discipline:`,
     `- Build a usable interaction, not a partial component (MVI). No speculative scope beyond the unit.`,
-    `- Hold AI-TDD: write the tests, run them, and do a mutation check — break 2-3 critical assertions,`,
-    `  confirm the tests FAIL, then restore. Report it in mutation_check.`,
-    `- Run the unit tests: \`${u.test_command}\`  and the static check: \`${u.static_check}\`.`,
+    `- Hold AI-TDD: write the tests and run them.${u.require_mutation_check === false ? ' (Mutation check disabled by config: require_mutation_check=false.)' : ' Then a mutation check — break 2-3 critical assertions, confirm the tests FAIL, then restore; report it in mutation_check.'}`,
+    `- Run the unit tests: \`${u.test_command}\`${(Array.isArray(u.static_checks) && u.static_checks.length === 0) ? ' (static check skipped — config static_checks=[]).' : `  and the static check: \`${u.static_check}\`.`}`,
     `- When (and only when) tests pass, COMMIT the passing state on the current branch`,
     `  (\`git add -A && git commit -m "writer: ${u.unit_id}"\`) and capture the short SHA — that is writer_sha.`,
     `- Persist your handoff: \`mkdir -p ${runDir(u)}\` then write it to ${runDir(u)}/impl--${u.unit_id}--writer.json.`,
@@ -172,7 +171,9 @@ phase('Writer')
 const writer = await agent(writerPrompt(unit), { schema: WRITER_HANDOFF, label: `writer:${unit.unit_id}`, phase: 'Writer' })
 
 // Entry gate — purely mechanical: writer declared done AND machine checks pass.
-const entryGate = !!(writer && writer.mvi_claimed && writer.tests && writer.tests.passed && writer.static_ok !== false)
+// static check is required unless config disabled it (static_checks=[]).
+const staticRequired = !(Array.isArray(unit.static_checks) && unit.static_checks.length === 0)
+const entryGate = !!(writer && writer.mvi_claimed && writer.tests && writer.tests.passed && (!staticRequired || writer.static_ok !== false))
 if (!writer) {
   log('Writer agent failed to return a handoff — aborting.')
   return { delivered: false, reason: 'writer_failed' }

--- a/studio/impl_loop.py
+++ b/studio/impl_loop.py
@@ -14,6 +14,7 @@ try:
     import tomllib  # Python 3.11+
 except ModuleNotFoundError:
     import tomli as tomllib  # type: ignore[no-redefine]  # Python 3.10 fallback
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List
@@ -146,3 +147,24 @@ def load_loop_config(path: Path | None = None, studio_root: Path | None = None) 
         read_scope=editor.get("read_scope", defaults.read_scope),
         output_budget=editor.get("output_budget", defaults.output_budget),
     )
+
+
+def runtime_knobs(config: LoopConfig) -> dict:
+    """Project a resolved LoopConfig onto the runtime knobs the JS workflow needs.
+
+    This is the consume side of load_loop_config(): the /studio-implement command
+    shells out to ``python -m impl_loop``, reads this dict, and merges it into the
+    workflow args. Only already-resolved config is exposed — no new fields.
+    """
+    return {
+        "editor_enabled": config.editor_enabled,
+        "test_command": config.test_command,
+        "static_checks": config.static_checks,
+        "require_mutation_check": config.require_mutation_check,
+        "read_scope": config.read_scope,
+        "output_budget": config.output_budget,
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(runtime_knobs(load_loop_config())))

--- a/studio/tests/test_impl_loop.py
+++ b/studio/tests/test_impl_loop.py
@@ -10,6 +10,7 @@ from impl_loop import (
     VALID_MANDATES,
     VALID_READ_SCOPES,
     load_loop_config,
+    runtime_knobs,
 )
 
 
@@ -192,6 +193,52 @@ def test_explicit_path_beats_resolution_chain():
             assert config.output_budget == 777
         finally:
             explicit.unlink()
+
+
+def test_runtime_knobs_default_config():
+    """runtime_knobs maps a default LoopConfig to the expected knob dict."""
+    knobs = runtime_knobs(LoopConfig())
+    assert knobs == {
+        "editor_enabled": True,
+        "test_command": "pytest -q",
+        "static_checks": ["ruff"],
+        "require_mutation_check": True,
+        "read_scope": "touched+importers",
+        "output_budget": 400,
+    }
+
+
+def test_runtime_knobs_off_mandate_disables_editor():
+    """mandate = 'off' surfaces as editor_enabled False in the knobs."""
+    knobs = runtime_knobs(LoopConfig(mandate="off"))
+    assert knobs["editor_enabled"] is False
+
+
+def test_runtime_knobs_reflects_loaded_override():
+    """Values from a loaded .studio override flow through to the knobs."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / ".studio").mkdir()
+        (root / ".studio" / "implementation_loop.toml").write_text(
+            "[gate]\n"
+            'test_command = "python -m pytest tests/ -q"\n'
+            'static_checks = ["ruff", "mypy"]\n'
+            "require_mutation_check = false\n"
+            "[editor]\n"
+            'mandate = "off"\n'
+            'read_scope = "touched"\n'
+            "output_budget = 250\n"
+        )
+        config = load_loop_config(studio_root=root)
+        knobs = runtime_knobs(config)
+        assert knobs == {
+            "editor_enabled": False,
+            "test_command": "python -m pytest tests/ -q",
+            "static_checks": ["ruff", "mypy"],
+            "require_mutation_check": False,
+            "read_scope": "touched",
+            "output_budget": 250,
+        }
 
 
 def test_load_default_loop_config():

--- a/studio/tests/test_impl_loop.py
+++ b/studio/tests/test_impl_loop.py
@@ -208,12 +208,6 @@ def test_runtime_knobs_default_config():
     }
 
 
-def test_runtime_knobs_off_mandate_disables_editor():
-    """mandate = 'off' surfaces as editor_enabled False in the knobs."""
-    knobs = runtime_knobs(LoopConfig(mandate="off"))
-    assert knobs["editor_enabled"] is False
-
-
 def test_runtime_knobs_reflects_loaded_override():
     """Values from a loaded .studio override flow through to the knobs."""
     with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## What

Closes the unused-config gap from the loop's Phase 2: `impl_loop.py`'s config is now **consumed end-to-end**, not just loadable. Includes the args-plumbing fix discovered while doing it (**supersedes #32**).

## The three layers

1. **Bridge** (`studio/impl_loop.py`) — built *by the loop itself* (`/studio-implement`): `runtime_knobs(config)` projects a `LoopConfig` into the workflow's knobs, and `python -m impl_loop` prints them as JSON. Writer + editor commits; editor cut 1 redundant test (19→18, green).
2. **Consumption** (`.claude/workflows/implementation-loop.js`) — the workflow honors the knobs: `editor.mandate="off"` → skips the editor pass (delivers writer's version); `read_scope`/`output_budget` injected into the editor prompt.
3. **Wiring** (`.claude/commands/studio-implement.md`) — `/studio-implement` reads `python -m impl_loop`, merges `editor_enabled`/`read_scope`/`output_budget` into the unit args, and invokes the loop by **`scriptPath`**.

## Args fix (was #32)

The loop ignored custom units across three runs. Two compounding harness gotchas, both pinned with ~$0 no-agent probes:

- **`Workflow({name})` resolves a FROZEN registry snapshot** — it never saw on-disk edits to the workflow. Fix: invoke by `scriptPath` (live file).
- **`args` arrives as a JSON string**, not an object. Fix: the workflow `JSON.parse`s it.

Both are now documented in the command's "Gotchas" section so they don't regress.

## Tests

`cd studio && python -m pytest tests/test_impl_loop.py -q` → 18 passed. `python -m impl_loop` emits valid knobs JSON. Workflow + probe verified that custom args resolve via `scriptPath`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)