### PR TITLE
feat(install): ship the implementation loop to all installed repos

### DIFF
--- a/.claude/commands/studio-implement.md
+++ b/.claude/commands/studio-implement.md
@@ -75,22 +75,27 @@ If `--plan`, stop here.
 
 ### Step 4 — Load config knobs, then run the loop
 
-First read the loop config so the run honors `implementation_loop.toml` (run from the `studio/`
-package dir):
+**Studio path:** use `.studio/source/impl_loop.py` for the command below. If that file does not
+exist but `studio/impl_loop.py` does, use that instead (you are in the Studio source repo).
+
+Read the loop config knobs. If the repo has a project override at `.studio/implementation_loop.toml`,
+pass it explicitly (it lives at the repo root, outside the snapshot's resolution chain); otherwise
+run with no arg (shipped default → built-in defaults):
 
 ```bash
-python -m impl_loop   # prints knobs JSON, e.g. {"editor_enabled": true, "read_scope": "touched+importers", "output_budget": 400, ...}
+python .studio/source/impl_loop.py [.studio/implementation_loop.toml]
+# prints knobs JSON, e.g. {"editor_enabled": true, "read_scope": "touched+importers", "output_budget": 400, ...}
 ```
 
-Then call the **Workflow** tool **by `scriptPath`** (NOT `name` — see Gotchas), merging the
-config knobs into the unit args:
+Then call the **Workflow** tool **by `scriptPath`** (NOT `name` — see Gotchas), pointing at this
+repo's copy of the workflow and merging the config knobs into the unit args:
 
 ```
 Workflow({ scriptPath: "<repo>/.claude/workflows/implementation-loop.js", args: {
   unit_id, title, instructions, static_check,
   test_command,            // per-unit inferred; if none, use the knob test_command
-  editor_enabled, read_scope, output_budget,           // from `python -m impl_loop`
-  static_checks, require_mutation_check                // from `python -m impl_loop`
+  editor_enabled, read_scope, output_budget,           // from impl_loop.py
+  static_checks, require_mutation_check                // from impl_loop.py
 }})
 ```
 

--- a/.claude/workflows/implementation-loop.js
+++ b/.claude/workflows/implementation-loop.js
@@ -127,8 +127,9 @@ function editorPrompt(u, writer) {
   return [
     `You are the EDITOR in an implementation writer/editor loop — a fresh agent reviewing the writer's unit.`,
     ``,
-    `Your mandate IS the CONTRARIAN_MANDATE defined in studio/scopes.py (read lines ~27-37 and adopt it),`,
-    `applied to code: default to deletion, name the specific cut, collapse don't accumulate, guard the essence.`,
+    `Your mandate IS the CONTRARIAN_MANDATE defined in scopes.py — read it at \`.studio/source/scopes.py\``,
+    `(installed repos) or \`studio/scopes.py\` (the Studio source repo), and adopt it: applied to code,`,
+    `default to deletion, name the specific cut, collapse don't accumulate, guard the essence.`,
     ``,
     `Scope of review: \`git diff ${writer.writer_sha}..\` — these are the writer's changes. Read the touched`,
     `files (${(writer.files_touched || []).join(', ') || 'see the diff'})${u.read_scope === 'touched' ? '' : ' and their direct importers'}.`,

--- a/studio/impl_loop.py
+++ b/studio/impl_loop.py
@@ -166,5 +166,18 @@ def runtime_knobs(config: LoopConfig) -> dict:
     }
 
 
+def _cli(argv: List[str]) -> str:
+    """Return the runtime-knobs JSON for the CLI.
+
+    Optional ``argv[1]`` is an explicit config path — used by /studio-implement to
+    pass an installed repo's ``.studio/implementation_loop.toml`` (the project override
+    lives at the target root, outside this snapshot's resolution chain). With no arg,
+    the normal resolution chain runs (shipped default → built-in defaults).
+    """
+    path = Path(argv[1]) if len(argv) > 1 else None
+    return json.dumps(runtime_knobs(load_loop_config(path)))
+
+
 if __name__ == "__main__":
-    print(json.dumps(runtime_knobs(load_loop_config())))
+    import sys
+    print(_cli(sys.argv))

--- a/studio/install.py
+++ b/studio/install.py
@@ -40,6 +40,7 @@ SOURCE_FILES = [
     "offload.py",
     "clarity.py",
     "setup.py",
+    "impl_loop.py",
     "studio.manifest.json",
     "validators/__init__.py",
     "validators/document_validator.py",
@@ -48,6 +49,7 @@ SOURCE_FILES = [
     "integrations/slack_digest.py",
     "config/scopes.toml",
     "config/studio_settings.toml",
+    "config/implementation_loop.toml",
     "docs/STUDIO_BRIDGE_TEMPLATE.md",
     "docs/CODING_PRINCIPLES.md",
 ]
@@ -65,6 +67,12 @@ SLASH_COMMANDS = [
     "detest.md",
     "offload.md",
     "studio-setup.md",
+    "studio-implement.md",
+]
+
+# Claude Code Workflows to copy to {target}/.claude/workflows/ (verbatim, like commands)
+WORKFLOW_FILES = [
+    "implementation-loop.js",
 ]
 
 # Sentinels for CLAUDE.md injection — update replaces content between these markers
@@ -264,6 +272,7 @@ def install_studio(target: Path, studio_dir: Optional[Path] = None) -> Path:
     Creates:
         {target}/.studio/source/     — Studio Python source + config
         {target}/.claude/commands/    — Slash commands (verbatim, use .studio/source/ paths)
+        {target}/.claude/workflows/   — Claude Code workflows (verbatim, resolve .studio/source/ at run time)
         {target}/.studio/VERSION      — Version info
         {target}/.studio/MANIFEST.json — Install manifest with checksums
 
@@ -298,6 +307,19 @@ def install_studio(target: Path, studio_dir: Optional[Path] = None) -> Path:
         if not src.exists():
             continue
         dst = commands_dest / cmd_name
+        if dst.exists() and src.samefile(dst):
+            continue
+        shutil.copy2(src, dst)
+
+    # Copy Claude Code workflows verbatim (they resolve .studio/source/ paths at run time)
+    workflows_dest = target / ".claude" / "workflows"
+    workflows_src = studio_dir.parent / ".claude" / "workflows"
+    for wf_name in WORKFLOW_FILES:
+        src = workflows_src / wf_name
+        if not src.exists():
+            continue
+        workflows_dest.mkdir(parents=True, exist_ok=True)
+        dst = workflows_dest / wf_name
         if dst.exists() and src.samefile(dst):
             continue
         shutil.copy2(src, dst)

--- a/studio/tests/test_impl_loop.py
+++ b/studio/tests/test_impl_loop.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Tests for the implementation writer/editor loop config loader."""
+import json
 import tempfile
 from pathlib import Path
 
@@ -9,6 +10,7 @@ from impl_loop import (
     LoopConfig,
     VALID_MANDATES,
     VALID_READ_SCOPES,
+    _cli,
     load_loop_config,
     runtime_knobs,
 )
@@ -249,3 +251,31 @@ def test_load_default_loop_config():
     assert config.mandate == "contrarian"
     assert config.read_scope == "touched+importers"
     assert config.output_budget == 400
+
+
+def test_cli_no_arg_emits_default_knobs():
+    """`impl_loop.py` with no arg prints the default runtime knobs as JSON."""
+    knobs = json.loads(_cli(["impl_loop.py"]))
+    assert knobs["editor_enabled"] is True
+    assert knobs["read_scope"] == "touched+importers"
+    assert knobs["output_budget"] == 400
+
+
+def test_cli_explicit_path_reflects_override():
+    """An explicit config path arg flows into the emitted knobs.
+
+    This is how /studio-implement passes an installed repo's project override
+    (`.studio/implementation_loop.toml`), which lives outside the snapshot chain.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg = Path(tmp) / "implementation_loop.toml"
+        cfg.write_text('[editor]\nmandate = "off"\noutput_budget = 99\n')
+        knobs = json.loads(_cli(["impl_loop.py", str(cfg)]))
+        assert knobs["editor_enabled"] is False
+        assert knobs["output_budget"] == 99
+
+
+def test_cli_explicit_missing_path_raises():
+    """A typo'd explicit config path is loud, not silently defaulted."""
+    with pytest.raises(FileNotFoundError):
+        _cli(["impl_loop.py", "/nonexistent/implementation_loop.toml"])

--- a/studio/tests/test_install.py
+++ b/studio/tests/test_install.py
@@ -91,6 +91,21 @@ class TestInstallStudio:
         assert (source / "config" / "scopes.toml").is_file()
         assert (source / "studio.manifest.json").is_file()
 
+    def test_ships_implementation_loop(self, target_dir, studio_dir):
+        """Install ships the writer/editor loop: source, config, command, workflow."""
+        install_studio(target_dir, studio_dir)
+        source = target_dir / ".studio" / "source"
+        # Python source + shipped config default
+        assert (source / "impl_loop.py").is_file()
+        assert (source / "config" / "implementation_loop.toml").is_file()
+        # Slash command
+        assert (target_dir / ".claude" / "commands" / "studio-implement.md").is_file()
+        # Claude Code workflow (copied verbatim, like commands)
+        wf = target_dir / ".claude" / "workflows" / "implementation-loop.js"
+        assert wf.is_file()
+        src_wf = studio_dir.parent / ".claude" / "workflows" / "implementation-loop.js"
+        assert wf.read_text() == src_wf.read_text()
+
     def test_copies_role_packs(self, target_dir, studio_dir):
         """Install copies role pack JSON files."""
         install_studio(target_dir, studio_dir)


### PR DESCRIPTION
## Why

`/studio-implement` worked only in the Studio source repo — the cross-repo installer shipped none of its machinery (no command, no `impl_loop.py`/config, no workflow-copy mechanism at all). Now that the loop is proven, open it to every repo that installs Studio.

## Changes

**Installer (`install.py`)** — `init` and `update` (which delegates to `install_studio`):
- `SOURCE_FILES` += `impl_loop.py` + `config/implementation_loop.toml` → `.studio/source/`.
- `SLASH_COMMANDS` += `studio-implement.md`.
- New `WORKFLOW_FILES` + a copy step → `.claude/workflows/implementation-loop.js` (verbatim, mirroring how commands are shipped).

**Path portability** — these files are copied verbatim, so they must resolve the *installed* layout (`.studio/source/`, not `studio/`):
- `studio-implement.md` runs `.studio/source/impl_loop.py` (falls back to `studio/impl_loop.py` in the source repo) and points `scriptPath` at the repo's own `.claude/workflows/implementation-loop.js`.
- `implementation-loop.js` editor prompt reads `CONTRARIAN_MANDATE` from `.studio/source/scopes.py` (or `studio/scopes.py`).

**Target-repo config override** — `impl_loop.py`'s CLI (`_cli`) now takes an optional config path, so the command passes `<repo>/.studio/implementation_loop.toml` when present (the project override lives at the target root, outside the snapshot's resolution chain). Loud on a typo'd path; defaults otherwise.

## Tests

- Install ships source + config + command + workflow (verbatim match).
- CLI: explicit path flows through / loud on missing / defaults with no arg.
- **607 pass** (full suite).

## Rollout

Existing installs pick it up via `/studio-update` (the new source files show as an available update; the command + workflow copy on re-install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)