### PR TITLE
fix(impl_loop): resolve project config override against the artifact root

### DIFF
--- a/.claude/commands/studio-implement.md
+++ b/.claude/commands/studio-implement.md
@@ -78,12 +78,12 @@ If `--plan`, stop here.
 **Studio path:** use `.studio/source/impl_loop.py` for the command below. If that file does not
 exist but `studio/impl_loop.py` does, use that instead (you are in the Studio source repo).
 
-Read the loop config knobs. If the repo has a project override at `.studio/implementation_loop.toml`,
-pass it explicitly (it lives at the repo root, outside the snapshot's resolution chain); otherwise
-run with no arg (shipped default → built-in defaults):
+Read the loop config knobs. Resolution finds a project override at the repo root
+(`.studio/implementation_loop.toml`) automatically, falling back to the shipped default →
+built-in defaults — so no path argument is needed:
 
 ```bash
-python .studio/source/impl_loop.py [.studio/implementation_loop.toml]
+python .studio/source/impl_loop.py
 # prints knobs JSON, e.g. {"editor_enabled": true, "read_scope": "touched+importers", "output_budget": 400, ...}
 ```
 

--- a/studio/impl_loop.py
+++ b/studio/impl_loop.py
@@ -21,6 +21,7 @@ except ModuleNotFoundError:
             "Install it with: python -m pip install tomli  (or upgrade to Python 3.11+)."
         )
 import json
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List
@@ -77,15 +78,33 @@ class LoopConfig:
         return self.mandate != "off"
 
 
+def _project_artifact_root(studio_root: Path) -> Path:
+    """The consuming repo root where project-local config lives.
+
+    Mirrors run_phase.get_artifact_root's installed-layout detection WITHOUT importing
+    run_phase (impl_loop ships standalone to .studio/source/): honor STUDIO_ARTIFACT_ROOT,
+    else map an installed snapshot ``<repo>/.studio/source`` to ``<repo>``, else fall back
+    to the source root itself (the Studio source repo, where they coincide).
+    """
+    env = os.environ.get("STUDIO_ARTIFACT_ROOT")
+    if env:
+        return Path(env).expanduser().resolve()
+    if studio_root.name == "source" and studio_root.parent.name == ".studio":
+        return studio_root.parent.parent
+    return studio_root
+
+
 def _resolve_config_path(path: Path | None, studio_root: Path) -> Path | None:
     """Resolve the config path via the resolution chain.
 
-    explicit path → .studio/implementation_loop.toml → config/implementation_loop.toml.
-    Returns None when nothing in the chain exists (caller falls back to defaults).
+    explicit ``path`` → ``<artifact-root>/.studio/implementation_loop.toml`` (the project
+    override, which lives at the consuming repo root — NOT under the source snapshot) →
+    ``<studio-root>/config/implementation_loop.toml`` (the shipped default). Returns None
+    when nothing in the chain exists (caller falls back to built-in defaults).
     """
     if path is not None:
         return Path(path)
-    local = studio_root / ".studio" / "implementation_loop.toml"
+    local = _project_artifact_root(studio_root) / ".studio" / "implementation_loop.toml"
     if local.exists():
         return local
     shipped = studio_root / "config" / "implementation_loop.toml"
@@ -98,12 +117,14 @@ def load_loop_config(path: Path | None = None, studio_root: Path | None = None) 
     """
     Load loop configuration from TOML, mirroring load_scopes_config().
 
-    Resolution chain: explicit ``path`` → ``.studio/implementation_loop.toml`` →
-    ``config/implementation_loop.toml`` → built-in defaults. An end-of-chain miss
-    (no ``path`` given and nothing found) yields the default LoopConfig — the loop
-    ships with a working default, so absence is not a failure. But an explicit
-    ``path`` that does not exist raises FileNotFoundError: a typo'd config path is an
-    error, not a silent request for defaults.
+    Resolution chain: explicit ``path`` → project override at
+    ``<artifact-root>/.studio/implementation_loop.toml`` (the consuming repo root, found
+    even when this module runs from an installed ``.studio/source`` snapshot) → shipped
+    ``<studio-root>/config/implementation_loop.toml`` → built-in defaults. An end-of-chain
+    miss (no ``path`` given and nothing found) yields the default LoopConfig — the loop
+    ships with a working default, so absence is not a failure. But an explicit ``path``
+    that does not exist raises FileNotFoundError: a typo'd config path is an error, not a
+    silent request for defaults.
 
     All tables/keys are optional; unspecified keys inherit the LoopConfig defaults.
     See config/implementation_loop.toml (the shipped default) and SPEC §4 for the
@@ -175,10 +196,10 @@ def runtime_knobs(config: LoopConfig) -> dict:
 def _cli(argv: List[str]) -> str:
     """Return the runtime-knobs JSON for the CLI.
 
-    Optional ``argv[1]`` is an explicit config path — used by /studio-implement to
-    pass an installed repo's ``.studio/implementation_loop.toml`` (the project override
-    lives at the target root, outside this snapshot's resolution chain). With no arg,
-    the normal resolution chain runs (shipped default → built-in defaults).
+    Optional ``argv[1]`` is an explicit config path for a non-standard location. With no
+    arg the normal resolution chain runs, which now finds the project override at the
+    consuming repo root (``<repo>/.studio/implementation_loop.toml``) on its own — so
+    callers no longer need to pass it explicitly just to honor an installed repo's override.
     """
     path = Path(argv[1]) if len(argv) > 1 else None
     return json.dumps(runtime_knobs(load_loop_config(path)))

--- a/studio/tests/test_impl_loop.py
+++ b/studio/tests/test_impl_loop.py
@@ -169,6 +169,37 @@ def test_load_loop_config_studio_override_beats_shipped_default():
         assert config.output_budget == 123
 
 
+def test_load_loop_config_installed_override_resolves_at_repo_root(tmp_path, monkeypatch):
+    """In an installed layout (studio_root = <repo>/.studio/source), the project override
+    is read from <repo>/.studio/, NOT from under the source snapshot."""
+    monkeypatch.delenv("STUDIO_ARTIFACT_ROOT", raising=False)
+    repo = tmp_path / "repo"
+    snapshot = repo / ".studio" / "source"
+    (snapshot / "config").mkdir(parents=True)
+    # shipped default under the snapshot
+    (snapshot / "config" / "implementation_loop.toml").write_text(
+        "[editor]\noutput_budget = 400\n"
+    )
+    # project override at the REPO ROOT .studio/ (where the wizard writes it)
+    (repo / ".studio" / "implementation_loop.toml").write_text(
+        "[editor]\noutput_budget = 42\n"
+    )
+    config = load_loop_config(studio_root=snapshot)
+    assert config.output_budget == 42  # override wins; before the fix this returned 400
+
+
+def test_load_loop_config_artifact_root_env_override(tmp_path, monkeypatch):
+    """STUDIO_ARTIFACT_ROOT points the project-override lookup at an explicit root."""
+    repo = tmp_path / "elsewhere"
+    (repo / ".studio").mkdir(parents=True)
+    (repo / ".studio" / "implementation_loop.toml").write_text("[editor]\nmandate = \"off\"\n")
+    snapshot = tmp_path / "src" / ".studio" / "source"
+    snapshot.mkdir(parents=True)
+    monkeypatch.setenv("STUDIO_ARTIFACT_ROOT", str(repo))
+    config = load_loop_config(studio_root=snapshot)
+    assert config.mandate == "off"
+
+
 def test_load_loop_config_falls_back_to_shipped_default():
     """With no .studio override, the shipped config/ default is used."""
     with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Why

The `/simplify` altitude review caught that `impl_loop.py` carries the **same config-resolution bug** the scopes/validation fix (#38) removed — one module deeper. `_resolve_config_path` resolved *both* the project override (`.studio/implementation_loop.toml`) and the shipped default against `STUDIO_ROOT`, which is `<repo>/.studio/source` in an installed repo. So the override was sought at `<repo>/.studio/source/.studio/implementation_loop.toml` — never where the wizard writes it (`<repo>/.studio/`). It was papered over by `/studio-implement` passing the path explicitly, meaning any other caller silently got shipped defaults.

## Fix

- New `_project_artifact_root(studio_root)` maps an installed snapshot (`<repo>/.studio/source` → `<repo>`) and honors `STUDIO_ARTIFACT_ROOT` — mirroring `run_phase.get_artifact_root`'s detection **without importing run_phase** (`impl_loop` ships standalone to `.studio/source/`).
- The project override now resolves at the consuming repo root; the shipped default stays under the source dir.
- Removed the `/studio-implement` explicit-path crutch (resolution handles it). The CLI's optional path arg stays for non-standard locations.

## Verified

- New tests: installed-layout override resolves at the repo root (the regression), `STUDIO_ARTIFACT_ROOT` override. **618 pass.**
- End-to-end smoke: a real `.studio/source/impl_loop.py` with an override at the repo root and **no path arg** now emits the override (`editor_enabled:false, output_budget:77`) instead of shipped defaults.

Stacked on #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)