### PR TITLE
docs: document the implementation loop (/studio-implement)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,16 @@ All runs (except `--mode questions`) include inline **decision point surfacing**
 
 The **Contrarian is an editor by default** — beyond hunting flaws and edge cases, it carries an always-on mandate to remove, merge, and simplify. The advocate piles it on; the contrarian carves out the essence (bias toward deletion, clarity, conciseness). This mandate is on in every deliverable run and stance, but deliberately **off in `--mode questions`**, where the contrarian instead judges question *relevance* and must not drop genuinely-open questions to keep the list lean.
 
+## Implementation Loop (Claude Code)
+
+The same advocate/contrarian cadence also runs during **implementation**, via `/studio-implement`:
+
+```
+/studio-implement Users can create and view a profile (hardcoded storage)
+```
+
+A **writer** agent builds one complete MVI unit and commits its passing state; a fresh **editor** agent (the `CONTRARIAN_MANDATE` applied to code) cuts/refines it against the writer's diff and reverts if an edit breaks green — a one-way pipeline gated on **"MVI unit complete AND tests green."** It runs the `.claude/workflows/implementation-loop.js` Claude Code Workflow, config-driven via `implementation_loop.toml` (editor on/off, read scope, output budget, mutation/static gates), with knobs exposed through `python -m impl_loop`. It is the executor described in `studio/docs/IMPLEMENTATION_LOOP_SPEC.md`. Status: executor + config shipped; cadence tuning (gate granularity vs. editor yield) is ongoing.
+
 ## CLI Commands
 
 ```bash
@@ -183,6 +193,7 @@ All source lives under `studio/`. `run_phase.py` is the sole entrypoint using on
 - **`install.py`** — Cross-repo installer: `init`/`check-install`/`update` copies source + slash commands into any project. Also injects coding principles into the target's `CLAUDE.md` via sentinel markers for safe updates.
 - **`offload.py`** — CLAUDE.md analyzer: classifies sections, detects embedded constraints, scores pointer strength, generates offload reports and manages canary tokens.
 - **`setup.py`** — Setup wizard: project configuration after install. Tracks setup state in `.studio/SETUP.json`, generates role overrides, scopes, and cleanup config. Supports incremental re-configuration when new features are added.
+- **`impl_loop.py`** — Implementation-loop config: `LoopConfig` dataclass + `load_loop_config()` (tomllib/tomli fallback, resolution chain explicit → `.studio/` → shipped → defaults, patterned on `scopes.py`). `runtime_knobs()` + a `python -m impl_loop` JSON CLI project the resolved config into the knobs the `.claude/workflows/implementation-loop.js` Workflow consumes (editor on/off, read scope, output budget, mutation/static gates). The only Python piece of the writer/editor implementation loop; see `studio/docs/IMPLEMENTATION_LOOP_SPEC.md`.
 - **`validators/`** — `DocumentValidator` (including `validate_question_mode()`) and `CodeValidator` for post-run quality checks.
 - **`integrations/slack_digest.py`** — Outbound run-digest notifier. Posts a finalized run's status/verdict/summary to a Slack Incoming Webhook (Block Kit) and/or an n8n Webhook node (flat JSON), stdlib `urllib` only. Config from `.studio/integrations.toml`; webhook URLs resolved from env vars (secrets never committed). Fires via the `notify` subcommand and, when enabled, auto-fires on `finalize` (soft-fail). See `studio/docs/INTEGRATIONS.md`.
 
@@ -192,12 +203,14 @@ All source lives under `studio/`. `run_phase.py` is the sole entrypoint using on
 - **`role_packs/*.json`** — Curated pod presets (e.g., `studio_core` = marketing + product + design + art + engineering + test_engineer + qa). Override with `--roles +role/-role`. Role dependencies in the manifest auto-inject co-required roles (e.g., engineering always brings test_engineer).
 - **`config/scopes.toml`** — Default three-tier scope configuration (alignment → depth → polish) with output budgets and debate modes.
 - **`config/studio_settings.toml`** — Cleanup TTL and storage limits.
+- **`config/implementation_loop.toml`** — Shipped defaults for the implementation writer/editor loop: `[loop]` (`deliver_on_gate_fail`), `[gate]` (`test_command`, `static_checks`, `require_mutation_check`), `[editor]` (`mandate`, `read_scope`, `output_budget`). Override with `.studio/implementation_loop.toml`. Loaded by `impl_loop.py`.
 - **`.studio/scopes.toml`** — Scope-based iteration budgets (auto-loaded if present).
 - **`.studio/validation.toml`** — Validation configuration.
 - **`.studio/roles/*.json`** — Project-local role overrides. Shallow-merge with manifest roles (override keys replace base, unspecified keys inherit).
 - **`.studio/personas.toml`** — Project-local single-phase persona overrides (market/design/tech/studio advocate, contrarian, notes, implementer, integrator). Per-phase shallow merge over the shipped `PHASE_DETAILS` defaults; loaded via `persona_overrides.py`, authored by the setup wizard.
 - **`.studio/integrations.toml`** — Optional outbound-webhook config for run digests. `[slack]` and `[n8n]` tables, each with `enabled` and `webhook_url_env` (env var holding the secret URL); `[n8n]` also takes optional `auth_header`/`auth_value_env` for Header Auth. Absent or no target `enabled` → notifications are off. Loaded by `integrations/slack_digest.py`.
 - **`.studio/unstale.toml`** — Optional per-repo override for the `/unstale` staleness audit: `[snapshot]` commands (`test_count`, `module_inventory`, `cli_help`) and `[audit]` globs (`doc_globs`, `source_globs`, `cross_refs`). When absent, `/unstale` self-detects the stack (Rust/Unity/Node/Python/Go) from marker files. Read directly by the `/unstale` command, not Python code.
+- **`.studio/implementation_loop.toml`** — Optional per-repo override for the implementation writer/editor loop config (shallow over `config/implementation_loop.toml`). Loaded by `impl_loop.py`; consumed by the `implementation-loop.js` Workflow via `python -m impl_loop`.
 
 ### Artifact structure
 

--- a/studio/docs/CLAUDE_CODE_USAGE.md
+++ b/studio/docs/CLAUDE_CODE_USAGE.md
@@ -375,6 +375,28 @@ Override keys replace the base; unspecified keys inherit from the manifest. Vali
 
 ---
 
+## Implementation Loop (`/studio-implement`)
+
+Brings the advocate/contrarian cadence into **implementation** — the writer/editor analogue of the planning-phase debate. One agent writes a complete unit; a fresh editor agent refines it; then it's delivered.
+
+```
+/studio-implement Users can create and view a profile (hardcoded storage)
+```
+
+How it runs:
+1. **Parse** — your request becomes one MVI unit (title, build instructions, inferred `test_command`).
+2. **Branch** — runs on a feature branch (creates `impl/<unit>` if you're on `main`); refuses a dirty tree.
+3. **Plan echo** — prints the unit + branch + test command, then runs (no separate confirmation step).
+4. **Writer** — builds the unit, runs tests + a mutation check, commits its passing state (`writer_sha`).
+5. **Editor** — a fresh agent (the `CONTRARIAN_MANDATE` applied to code) diffs against `writer_sha`, cuts/refines, re-runs tests, and **reverts** if an edit breaks green. One-way pipeline — no ping-pong.
+6. **Report** — what was built, what the editor cut, the MVI verdict, whether anything reverted.
+
+The gate is **"MVI unit complete AND tests green"**, split into an *entry* gate (writer declares done + tests/static pass → triggers the editor) and an *exit* gate (the editor's authoritative MVI verdict, which can overturn the writer's claim).
+
+**Config** — `implementation_loop.toml` (override at `.studio/implementation_loop.toml`): `mandate = "off"` disables the editor pass; `read_scope`, `output_budget`, `require_mutation_check`, `static_checks`, and `test_command` tune the loop. Knobs reach the workflow via `python -m impl_loop`.
+
+Full design, gate semantics, and portability rationale: [`IMPLEMENTATION_LOOP_SPEC.md`](IMPLEMENTATION_LOOP_SPEC.md). (Implementation note: the command invokes the `.claude/workflows/implementation-loop.js` Workflow by `scriptPath`, not by `name` — the latter resolves a frozen registry snapshot.)
+
 ## Utility Slash Commands
 
 In addition to phase runners, these slash commands are available:

--- a/studio/docs/IMPLEMENTATION_LOOP_SPEC.md
+++ b/studio/docs/IMPLEMENTATION_LOOP_SPEC.md
@@ -1,8 +1,10 @@
 # Implementation Writer/Editor Loop — Spec
 
-> **Status: design, not yet built.** This document specifies a feature. Nothing here is wired
-> into `run_phase.py` or shipped as config yet. It exists so the design can be reviewed before
-> any code is written. The "Build phases" section at the end is the implementation path.
+> **Status: shipped (executor + config); cadence tuning ongoing.** The Workflow shell
+> (`.claude/workflows/implementation-loop.js`), the `/studio-implement` trigger, and the config
+> loader (`studio/impl_loop.py` + `config/implementation_loop.toml`) are built and merged. What
+> remains is the cadence lab — tuning gate granularity against the success/kill metric. This doc
+> is the design of record; the "Build phases" section tracks what's done.
 >
 > Refined once via a Product + Engineering role pass (see "Refinement log").
 
@@ -262,20 +264,23 @@ value lives in config, the tuning result survives any later port.
 Each phase must end in something usable (the feature's own MVI rule applies to its build). Each is
 gated on reviewing the one before it.
 
-1. **Runnable loop on one unit** — the Claude Workflow shell + the minimum gate glue (run
-   `test_command`, `ruff`, aggregate to bool, writer commit + revert), driving one small real MVI
-   unit end-to-end. Config may be inlined/minimal here. **This is the first deliverable** because a
-   config no executor reads is a wheel, not a skateboard — and the core hypothesis (is the editor
-   pass worth its cost?) can't be tested without a running loop.
-2. **Extract config + harden** — pull the inlined settings into
-   `studio/config/implementation_loop.toml` + `studio/impl_loop.py` (`LoopConfig` +
-   `load_loop_config()`), patterned on `scopes.py`, with loader tests mirroring the scopes tests
-   (valid parses, missing → defaults, bad TOML → clear error, `.studio/` overrides default).
-3. **Cadence lab** — capture the no-editor baseline, run real units, tune granularity against the
-   success/kill metric, write the result back into config.
+1. ✅ **Runnable loop on one unit** — the Claude Workflow shell + gate glue (run `test_command`,
+   `ruff`, writer commit + revert), driving a real MVI unit end-to-end. *Done* — the loop built its
+   own config loader as the first real run.
+2. ✅ **Extract config + harden** — `studio/config/implementation_loop.toml` + `studio/impl_loop.py`
+   (`LoopConfig` + `load_loop_config()`), patterned on `scopes.py`, with loader tests. Plus
+   `runtime_knobs()` / `python -m impl_loop` so the workflow consumes the config, and the
+   `/studio-implement` command. *Done.*
+3. ⏳ **Cadence lab** — capture the no-editor baseline, run real units, tune granularity against the
+   success/kill metric, write the result back into config. *Pending* — only ~2 data points so far.
 
-When the loop ships, the documentation contract applies: update `CLAUDE.md` (Architecture) and
-`CLAUDE_CODE_USAGE.md` alongside it.
+The documentation contract is satisfied: `CLAUDE.md` (Architecture + Implementation Loop section)
+and `CLAUDE_CODE_USAGE.md` (`/studio-implement` section) document the shipped loop.
+
+> **Implementation gotchas** (cost three no-op runs to find; documented in
+> `.claude/commands/studio-implement.md`): `Workflow({name})` resolves a *frozen registry snapshot*
+> and ignores on-disk edits — invoke by `scriptPath`; and the Workflow `args` arrive as a *JSON
+> string*, not an object — the workflow `JSON.parse`s them.
 
 ## Refinement log
 

--- a/studio/docs/INDEX.md
+++ b/studio/docs/INDEX.md
@@ -15,6 +15,7 @@
 - **[TEST_DRIVEN_GUIDE.md](./TEST_DRIVEN_GUIDE.md)** - Test-driven discipline for tech phase
 - **[AI_TDD_METHODOLOGY.md](./AI_TDD_METHODOLOGY.md)** - Full AI-TDD methodology (scenario-first, stack boundary, mutation verification)
 - **[MVI_METHODOLOGY.md](./MVI_METHODOLOGY.md)** - Minimum Viable Interaction — every milestone ends in something usable
+- **[IMPLEMENTATION_LOOP_SPEC.md](./IMPLEMENTATION_LOOP_SPEC.md)** - Writer/editor implementation loop (`/studio-implement`): design, gate semantics, config knobs
 - **[STORAGE_MANAGEMENT.md](./STORAGE_MANAGEMENT.md)** - Cleanup, TTL, and storage budgets
 
 ## Integration


### PR DESCRIPTION
## Why

The writer/editor implementation loop shipped across #30/#31/#33, but the usage docs hadn't caught up — closing the MVI docs gate (a milestone isn't done without usage docs).

## Changes (docs only)

- **CLAUDE.md** — new "Implementation Loop (Claude Code)" section; `impl_loop.py` in Core modules; `config/implementation_loop.toml` + `.studio/implementation_loop.toml` in Configuration files.
- **CLAUDE_CODE_USAGE.md** — a `/studio-implement` section: the 6-step flow, the entry/exit gate, and the config knobs.
- **INDEX.md** — link `IMPLEMENTATION_LOOP_SPEC.md` under Workflow Features (it was unlinked).
- **IMPLEMENTATION_LOOP_SPEC.md** — status flipped from "design, not yet built" → "shipped; cadence tuning ongoing"; build phases 1–2 marked done, 3 pending; the `scriptPath` / JSON-string-`args` gotchas folded in.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)