### PR TITLE
feat(update): clobber-preview precondition + draft-PR etiquette

### DIFF
--- a/.claude/commands/studio-update.md
+++ b/.claude/commands/studio-update.md
@@ -26,13 +26,21 @@ real upstream — so it may report "up to date" when it isn't. In that case, tel
 update from the upstream Studio source repo instead:
 `python studio/run_phase.py update --target <this-repo>`. Do not trust the result until then.
 
+**If the output contains a `⚠️ … LOCAL EDITS` block** (installed snapshot files the user edited),
+this is the clobber preview — **STOP and surface it to the user before updating.** `update` will
+refuse to overwrite these unless `--force` is passed. For each listed file: if it's project config,
+the fix is to move it to `<repo>/.studio/<name>.toml` (the project-override location update never
+touches); otherwise confirm with the user whether to keep the edit (back it up) or discard it.
+
 ### Step 3: Update
 
 ```bash
 python ".studio/source/run_phase.py" update --target .
 ```
 
-Show the user what was updated (files changed, added, removed).
+If `update` prints `Update BLOCKED`, do NOT pass `--force` on your own — relay the listed files to
+the user and let them decide (move config out, back up, or explicitly approve `--force`). Otherwise
+show the user what was updated (files changed, added, removed).
 
 ### Step 4: Remind about restart
 

--- a/studio/docs/CODING_PRINCIPLES.md
+++ b/studio/docs/CODING_PRINCIPLES.md
@@ -60,6 +60,12 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
+## 5. Git & PR Etiquette
+
+**Open pull requests as drafts first.**
+
+A new PR starts as a **draft**, not ready-for-review. Mark it ready only when the work is complete, tests pass, and you actually want a human to review and merge it. Opening as a draft prevents two failure modes: accidental early merges (a not-yet-finished PR getting merged by mistake) and reviewer churn (reviewers spending attention on a still-moving target). Flip to ready when it's genuinely ready for eyes.
+
 ---
 
 *These guidelines are working if:* fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/studio/install.py
+++ b/studio/install.py
@@ -176,6 +176,25 @@ def _resolve_source_dir(
     return live, None
 
 
+def _recorded_upstream_source(version_path: Path, snapshot: Path) -> Optional[Path]:
+    """Return the upstream source dir recorded in an existing VERSION — but only if
+    it is still a usable upstream: it exists, has ``run_phase.py``, and is NOT the
+    target's own snapshot. Used to avoid overwriting a good pointer with a
+    self-pointing one when (re)installing from the snapshot.
+    """
+    try:
+        version = json.loads(version_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    sp = version.get("source_path")
+    if not sp:
+        return None
+    p = Path(sp)
+    if p.resolve() == snapshot or not (p / "run_phase.py").is_file():
+        return None
+    return p
+
+
 def _collect_source_files(studio_dir: Path) -> List[Path]:
     """Collect all source files to install (relative to studio/)."""
     files: List[Path] = []
@@ -340,14 +359,24 @@ def install_studio(target: Path, studio_dir: Optional[Path] = None) -> Path:
     # Write VERSION
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     git = _git_info(studio_dir.parent)
+    version_path = dot_studio / "VERSION"
+    # Never record a source_path that points at the target's own snapshot: it would
+    # make every future snapshot-based check compare the snapshot against itself
+    # (silent "up to date") and leave `update` with no breadcrumb back to upstream.
+    # When (re)installing FROM the snapshot (e.g. `init` run inside an installed
+    # repo), preserve a previously-recorded upstream pointer instead of clobbering it.
+    source_path = studio_dir
+    if studio_dir.resolve() == source_dest.resolve():
+        prior = _recorded_upstream_source(version_path, source_dest.resolve())
+        if prior is not None:
+            source_path = prior
     version_info = {
         "installed_at": now,
-        "source_path": str(studio_dir),
+        "source_path": str(source_path),
         "commit": git.get("commit", "unknown"),
         "commit_date": git.get("commit_date", ""),
         "file_count": len(manifest),
     }
-    version_path = dot_studio / "VERSION"
     version_path.write_text(
         json.dumps(version_info, indent=2), encoding="utf-8"
     )

--- a/studio/install.py
+++ b/studio/install.py
@@ -364,9 +364,12 @@ def check_studio(target: Path, studio_dir: Optional[Path] = None) -> dict:
     Returns dict with:
         installed: bool — whether .studio/VERSION exists
         up_to_date: bool — whether all files match source checksums
-        changed: list[str] — files that differ
+        changed: list[str] — files where upstream differs from what was installed (update available)
         missing: list[str] — files in source but not installed
         extra: list[str] — files installed but not in source
+        locally_modified: list[str] — installed source files whose ON-DISK content has
+            drifted from the checksum recorded at install — i.e. local edits that an
+            `update` would OVERWRITE (the clobber set; commonly an edited snapshot config)
         warning: str | None — set when the live source could not be resolved
             (e.g. run from a stale snapshot), so the result may be unreliable
     """
@@ -376,7 +379,7 @@ def check_studio(target: Path, studio_dir: Optional[Path] = None) -> dict:
     manifest_path = dot_studio / "MANIFEST.json"
 
     if not version_path.exists():
-        return {"installed": False, "up_to_date": False, "changed": [], "missing": [], "extra": [], "warning": None}
+        return {"installed": False, "up_to_date": False, "changed": [], "missing": [], "extra": [], "locally_modified": [], "warning": None}
 
     studio_dir, warning = _resolve_source_dir(target, studio_dir)
 
@@ -408,6 +411,16 @@ def check_studio(target: Path, studio_dir: Optional[Path] = None) -> dict:
         if rel not in source_manifest:
             extra.append(rel)
 
+    # Local modifications: installed source file on disk differs from what was recorded
+    # at install. These are the files an `update` re-install would clobber.
+    source_dest = dot_studio / "source"
+    locally_modified: List[str] = []
+    for rel, recorded_sha in installed_manifest.items():
+        f = source_dest / rel
+        if f.is_file() and _sha256(f) != recorded_sha:
+            locally_modified.append(rel)
+    locally_modified.sort()
+
     up_to_date = not changed and not missing
 
     return {
@@ -416,15 +429,21 @@ def check_studio(target: Path, studio_dir: Optional[Path] = None) -> dict:
         "changed": changed,
         "missing": missing,
         "extra": extra,
+        "locally_modified": locally_modified,
         "warning": warning,
     }
 
 
-def update_studio(target: Path, studio_dir: Optional[Path] = None) -> dict:
+def update_studio(target: Path, studio_dir: Optional[Path] = None, force: bool = False) -> dict:
     """Update an installed Studio from the source.
 
     Preserves user customizations in .studio/ (roles/, scopes.toml, etc.)
     by only overwriting source/ and slash commands.
+
+    PRECONDITION: if any installed source file has local edits (drifted from its
+    recorded checksum), the update is BLOCKED — re-installing would overwrite them.
+    Returns ``{"blocked": True, "locally_modified": [...]}`` instead of updating.
+    Pass ``force=True`` to overwrite anyway.
 
     Returns dict with counts of updated/added/removed files, plus a ``warning``
     key (str | None) when the live source could not be resolved (e.g. run from a
@@ -446,7 +465,13 @@ def update_studio(target: Path, studio_dir: Optional[Path] = None) -> dict:
     status = check_studio(target, source_dir)
 
     if status["up_to_date"]:
-        return {"updated": 0, "added": 0, "removed": 0, "warning": warning}
+        return {"updated": 0, "added": 0, "removed": 0, "locally_modified": status["locally_modified"], "warning": warning}
+
+    # Preview precondition: refuse to clobber locally-edited snapshot files unless forced.
+    locally_modified = status.get("locally_modified", [])
+    if locally_modified and not force:
+        return {"blocked": True, "locally_modified": locally_modified,
+                "updated": 0, "added": 0, "removed": 0, "warning": warning}
 
     # Re-install (install_studio is idempotent and preserves user dirs)
     install_studio(target, source_dir)
@@ -455,5 +480,6 @@ def update_studio(target: Path, studio_dir: Optional[Path] = None) -> dict:
         "updated": len(status["changed"]),
         "added": len(status["missing"]),
         "removed": 0,  # We don't remove extra files
+        "locally_modified": locally_modified,
         "warning": warning,
     }

--- a/studio/run_phase.py
+++ b/studio/run_phase.py
@@ -1836,6 +1836,11 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         help="Path to the target project directory.",
     )
+    update_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite even locally-modified snapshot files (default: refuse and list them).",
+    )
 
     # --- Clarity commands ---
     show_clarity_parser = subparsers.add_parser(
@@ -2857,14 +2862,31 @@ def _do_check_install(args: argparse.Namespace) -> None:
             print(f"  Missing: {', '.join(status['missing'])}")
         print(f"\nRun: {_entrypoint()} update --target {target}")
 
+    locally_modified = status.get("locally_modified", [])
+    if locally_modified:
+        print(f"\n⚠️  {len(locally_modified)} installed file(s) have LOCAL EDITS that update would overwrite:")
+        for rel in locally_modified:
+            print(f"   - .studio/source/{rel}")
+        print("   If any is project config, move it to <repo>/.studio/<name>.toml (update never")
+        print("   touches that). update will refuse to clobber these unless run with --force.")
+
 
 def _do_update(args: argparse.Namespace) -> None:
     """Update installed Studio from source."""
     from install import update_studio
     target = Path(args.target).resolve()
-    result = update_studio(target)
+    result = update_studio(target, force=getattr(args, "force", False))
     if result.get("warning"):
         print(f"WARNING: {result['warning']}\n")
+    if result.get("blocked"):
+        mods = result["locally_modified"]
+        print(f"Update BLOCKED: {len(mods)} installed file(s) have local edits that would be overwritten:")
+        for rel in mods:
+            print(f"   - .studio/source/{rel}")
+        print("\nThese are edits to the Studio snapshot (it gets replaced on update). If any is")
+        print("project config, move it to <repo>/.studio/<name>.toml — the project-override location")
+        print(f"update never touches. To overwrite anyway: {_entrypoint()} update --target {target} --force")
+        return
     if result["updated"] == 0 and result["added"] == 0:
         print(f"Studio at {target} is already up to date.")
     else:

--- a/studio/run_phase.py
+++ b/studio/run_phase.py
@@ -2862,7 +2862,7 @@ def _do_check_install(args: argparse.Namespace) -> None:
             print(f"  Missing: {', '.join(status['missing'])}")
         print(f"\nRun: {_entrypoint()} update --target {target}")
 
-    locally_modified = status.get("locally_modified", [])
+    locally_modified = status["locally_modified"]
     if locally_modified:
         print(f"\n⚠️  {len(locally_modified)} installed file(s) have LOCAL EDITS that update would overwrite:")
         for rel in locally_modified:

--- a/studio/tests/test_install.py
+++ b/studio/tests/test_install.py
@@ -334,6 +334,22 @@ class TestSnapshotStaleDetection:
         assert status["warning"] is not None
         assert "snapshot" in status["warning"]
 
+    def test_self_install_preserves_upstream_source_path(
+        self, target_dir, studio_dir
+    ):
+        """Re-installing FROM the snapshot must not record a self-pointing
+        source_path — it would make future snapshot checks compare the snapshot
+        against itself (silent 'up to date'). A prior upstream pointer survives."""
+        install_studio(target_dir, studio_dir)  # source_path -> real upstream
+        snapshot = target_dir / ".studio" / "source"
+
+        # Simulate `init`/install run through the installed snapshot itself.
+        install_studio(target_dir, snapshot)
+
+        version = json.loads((target_dir / ".studio" / "VERSION").read_text())
+        assert Path(version["source_path"]).resolve() == studio_dir.resolve()
+        assert Path(version["source_path"]).resolve() != snapshot.resolve()
+
 
 class TestSlashCommandsUseDirectPaths:
     """Verify slash commands use .studio/source/ paths directly (no rewriting needed)."""

--- a/studio/tests/test_install.py
+++ b/studio/tests/test_install.py
@@ -182,6 +182,15 @@ class TestCheckStudio:
         assert status["up_to_date"] is False
         assert "run_phase.py" in status["changed"]
 
+    def test_check_reports_locally_modified(self, target_dir, studio_dir):
+        """check_studio flags installed source files edited after install (the clobber set)."""
+        install_studio(target_dir, studio_dir)
+        f = target_dir / ".studio" / "source" / "config" / "scopes.toml"
+        f.write_text(f.read_text() + "\n# local edit\n", encoding="utf-8")
+        status = check_studio(target_dir, studio_dir)
+        assert "config/scopes.toml" in status["locally_modified"]
+        assert "run_phase.py" not in status["locally_modified"]  # untouched → not flagged
+
 
 class TestUpdateStudio:
     """Tests for update_studio()."""
@@ -229,6 +238,29 @@ class TestUpdateStudio:
         # Should succeed (no SameFileError) and report no changes
         assert result["updated"] == 0
         assert result["added"] == 0
+
+    def test_update_blocked_on_local_modification(self, target_dir, studio_dir):
+        """A locally-edited snapshot file blocks update (no clobber); --force overrides."""
+        install_studio(target_dir, studio_dir)
+        # Local edit to an installed source file, WITHOUT syncing the manifest (drift).
+        cfg = target_dir / ".studio" / "source" / "config" / "scopes.toml"
+        cfg.write_text(cfg.read_text() + "\n# my local tweak\n", encoding="utf-8")
+        # Make an update appear pending by dropping a different file from the manifest.
+        manifest_path = target_dir / ".studio" / "MANIFEST.json"
+        manifest = json.loads(manifest_path.read_text())
+        del manifest["verdict.py"]
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        # update refuses to clobber the local edit
+        result = update_studio(target_dir, studio_dir)
+        assert result.get("blocked") is True
+        assert "config/scopes.toml" in result["locally_modified"]
+        assert "# my local tweak" in cfg.read_text()  # edit survived
+
+        # --force overrides — the edit is intentionally overwritten
+        forced = update_studio(target_dir, studio_dir, force=True)
+        assert not forced.get("blocked")
+        assert "# my local tweak" not in cfg.read_text()
 
 
 class TestSnapshotStaleDetection:


### PR DESCRIPTION
Opened as a **draft** per the new Git/PR etiquette this PR adds. 🙂

## Why

You hit a case where the agent running `/studio-update` feared overwriting existing config. Validated: project config at `<repo>/.studio/*.toml` was always safe (update never writes there), but **edited files inside the snapshot** (`<repo>/.studio/source/**`, e.g. an edited shipped config) *do* get overwritten on update — because update re-installs the whole snapshot. This adds a real guard.

## Clobber-preview precondition

- **`check_studio` now returns `locally_modified`** — installed source files whose on-disk content has drifted from the checksum recorded at install (the clobber set). Distinct from `changed` (upstream-vs-installed = an update is available).
- **`update_studio` gains `force`** — when `locally_modified` is non-empty it returns `{blocked: True, locally_modified: [...]}` instead of overwriting.
- **`check-install`** surfaces a `⚠️ LOCAL EDITS` preview; **`update`** prints `Update BLOCKED` + the files + guidance (move project config to `<repo>/.studio/`, or re-run with `--force`).
- **`studio-update.md`** makes the preview a hard pre-condition and tells the agent **not** to `--force` on its own — surface to the human.

Tests: check flags an edited snapshot file; update blocks (edit survives); `--force` overrides. **620 pass.**

## Also: Git/PR etiquette in the injected principles

Added a section to `CODING_PRINCIPLES.md` (injected into every target repo's CLAUDE.md): **open PRs as drafts first** — prevents accidental early merges and reviewer churn on a moving target. Flip to ready when complete + green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)