### PR TITLE
feat: add web_product role to manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to TheGameStudio are documented here.
 - `/unstale` Agent 5 — project tracking audit (GitHub Issues + local tracking files) with permission-gated destructive actions
 - Stack-agnostic `/unstale` — the command now self-detects the project stack (Rust/Unity/Node/Python/Go) from marker files instead of assuming the Studio Python layout, so it works in any installed repo. Optional per-repo `.studio/unstale.toml` override pins exact snapshot commands and audit globs; authored by a new setup wizard `unstale_config` step (`CURRENT_SETUP_VERSION` 3) via `suggest_unstale_from_stack`
 - `ai_engineer` role in manifest — Staff AI Engineer specializing in prompt architecture & agent optimization
+- `web_product` role in manifest — Director of Product (Web Platforms & Creator Tools): opportunity framing (ICP/JTBD), build-vs-fork-vs-buy with licensing implications, MVI-gated roadmaps. Completes the `web_*` role set so downstream packs that list it survive updates (#35)
 - `/studio-setup` slash command + `setup` CLI subcommand — post-install wizard for role pack selection, role customization, scope tuning, and cleanup settings with incremental versioned steps (`setup.py`, 43 tests)
 - `docs/CODING_PRINCIPLES.md` — standalone Karpathy-inspired principles file, shipped with cross-repo installs
 - Cross-repo install now injects coding principles into target's `CLAUDE.md` via sentinel markers (`<!-- STUDIO:CODING_PRINCIPLES:BEGIN/END -->`), with idempotent update support (6 tests)

--- a/studio/studio.manifest.json
+++ b/studio/studio.manifest.json
@@ -181,6 +181,24 @@
         "Asset loading failures on GitHub Pages"
       ]
     },
+    "web_product": {
+      "title": "Director of Product — Web Platforms & Creator Tools",
+      "advocate_focus": "Frame the opportunity for a web product/platform: who it's for (ICP), the job-to-be-done, positioning vs existing tools, build-vs-fork-vs-buy tradeoffs, monetization and licensing fit, and a roadmap where every milestone ends in a shippable MVI (Minimum Viable Interaction) — something a user can actually use, not a partial component.",
+      "contrarian_focus": "Challenge market assumptions, undifferentiated 'me too' positioning, vague ICP, licensing/IP traps (e.g. copyleft/AGPL obligations when forking), monetization hand-waving, and MVI violations. Reject roadmaps where any milestone ends in an unusable state, or where 'extract as a reusable platform' is assumed before the single-user product is proven.",
+      "prompt_doc": "",
+      "deliverables": [
+        "Opportunity framing (ICP, JTBD, positioning vs alternatives)",
+        "Build-vs-fork-vs-buy recommendation with explicit licensing implications",
+        "Phased roadmap where every milestone ends in a usable MVI",
+        "Success/kill metrics and explicit scope cuts"
+      ],
+      "escalate_on": [
+        "Licensing/IP obligations that conflict with the product's distribution model",
+        "Platform/extraction work prioritized before the core single-user product is validated",
+        "Milestone that ends in an unusable state (violates MVI)",
+        "No differentiation vs existing open-source or commercial tools"
+      ]
+    },
     "ml": {
       "title": "ML Systems Lead",
       "advocate_focus": "Design and deliver the AI critique engine with measurable quality and cost control.",


### PR DESCRIPTION
Adds the **`web_product`** role (Director of Product — Web Platforms & Creator Tools) to `studio/studio.manifest.json`, alongside the existing `web_engineering` / `web_test_engineer` / `web_qa`.

**Why:** the role was only defined in downstream installs. Because `studio.manifest.json` is in `install.py`'s `SOURCE_FILES`, every `update`/`init` overwrote the downstream manifest with upstream's and silently dropped `web_product`, breaking any pack that lists it (e.g. an `orcpunk_web` pod) and forcing a manual re-merge after each update.

**Change:** one role definition added to the manifest (18 lines) + a CHANGELOG entry. No code changes.

Closes #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)