### PR TITLE
fix: cross-repo CLI hardening (config resolution, error UX, hints, install gaps)

### DIFF
--- a/.claude/commands/run-studio-phase.md
+++ b/.claude/commands/run-studio-phase.md
@@ -152,7 +152,7 @@ python ".studio/source/run_phase.py" inject-context --run-dir {run_dir} --scope 
 > - {List specific S2 files this role needs per the dependency map}
 > - Condensed brief of all other roles: `{run_dir}/S2-brief.md`
 >
-> {If this role has a prompt doc, read it at `.studio/source/{prompt_doc}` for detailed guidance.}
+> {If this role has a prompt doc (the `prompt_doc` shown in the Role Menu), read it at that path — it is relative to the repo root (a doc that lives in THIS project), not the Studio snapshot.}
 >
 > Write a thorough proposal covering all required deliverables. No word cap — this is the full analysis.
 > Save to `{run_dir}/advocate--{role}--S2-01.md`.

--- a/.claude/commands/studio-update.md
+++ b/.claude/commands/studio-update.md
@@ -20,6 +20,12 @@ python ".studio/source/run_phase.py" check-install --target .
 
 If already up to date, tell the user and stop.
 
+**If the output contains a `WARNING:` line** (e.g. "running from the installed snapshot … cannot
+compare against live source"), the check/update is running against the snapshot and cannot see the
+real upstream — so it may report "up to date" when it isn't. In that case, tell the user to run the
+update from the upstream Studio source repo instead:
+`python studio/run_phase.py update --target <this-repo>`. Do not trust the result until then.
+
 ### Step 3: Update
 
 ```bash

--- a/studio/impl_loop.py
+++ b/studio/impl_loop.py
@@ -13,7 +13,13 @@ from __future__ import annotations
 try:
     import tomllib  # Python 3.11+
 except ModuleNotFoundError:
-    import tomli as tomllib  # type: ignore[no-redefine]  # Python 3.10 fallback
+    try:
+        import tomli as tomllib  # type: ignore[no-redefine]  # Python 3.10 fallback
+    except ModuleNotFoundError:
+        raise SystemExit(
+            "Studio needs the 'tomli' package on Python 3.10. "
+            "Install it with: python -m pip install tomli  (or upgrade to Python 3.11+)."
+        )
 import json
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/studio/install.py
+++ b/studio/install.py
@@ -52,6 +52,7 @@ SOURCE_FILES = [
     "config/implementation_loop.toml",
     "docs/STUDIO_BRIDGE_TEMPLATE.md",
     "docs/CODING_PRINCIPLES.md",
+    "docs/SCOPES_GUIDE.md",
 ]
 
 # Glob patterns for additional files
@@ -241,6 +242,7 @@ def _inject_principles_into_claude_md(target: Path, studio_dir: Path) -> None:
 
     if not claude_md.exists():
         claude_md.write_text(block + "\n", encoding="utf-8")
+        print(f"  Created {claude_md} (Studio coding principles only — add your project notes).")
         return
 
     content = claude_md.read_text(encoding="utf-8")

--- a/studio/run_phase.py
+++ b/studio/run_phase.py
@@ -75,7 +75,13 @@ from integrations.slack_digest import load_integrations_config, notify_run
 try:
     import tomllib  # Python 3.11+
 except ModuleNotFoundError:
-    import tomli as tomllib  # type: ignore[no-redefine]  # Python 3.10 fallback
+    try:
+        import tomli as tomllib  # type: ignore[no-redefine]  # Python 3.10 fallback
+    except ModuleNotFoundError:
+        raise SystemExit(
+            "Studio needs the 'tomli' package on Python 3.10. "
+            "Install it with: python -m pip install tomli  (or upgrade to Python 3.11+)."
+        )
 
 
 def get_storage_stats() -> dict:
@@ -224,6 +230,15 @@ def get_studio_root() -> Path:
     return Path(__file__).resolve().parent
 
 
+def _entrypoint() -> str:
+    """How to invoke this CLI in next-step hints — echoes the path as actually called,
+    so hints copy-paste correctly in both the source repo (``studio/run_phase.py``) and
+    installed repos (``.studio/source/run_phase.py``) instead of a bare ``run_phase.py``.
+    """
+    argv0 = sys.argv[0] if sys.argv and sys.argv[0] else "run_phase.py"
+    return f"python {argv0}"
+
+
 _artifact_root_override: Path | None = None
 _artifact_root_warned: bool = False
 
@@ -232,6 +247,29 @@ def set_artifact_root(path: Path | None) -> None:
     """Set an explicit artifact root (used by --artifact-root CLI flag)."""
     global _artifact_root_override
     _artifact_root_override = path
+
+
+def _installed_repo_root(studio_root: Path) -> Path | None:
+    """Return the consuming repo root when studio_root is an installed snapshot.
+
+    Installed layout places the source at ``<repo>/.studio/source``; the artifact
+    root is then ``<repo>``, not the snapshot dir.
+    """
+    if studio_root.name == "source" and studio_root.parent.name == ".studio":
+        return studio_root.parent.parent
+    return None
+
+
+def _find_installed_root_upwards(start: Path) -> Path | None:
+    """Walk up from ``start`` for an installed repo root (has ``.studio/VERSION``).
+
+    Lets a CLI call from a monorepo subdirectory resolve to the real repo root
+    instead of scaffolding a fresh, unconfigured ``.studio/`` in the subdir.
+    """
+    for d in [start, *start.parents]:
+        if (d / ".studio" / "VERSION").is_file():
+            return d
+    return None
 
 
 def get_artifact_root() -> Path:
@@ -244,8 +282,24 @@ def get_artifact_root() -> Path:
 
     studio_root = get_studio_root().resolve()
     cwd = Path.cwd().resolve()
+    installed_root = _installed_repo_root(studio_root)
+
     if cwd == studio_root or _is_within(cwd, studio_root):
-        return studio_root
+        # Running from the source tree (or from inside an installed snapshot).
+        # In the source repo the artifact root IS the studio dir; in an installed
+        # snapshot it's the consuming repo root, never the snapshot itself.
+        return installed_root if installed_root is not None else studio_root
+
+    # Anywhere under an init'd repo (e.g. a monorepo subdir): resolve to its root.
+    found = _find_installed_root_upwards(cwd)
+    if found is not None:
+        return found
+
+    # cwd is already a scaffolded/installed repo root — defaulting to it is correct.
+    if (cwd / ".studio").is_dir():
+        return cwd
+
+    # Genuine first run in a fresh external repo with no .studio/: default to cwd, warn once.
     global _artifact_root_warned
     if not _artifact_root_warned:
         print(
@@ -1045,13 +1099,15 @@ def _resolve_scopes(args: argparse.Namespace):
     if args.no_scopes:
         return None, None, None
 
-    # Determine scopes path
+    # Determine scopes path. Project-local config lives at the artifact root
+    # (<repo>/.studio/), like roles/personas/clarity/integrations — NOT the source
+    # snapshot. The shipped default stays under the source dir.
     if args.scopes:
         scopes_path = Path(args.scopes)
         if not scopes_path.is_absolute():
-            scopes_path = get_studio_root() / scopes_path
+            scopes_path = get_artifact_root() / scopes_path
     else:
-        default_scopes = get_studio_root() / ".studio" / "scopes.toml"
+        default_scopes = get_artifact_root() / ".studio" / "scopes.toml"
         if default_scopes.exists():
             scopes_path = default_scopes
         else:
@@ -1084,7 +1140,7 @@ def _resolve_scopes(args: argparse.Namespace):
             f"To fix:\n"
             f"1. Create .studio/scopes.toml with scope definitions, or\n"
             f"2. Use --no-scopes to disable scope-based iteration, or\n"
-            f"3. See docs/SCOPES_GUIDE.md for examples"
+            f"3. See .studio/source/docs/SCOPES_GUIDE.md for examples"
         ) from exc
     except ValueError as exc:
         raise RuntimeError(
@@ -1092,7 +1148,7 @@ def _resolve_scopes(args: argparse.Namespace):
             f"To fix:\n"
             f"1. Check TOML syntax in your scopes config\n"
             f"2. Ensure all scopes have 'focus' and 'max_iterations' fields\n"
-            f"3. See docs/SCOPES_GUIDE.md for valid examples"
+            f"3. See .studio/source/docs/SCOPES_GUIDE.md for valid examples"
         ) from exc
 
 
@@ -1128,36 +1184,48 @@ def _build_run_meta(
     return meta
 
 
-def _scaffold_external_repo(artifact_root: Path, studio_root: Path) -> None:
-    """Create .studio/ structure and bridge doc in an external repo on first use."""
-    studio_dir = artifact_root / ".studio"
-    if studio_dir.exists():
+def _ensure_bridge_doc(artifact_root: Path, studio_root: Path) -> None:
+    """Create the project bridge doc if none exists yet.
+
+    Kept separate from the .studio/ scaffold guard: an ``init``-installed repo already
+    has .studio/ (so the scaffold short-circuits), but still needs its bridge doc — so
+    this runs regardless of whether .studio/ pre-existed.
+    """
+    bridge_candidates = [
+        artifact_root / "docs" / "studio-bridge.md",
+        artifact_root / "studio-bridge.md",
+    ]
+    if any(c.exists() for c in bridge_candidates):
         return
+    template_path = studio_root / "docs" / "STUDIO_BRIDGE_TEMPLATE.md"
+    if not template_path.exists():
+        return
+    dest = artifact_root / "docs" / "studio-bridge.md"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    template = template_path.read_text(encoding="utf-8")
+    template = template.replace(
+        'export STUDIO_ROOT="/path/to/studio"',
+        f'export STUDIO_ROOT="{studio_root}"',
+    )
+    dest.write_text(template, encoding="utf-8")
+    print(f"  Created bridge doc: {dest}")
+    print(f"  Fill in the canon table and project summary.")
+
+
+def _scaffold_external_repo(artifact_root: Path, studio_root: Path) -> None:
+    """Ensure .studio/ structure and the bridge doc exist in an external repo."""
+    studio_dir = artifact_root / ".studio"
+    fresh = not studio_dir.exists()
 
     studio_dir.mkdir(parents=True, exist_ok=True)
     (studio_dir / "output").mkdir(exist_ok=True)
     (studio_dir / "knowledge").mkdir(exist_ok=True)
 
-    # Copy bridge template if no bridge doc exists
-    bridge_candidates = [
-        artifact_root / "docs" / "studio-bridge.md",
-        artifact_root / "studio-bridge.md",
-    ]
-    if not any(c.exists() for c in bridge_candidates):
-        template_path = studio_root / "docs" / "STUDIO_BRIDGE_TEMPLATE.md"
-        if template_path.exists():
-            dest = artifact_root / "docs" / "studio-bridge.md"
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            template = template_path.read_text(encoding="utf-8")
-            template = template.replace(
-                'export STUDIO_ROOT="/path/to/studio"',
-                f'export STUDIO_ROOT="{studio_root}"',
-            )
-            dest.write_text(template, encoding="utf-8")
-            print(f"  Created bridge doc: {dest}")
-            print(f"  Fill in the canon table and project summary.")
+    # Bridge doc is ensured even for init'd repos (where .studio/ already existed).
+    _ensure_bridge_doc(artifact_root, studio_root)
 
-    print(f"  Initialized .studio/ in {artifact_root}")
+    if fresh:
+        print(f"  Initialized .studio/ in {artifact_root}")
 
 
 def prepare_run(args: argparse.Namespace) -> str:
@@ -1236,7 +1304,7 @@ def prepare_run(args: argparse.Namespace) -> str:
         print(f"\n💡 Tip: Scopes are active. Work through {scopes_meta['scopes'][0]['name']} scope first.")
     else:
         print(f"\n💡 Tip: Want to optimize iteration budgets? Create .studio/scopes.toml")
-        print(f"   See: docs/SCOPES_GUIDE.md")
+        print(f"   See: .studio/source/docs/SCOPES_GUIDE.md")
 
     # Append to usage log (fail silently — don't break prepare over logging)
     try:
@@ -1255,8 +1323,8 @@ def prepare_run(args: argparse.Namespace) -> str:
     if storage_stats.get("cleanup_suggested", False):
         print(f"\n🧹 Storage Tip: You have {storage_stats['total_size_mb']}MB of Studio artifacts")
         print(f"   (oldest: {storage_stats['oldest_artifact_days']} days ago). Consider cleanup:")
-        print(f"   python run_phase.py cleanup --dry-run  # Preview what would be deleted")
-        print(f"   python run_phase.py cleanup           # Execute cleanup")
+        print(f"   {_entrypoint()} cleanup --dry-run  # Preview what would be deleted")
+        print(f"   {_entrypoint()} cleanup           # Execute cleanup")
 
     return run_id
 
@@ -1345,7 +1413,7 @@ def finalize_run(args: argparse.Namespace) -> None:
     # Contextual hints for next steps
     if meta['status'] == 'COMPLETED' and meta.get('verdict') == 'APPROVED':
         print(f"\n💡 Next steps:")
-        print(f"   1. Validate outputs: python run_phase.py validate --run-id {run_id}")
+        print(f"   1. Validate outputs: {_entrypoint()} validate --phase {phase} --run-id {run_id}")
         print(f"   2. Review summary: {run_dir}/summary.md")
         if phase != 'studio':
             print(f"   3. Implement recommendations from the run")
@@ -1864,10 +1932,10 @@ def validate_run(args: argparse.Namespace) -> None:
     if not run_dir.exists():
         raise FileNotFoundError(f"Run directory not found: {run_dir}")
     
-    # Load validation config
+    # Load validation config (project-local lives at the artifact root, not the snapshot)
     config_path = args.config
     if not config_path:
-        config_path = get_studio_root() / ".studio" / "validation.toml"
+        config_path = get_artifact_root() / ".studio" / "validation.toml"
     
     if not config_path.exists():
         print(f"Warning: Validation config not found at {config_path}")
@@ -2242,7 +2310,7 @@ def _prompt_for_rating(run_dir: Path) -> None:
     finalize via a non-interactive shell — never blocks on stdin.
     """
     nudge = (
-        f"   python run_phase.py rate --run-dir {run_dir} "
+        f"   {_entrypoint()} rate --run-dir {run_dir} "
         f"--score <1-5> --note \"...\""
     )
     if not sys.stdin.isatty():
@@ -2552,6 +2620,14 @@ def inject_context(args: argparse.Namespace) -> None:
                     (i for i, s in enumerate(scopes_config.scopes) if s.name == scope.name),
                     0,
                 )
+        else:
+            # The run recorded a scopes config that no longer resolves (e.g. moved, or a
+            # path from another machine). Don't silently drop scope guidance — say so.
+            print(
+                f"Warning: scopes config {scopes_path} (from run.json) not found; "
+                "emitting context without scope guidance.",
+                file=sys.stderr,
+            )
 
     # Resolve role details from manifest via existing utility
     manifest = load_manifest(studio_root)
@@ -2713,7 +2789,7 @@ def _do_check_install(args: argparse.Namespace) -> None:
     status = check_studio(target)
     if not status["installed"]:
         print(f"Studio is NOT installed at {target}")
-        print("Run: python run_phase.py init --target " + str(target))
+        print(f"Run: {_entrypoint()} init --target {target}")
         return
     if status.get("warning"):
         print(f"WARNING: {status['warning']}\n")
@@ -2725,7 +2801,7 @@ def _do_check_install(args: argparse.Namespace) -> None:
             print(f"  Changed: {', '.join(status['changed'])}")
         if status["missing"]:
             print(f"  Missing: {', '.join(status['missing'])}")
-        print(f"\nRun: python run_phase.py update --target {target}")
+        print(f"\nRun: {_entrypoint()} update --target {target}")
 
 
 def _do_update(args: argparse.Namespace) -> None:
@@ -2845,14 +2921,7 @@ def do_offload(args: argparse.Namespace) -> None:
         print(report)
 
 
-def main() -> None:
-    args = parse_cli_args()
-
-    # Apply --artifact-root override before any command runs
-    artifact_root = getattr(args, "artifact_root", None)
-    if artifact_root is not None:
-        set_artifact_root(artifact_root)
-
+def _dispatch(args: argparse.Namespace) -> None:
     if args.command == "prepare":
         prepare_run(args)
     elif args.command == "finalize":
@@ -2898,6 +2967,23 @@ def main() -> None:
         _do_setup(args)
     else:
         raise ValueError("Unknown command")
+
+
+def main() -> None:
+    args = parse_cli_args()
+
+    # Apply --artifact-root override before any command runs
+    artifact_root = getattr(args, "artifact_root", None)
+    if artifact_root is not None:
+        set_artifact_root(artifact_root)
+
+    try:
+        _dispatch(args)
+    except Exception as exc:  # operational failure — surface an actionable message, not a traceback
+        if os.environ.get("STUDIO_DEBUG"):
+            raise
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/studio/tests/test_install.py
+++ b/studio/tests/test_install.py
@@ -91,6 +91,11 @@ class TestInstallStudio:
         assert (source / "config" / "scopes.toml").is_file()
         assert (source / "studio.manifest.json").is_file()
 
+    def test_ships_scopes_guide(self, target_dir, studio_dir):
+        """SCOPES_GUIDE.md is shipped so the CLI's 'see SCOPES_GUIDE' pointers resolve."""
+        install_studio(target_dir, studio_dir)
+        assert (target_dir / ".studio" / "source" / "docs" / "SCOPES_GUIDE.md").is_file()
+
     def test_ships_implementation_loop(self, target_dir, studio_dir):
         """Install ships the writer/editor loop: source, config, command, workflow."""
         install_studio(target_dir, studio_dir)

--- a/studio/tests/test_run_phase.py
+++ b/studio/tests/test_run_phase.py
@@ -864,3 +864,59 @@ class TestFreshRunClarityReset:
         # Should NOT contain rerun context from the old objective
         assert "This is terrible" not in instructions
         assert "Prior Run" not in instructions
+
+
+# --- Cross-repo CLI hardening (installed-layout path resolution) ---
+
+def _installed(tmp_path, monkeypatch, *, version=True):
+    """Set up an installed-layout repo: <repo>/.studio/source as STUDIO_ROOT."""
+    repo = tmp_path / "repo"
+    snapshot = repo / ".studio" / "source"
+    snapshot.mkdir(parents=True)
+    if version:
+        (repo / ".studio" / "VERSION").write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("STUDIO_ROOT", str(snapshot))
+    monkeypatch.delenv("STUDIO_ARTIFACT_ROOT", raising=False)
+    monkeypatch.setattr(run_phase, "_artifact_root_override", None)
+    return repo, snapshot
+
+
+def test_artifact_root_from_inside_snapshot_returns_repo_root(tmp_path, monkeypatch):
+    """Running from inside <repo>/.studio/source resolves to the repo root, not the snapshot."""
+    repo, snapshot = _installed(tmp_path, monkeypatch)
+    monkeypatch.chdir(snapshot)
+    assert run_phase.get_artifact_root() == repo
+
+
+def test_artifact_root_walks_up_to_installed_root(tmp_path, monkeypatch):
+    """A CLI call from a monorepo subdirectory resolves to the repo root via .studio/VERSION."""
+    repo, _ = _installed(tmp_path, monkeypatch)
+    subdir = repo / "packages" / "app"
+    subdir.mkdir(parents=True)
+    monkeypatch.chdir(subdir)
+    assert run_phase.get_artifact_root() == repo
+
+
+def test_scopes_config_read_from_artifact_root(tmp_path, monkeypatch):
+    """Project-local .studio/scopes.toml is read from the artifact root, not the source snapshot."""
+    repo, _ = _installed(tmp_path, monkeypatch)
+    (repo / ".studio" / "scopes.toml").write_text(
+        '[scopes.alignment]\nfocus = "x"\nmax_iterations = 99\n', encoding="utf-8"
+    )
+    monkeypatch.chdir(repo)
+    _, _, meta = run_phase._resolve_scopes(
+        argparse.Namespace(scopes=None, no_scopes=False, max_iterations=6)
+    )
+    assert meta is not None
+    assert meta["config_path"] == (repo / ".studio" / "scopes.toml").as_posix()
+
+
+def test_bridge_doc_created_even_when_studio_dir_exists(tmp_path):
+    """init'd repos (where .studio/ already exists) still get a bridge doc on scaffold."""
+    studio_root = tmp_path / "studio"
+    (studio_root / "docs").mkdir(parents=True)
+    (studio_root / "docs" / "STUDIO_BRIDGE_TEMPLATE.md").write_text("# Bridge\n", encoding="utf-8")
+    repo = tmp_path / "repo"
+    (repo / ".studio").mkdir(parents=True)  # simulates an init'd repo
+    run_phase._scaffold_external_repo(repo, studio_root)
+    assert (repo / "docs" / "studio-bridge.md").is_file()


### PR DESCRIPTION
## Why

Using Studio from *installed* repos kept producing little friction points — CLI quirks that made agents bulldoze past the intended process instead of following it. A fan-out review (5 reviewers + adversarial verification) surfaced **21 confirmed findings**, nearly all the same shape: *works in the source repo, silently breaks or confuses in an installed repo*. This fixes the whole cluster.

## The headline bug — project config silently ignored

`_resolve_scopes` (and `validation.toml`) read project-local config relative to `get_studio_root()`, which in an installed repo is `<repo>/.studio/source/` — so they probed `…/.studio/source/.studio/scopes.toml` (never exists) and fell back to shipped defaults. But the setup wizard writes to `<repo>/.studio/`. **`/studio-setup`-tuned scope budgets were silently dropped on every installed run.** Now both read from the artifact root, like roles/personas/clarity/integrations already do.

## `get_artifact_root` rewrite (H2 / H7 / M2 / L1)

- Recognizes the installed snapshot: `<repo>/.studio/source` → repo root (never writes into the snapshot).
- Walks up for `.studio/VERSION`, so a call from a monorepo subdir resolves to the repo root instead of scaffolding a second unconfigured `.studio/`.
- Only warns on a genuine fresh external run (no more spurious "defaulting to cwd" on every correct install).

## The "bulldoze" root cause — error/hint UX

- `main()` now surfaces operational failures as `Error: <msg>` + exit 1 instead of a raw traceback (`STUDIO_DEBUG=1` restores it).
- `tomli`-missing on 3.10 → actionable `pip install tomli` message.
- `finalize`'s next-step `validate` hint was broken (missing `--phase`, unresolvable path); all hints now use `_entrypoint()` so they copy-paste in source **and** installed repos.
- `inject-context` warns instead of silently dropping scope guidance when a recorded path doesn't resolve.

## Slash commands / install

- `run-studio-phase.md`: `prompt_doc` path is repo-root-relative (the stale `.studio/source/` prefix from the role-prompt decoupling skipped installed personas).
- `studio-update.md`: detect the snapshot `WARNING` and route the user to update from upstream.
- Installer ships `docs/SCOPES_GUIDE.md` (the CLI pointed at it but never shipped it); `init` announces a created `CLAUDE.md`; the bridge doc is created even for `init`'d repos (the `.studio`-exists guard had skipped it).

## Tests

Artifact-root snapshot/subdir resolution, scopes-from-artifact-root, bridge-on-init, SCOPES_GUIDE shipped. **612 pass** (full suite).

*Review cost: 32 agents, ~1M tokens; 6 findings rejected by the verifier as not strictly cross-repo (a few are real CLI-ergonomic quirks — e.g. no machine-readable `prepare`/`extract-decisions` output — left for a separate, more invasive pass).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)