### PR TITLE
feat(cli): machine-readable output + derivable --phase (ergonomic pass)

### DIFF
--- a/.claude/commands/run-phase.md
+++ b/.claude/commands/run-phase.md
@@ -18,12 +18,14 @@ Run the prepare command to create a run directory and instructions:
 **Studio path:** Use `.studio/source/run_phase.py` for all commands below. If that file does not exist but `studio/run_phase.py` does, use `studio/run_phase.py` instead (you are in the Studio source repo).
 
 ```bash
-python ".studio/source/run_phase.py" prepare $ARGUMENTS
+python ".studio/source/run_phase.py" prepare $ARGUMENTS --json
 ```
 
 If running from a repo that is NOT the Studio repo itself, artifacts will automatically land in the current repo under `.studio/output/`. A bridge doc will be created on first use.
 
-Note the run_id and run directory path from the output.
+`--json` prints a machine-readable object as the **final line of stdout** — parse it for
+`run_id`, `run_dir`, and `instructions` rather than scraping prose:
+`{"run_id": "...", "run_dir": "...", "instructions": "...", "phase": "...", ...}`.
 
 ### Step 2: Read Instructions
 
@@ -71,10 +73,12 @@ python ".studio/source/run_phase.py" record-metrics --run-dir {run_dir} --agent 
 
 Then extract decision points:
 ```bash
-python ".studio/source/run_phase.py" extract-decisions --run-dir {run_dir}
+python ".studio/source/run_phase.py" extract-decisions --run-dir {run_dir} --json
 ```
 
-**If the output is non-empty (any decision points found), you MUST pause and present them ALL to the user before proceeding.** Do not continue to the contrarian until the user has responded.
+`--json` emits `{"count": N, "decisions": [...]}`. **If `count > 0`, you MUST pause and present
+every decision to the user before proceeding.** Do not continue to the contrarian until the user
+has responded. (Gate on `count`, not on whether stdout is empty.)
 
 Present each decision to the user:
 
@@ -121,7 +125,7 @@ This displays per-topic confidence scores so the user can see which areas are se
 ```bash
 python ".studio/source/run_phase.py" record-metrics --run-dir {run_dir} --agent contrarian --total-tokens {N} --tool-uses {N} --duration-ms {N}
 ```
-Then run `python ".studio/source/run_phase.py" extract-decisions --run-dir {run_dir}` again. If new decision points appear (from the contrarian), present them to the user and record as in step (b).
+Then run `python ".studio/source/run_phase.py" extract-decisions --run-dir {run_dir} --json` again. If `count > 0` (new decision points from the contrarian), present them to the user and record as in step (b).
 
 **e. Check verdict** — Read the contrarian output. If `VERDICT: APPROVED`, proceed to Step 4. If `VERDICT: REJECTED` and iterations remain, loop back to (a) with the rejection feedback.
 

--- a/.claude/commands/run-studio-phase.md
+++ b/.claude/commands/run-studio-phase.md
@@ -43,10 +43,11 @@ Read the generated `instructions.md` file. Pay attention to:
 
 2. **Extract decision points** — Run this command (do NOT manually scan files):
    ```bash
-   python ".studio/source/run_phase.py" extract-decisions --run-dir {run_dir}
+   python ".studio/source/run_phase.py" extract-decisions --run-dir {run_dir} --json
    ```
+   `--json` emits `{"count": N, "decisions": [...]}`.
 
-3. **If the output is non-empty**, you MUST pause and present ALL decision points to the user. Do not spawn the next agent until the user has responded. Present each as:
+3. **If `count > 0`**, you MUST pause and present ALL decision points to the user. Do not spawn the next agent until the user has responded. Present each as:
    - **Decision [priority]:** [question]
    - Unblocks: [context]
    - Options: [options if present]
@@ -180,9 +181,9 @@ python ".studio/source/run_phase.py" inject-context --run-dir {run_dir} --scope 
 
 **Check decision points** — After each S2 advocate and contrarian saves output, run:
 ```bash
-python ".studio/source/run_phase.py" extract-decisions --run-dir {run_dir} --scope S2
+python ".studio/source/run_phase.py" extract-decisions --run-dir {run_dir} --scope S2 --json
 ```
-If non-empty, follow the Decision Point Handling protocol above. Since S2 is sequential, decisions from earlier roles inform later roles.
+If `count > 0`, follow the Decision Point Handling protocol above. Since S2 is sequential, decisions from earlier roles inform later roles.
 
 **Brief update cadence — MANDATORY:** After every 2-3 roles complete:
 1. Run `python ".studio/source/run_phase.py" extract-decisions --run-dir {run_dir}` to gather all decisions

--- a/studio/run_phase.py
+++ b/studio/run_phase.py
@@ -296,20 +296,20 @@ def get_artifact_root() -> Path:
 
     studio_root = get_studio_root().resolve()
     cwd = Path.cwd().resolve()
-    installed_root = _installed_repo_root(studio_root)
 
     if cwd == studio_root or _is_within(cwd, studio_root):
         # Running from the source tree (or from inside an installed snapshot).
         # In the source repo the artifact root IS the studio dir; in an installed
         # snapshot it's the consuming repo root, never the snapshot itself.
+        installed_root = _installed_repo_root(studio_root)
         return installed_root if installed_root is not None else studio_root
 
-    # Anywhere under an init'd repo (e.g. a monorepo subdir): resolve to its root.
+    # The next two branches are distinct on purpose: an init'd repo is marked by
+    # .studio/VERSION (walk UP for it — handles monorepo subdirs), whereas a merely
+    # scaffolded repo has a bare .studio/ and no VERSION (check cwd ONLY). Don't merge.
     found = _find_installed_root_upwards(cwd)
     if found is not None:
         return found
-
-    # cwd is already a scaffolded/installed repo root — defaulting to it is correct.
     if (cwd / ".studio").is_dir():
         return cwd
 
@@ -2127,6 +2127,18 @@ def record_decisions(args: argparse.Namespace) -> None:
     print(f"  decisions.md:   {run_dir / 'decisions.md'}")
 
 
+def _decision_to_dict(dp) -> dict:
+    """Serialize a DecisionPoint — single source of truth for the machine-readable
+    shape shared by `check-decisions` and `extract-decisions --json`."""
+    return {
+        "priority": dp.priority,
+        "question": dp.question,
+        "unblocks": dp.unblocks,
+        "options": dp.options,
+        "source_file": dp.source_file,
+    }
+
+
 def check_decisions(args: argparse.Namespace) -> None:
     """Parse decision points from a single agent output file and print as JSON."""
     file_path = Path(args.file)
@@ -2138,13 +2150,8 @@ def check_decisions(args: argparse.Namespace) -> None:
 
     grouped: dict[str, list[dict]] = {"P0": [], "P1": [], "P2": []}
     for dp in points:
-        entry = {
-            "question": dp.question,
-            "unblocks": dp.unblocks,
-            "options": dp.options,
-            "source_file": dp.source_file,
-        }
-        grouped[dp.priority].append(entry)
+        entry = _decision_to_dict(dp)
+        grouped[entry.pop("priority")].append(entry)  # grouped by priority → drop it from the entry
 
     print(json.dumps(grouped, indent=2))
 
@@ -2178,16 +2185,7 @@ def extract_decisions(args: argparse.Namespace) -> None:
 
     if getattr(args, "json", False):
         # Machine-readable: always emit (count lets callers gate on a number, not empty stdout).
-        decisions = [
-            {
-                "priority": dp.priority,
-                "question": dp.question,
-                "unblocks": dp.unblocks,
-                "options": dp.options,
-                "source_file": dp.source_file,
-            }
-            for dp in all_decisions
-        ]
+        decisions = [_decision_to_dict(dp) for dp in all_decisions]
         print(json.dumps({"count": len(decisions), "decisions": decisions}, indent=2))
         return
 

--- a/studio/run_phase.py
+++ b/studio/run_phase.py
@@ -239,6 +239,20 @@ def _entrypoint() -> str:
     return f"python {argv0}"
 
 
+def _phase_from_run_id(run_id: str) -> str:
+    """Derive the phase from a run_id (format ``run_<phase>_<timestamp>``).
+
+    Lets run-scoped commands (finalize/validate/recompute-clarity) make ``--phase``
+    optional — it's redundant with ``--run-id``, which already encodes it.
+    """
+    parts = run_id.split("_")
+    if len(parts) >= 3 and parts[0] == "run" and parts[1] in PHASE_DETAILS:
+        return parts[1]
+    raise ValueError(
+        f"Cannot derive phase from run_id '{run_id}' — pass --phase explicitly."
+    )
+
+
 _artifact_root_override: Path | None = None
 _artifact_root_warned: bool = False
 
@@ -1294,17 +1308,28 @@ def prepare_run(args: argparse.Namespace) -> str:
     write_json(run_dir / "run.json", meta)
     rebuild_index()
 
-    print(f"Prepared {run_id} ({phase})")
-    print(f"- Run directory: {run_dir_abs}")
-    print(f"- Instructions: {instructions_abs_path}")
-    if objective_changed:
-        print(f"- Fresh run: cleared stale clarity from previous objective")
-
-    if scopes_meta:
-        print(f"\n💡 Tip: Scopes are active. Work through {scopes_meta['scopes'][0]['name']} scope first.")
+    emit_json = getattr(args, "json", False)
+    if emit_json:
+        print(json.dumps({
+            "run_id": run_id,
+            "phase": phase,
+            "run_dir": str(run_dir_abs),
+            "instructions": str(instructions_abs_path),
+            "scoped": bool(scopes_meta),
+            "objective_changed": bool(objective_changed),
+        }))
     else:
-        print(f"\n💡 Tip: Want to optimize iteration budgets? Create .studio/scopes.toml")
-        print(f"   See: .studio/source/docs/SCOPES_GUIDE.md")
+        print(f"Prepared {run_id} ({phase})")
+        print(f"- Run directory: {run_dir_abs}")
+        print(f"- Instructions: {instructions_abs_path}")
+        if objective_changed:
+            print(f"- Fresh run: cleared stale clarity from previous objective")
+
+        if scopes_meta:
+            print(f"\n💡 Tip: Scopes are active. Work through {scopes_meta['scopes'][0]['name']} scope first.")
+        else:
+            print(f"\n💡 Tip: Want to optimize iteration budgets? Create .studio/scopes.toml")
+            print(f"   See: .studio/source/docs/SCOPES_GUIDE.md")
 
     # Append to usage log (fail silently — don't break prepare over logging)
     try:
@@ -1320,7 +1345,7 @@ def prepare_run(args: argparse.Namespace) -> str:
         pass  # Usage logging must never block prepare
 
     storage_stats = meta.get("storage", {})
-    if storage_stats.get("cleanup_suggested", False):
+    if storage_stats.get("cleanup_suggested", False) and not emit_json:
         print(f"\n🧹 Storage Tip: You have {storage_stats['total_size_mb']}MB of Studio artifacts")
         print(f"   (oldest: {storage_stats['oldest_artifact_days']} days ago). Consider cleanup:")
         print(f"   {_entrypoint()} cleanup --dry-run  # Preview what would be deleted")
@@ -1330,8 +1355,8 @@ def prepare_run(args: argparse.Namespace) -> str:
 
 
 def finalize_run(args: argparse.Namespace) -> None:
-    phase = args.phase.lower()
     run_id = args.run_id
+    phase = (args.phase or _phase_from_run_id(run_id)).lower()
     run_dir = get_output_root() / phase / run_id
     meta_path = run_dir / "run.json"
     if not meta_path.exists():
@@ -1578,14 +1603,21 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Preview cleanup deletions without removing any files.",
     )
+    prepare_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable JSON object {run_id, run_dir, instructions, phase, ...} "
+             "as the final line of stdout (instead of the prose summary + tips).",
+    )
     _add_artifact_root_arg(prepare_parser)
 
     finalize_parser = subparsers.add_parser("finalize", help="Mark an existing run as completed and refresh index.")
     finalize_parser.add_argument(
         "--phase",
-        required=True,
+        required=False,
+        default=None,
         choices=sorted(PHASE_DETAILS.keys()),
-        help="Phase the run belongs to.",
+        help="Phase the run belongs to (optional — derived from --run-id when omitted).",
     )
     finalize_parser.add_argument(
         "--run-id",
@@ -1642,9 +1674,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     validate_parser.add_argument(
         "--phase",
-        required=True,
+        required=False,
+        default=None,
         choices=sorted(PHASE_DETAILS.keys()),
-        help="Phase the run belongs to.",
+        help="Phase the run belongs to (optional — derived from --run-id when omitted).",
     )
     validate_parser.add_argument(
         "--run-id",
@@ -1737,6 +1770,11 @@ def build_parser() -> argparse.ArgumentParser:
         dest="show_all",
         help="Show all decisions including already-settled ones (default: only unsettled).",
     )
+    extract_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON {count, decisions:[...]} instead of markdown (gate on count, not empty stdout).",
+    )
 
     inject_parser = subparsers.add_parser(
         "inject-context", help="Generate context block for the next agent in a scoped run."
@@ -1822,7 +1860,10 @@ def build_parser() -> argparse.ArgumentParser:
     recompute_clarity_parser = subparsers.add_parser(
         "recompute-clarity", help="Recompute clarity from a run's decisions."
     )
-    recompute_clarity_parser.add_argument("--phase", required=True, choices=sorted(PHASE_DETAILS.keys()))
+    recompute_clarity_parser.add_argument(
+        "--phase", required=False, default=None, choices=sorted(PHASE_DETAILS.keys()),
+        help="Phase the run belongs to (optional — derived from --run-id when omitted).",
+    )
     recompute_clarity_parser.add_argument("--run-id", required=True)
     recompute_clarity_parser.add_argument(
         "--artifact-root", type=Path, default=None,
@@ -1925,8 +1966,8 @@ def build_parser() -> argparse.ArgumentParser:
 
 def validate_run(args: argparse.Namespace) -> None:
     """Validate Studio run outputs."""
-    phase = args.phase.lower()
     run_id = args.run_id
+    phase = (args.phase or _phase_from_run_id(run_id)).lower()
     run_dir = get_output_root() / phase / run_id
     
     if not run_dir.exists():
@@ -2134,6 +2175,21 @@ def extract_decisions(args: argparse.Namespace) -> None:
     if not getattr(args, "show_all", False):
         settled = load_decisions_json(run_dir)
         all_decisions = filter_unsettled(all_decisions, settled)
+
+    if getattr(args, "json", False):
+        # Machine-readable: always emit (count lets callers gate on a number, not empty stdout).
+        decisions = [
+            {
+                "priority": dp.priority,
+                "question": dp.question,
+                "unblocks": dp.unblocks,
+                "options": dp.options,
+                "source_file": dp.source_file,
+            }
+            for dp in all_decisions
+        ]
+        print(json.dumps({"count": len(decisions), "decisions": decisions}, indent=2))
+        return
 
     if not all_decisions:
         # Silent exit — no decisions found is normal
@@ -2743,8 +2799,8 @@ def recompute_clarity(args: argparse.Namespace) -> None:
     making this usable mid-run.
     """
     root = Path(args.artifact_root).resolve() if args.artifact_root else get_artifact_root()
-    phase = args.phase.lower()
     run_id = args.run_id
+    phase = (args.phase or _phase_from_run_id(run_id)).lower()
     run_dir = get_output_root() / phase / run_id
     if not run_dir.is_dir():
         raise FileNotFoundError(f"Run directory not found: {run_dir}")

--- a/studio/tests/test_run_phase.py
+++ b/studio/tests/test_run_phase.py
@@ -1,5 +1,6 @@
 """Unit tests for run_phase.py core functions."""
 import argparse
+import json
 
 import pytest
 
@@ -920,3 +921,46 @@ def test_bridge_doc_created_even_when_studio_dir_exists(tmp_path):
     (repo / ".studio").mkdir(parents=True)  # simulates an init'd repo
     run_phase._scaffold_external_repo(repo, studio_root)
     assert (repo / "docs" / "studio-bridge.md").is_file()
+
+
+# --- CLI ergonomics: --json output + --phase derivable from run_id ---
+
+def test_phase_from_run_id():
+    assert run_phase._phase_from_run_id("run_market_20260101_120000") == "market"
+    assert run_phase._phase_from_run_id("run_studio_20260101_120000") == "studio"
+    with pytest.raises(ValueError):
+        run_phase._phase_from_run_id("not_a_valid_id")
+
+
+def test_prepare_json_output(studio_root, capsys):
+    """prepare --json emits a parseable object as the final stdout line."""
+    run_phase.prepare_run(make_prepare_args(text="json test", json=True))
+    lines = [ln for ln in capsys.readouterr().out.strip().splitlines() if ln.strip()]
+    payload = json.loads(lines[-1])
+    assert payload["phase"] == "market"
+    assert payload["run_id"].startswith("run_market_")
+    assert payload["run_dir"] and payload["instructions"]
+
+
+def test_finalize_derives_phase_when_omitted(studio_root):
+    """finalize works with --phase omitted (derived from run_id)."""
+    run_id = run_phase.prepare_run(make_prepare_args())
+    run_dir = studio_root / "output" / "market" / run_id
+    (run_dir / "advocate_1.md").write_text("a", encoding="utf-8")
+    (run_dir / "contrarian_1.md").write_text("c", encoding="utf-8")
+    (run_dir / "summary.md").write_text("s", encoding="utf-8")
+    run_phase.finalize_run(make_finalize_args(phase=None, run_id=run_id))
+    meta = json.loads((run_dir / "run.json").read_text(encoding="utf-8"))
+    assert meta["status"] == "COMPLETED"
+
+
+def test_extract_decisions_json_emits_count(studio_root, capsys):
+    """extract-decisions --json always emits {count, decisions} (count, not empty stdout, gates)."""
+    run_id = run_phase.prepare_run(make_prepare_args())
+    run_dir = studio_root / "output" / "market" / run_id
+    capsys.readouterr()  # discard prepare's prose so we read only extract's output
+    run_phase.extract_decisions(
+        argparse.Namespace(run_dir=run_dir, scope=None, show_all=False, json=True)
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"count": 0, "decisions": []}


### PR DESCRIPTION
## Why

The cross-repo review (#38) verifier rejected 6 findings as "real but not cross-repo-specific." Three of those are genuine CLI-ergonomic quirks that make agents work *around* the process — they just bite equally everywhere, not only in installed repos. This is that cluster (R3/R4/R6). Stacked on #38.

## Changes

- **`prepare --json`** (R6) — emits `{run_id, run_dir, instructions, phase, scoped, objective_changed}` as the **final line of stdout** (cleanup/scaffold notices precede it; the storage tip is suppressed under `--json`). Agents parse it instead of scraping the prose summary that every downstream `--run-dir` step depended on.
- **`extract-decisions --json`** (R3) — emits `{count, decisions:[...]}` so the pause/proceed gate keys off `count`, not "is stdout empty." Mirrors the existing `check-decisions`/`stats --json`.
- **`--phase` now optional** on `finalize` / `validate` / `recompute-clarity` (R4) — derived from `run_id` (`run_<phase>_<ts>`) via `_phase_from_run_id`; a malformed `run_id` errors clearly. Removes the redundant-arg friction (phase was always encoded in `run_id`).

## Commands wired to use it

`run-phase.md` and `run-studio-phase.md` now call `prepare --json` (parse the last line) and gate decision pauses on `count > 0` — no more prose-scraping or empty-stdout detection.

## Skipped from the 6 (per the earlier analysis)

R1 (`studio-setup` hardcodes `.studio/source/` — only breaks the *source* repo), R2 (`<repo>` placeholder — layout-neutral doc gap, friction claim was unsupported), R5 (rating `input()` — already TTY-guarded + both commands pass `--no-rate-prompt`).

## Tests

`_phase_from_run_id` (derive + raise), `prepare --json` shape, `finalize` without `--phase`, `extract-decisions --json` count. **616 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)