### PR TITLE
docs: unstale doc-sync — roles, counts, --force, dupes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,8 +157,8 @@ python studio/run_phase.py notify --run-dir <run_dir> --dry-run  # print payload
 
 # Cross-repo install (installs slash commands + source into any project)
 python studio/run_phase.py init --target /path/to/project
-python studio/run_phase.py check-install --target /path/to/project
-python studio/run_phase.py update --target /path/to/project
+python studio/run_phase.py check-install --target /path/to/project   # previews locally-edited snapshot files an update would clobber
+python studio/run_phase.py update --target /path/to/project          # add --force to overwrite locally-edited snapshot files
 
 # Setup wizard (configure roles, scopes, cleanup after install)
 python studio/run_phase.py setup --target . --status
@@ -199,7 +199,7 @@ All source lives under `studio/`. `run_phase.py` is the sole entrypoint using on
 
 ### Configuration files
 
-- **`studio.manifest.json`** — Defines all disciplines (marketing, product, design, art, engineering, test_engineer, qa, web_engineering, web_test_engineer, web_qa, ml, ai_engineer, pmm) with advocate/contrarian focuses, deliverables, escalation cues, and role dependencies.
+- **`studio.manifest.json`** — Defines all disciplines (marketing, product, design, art, engineering, test_engineer, qa, web_engineering, web_product, web_test_engineer, web_qa, ml, ai_engineer, pmm) with advocate/contrarian focuses, deliverables, escalation cues, and role dependencies.
 - **`role_packs/*.json`** — Curated pod presets (e.g., `studio_core` = marketing + product + design + art + engineering + test_engineer + qa). Override with `--roles +role/-role`. Role dependencies in the manifest auto-inject co-required roles (e.g., engineering always brings test_engineer).
 - **`config/scopes.toml`** — Default three-tier scope configuration (alignment → depth → polish) with output budgets and debate modes.
 - **`config/studio_settings.toml`** — Cleanup TTL and storage limits.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ python studio/run_phase.py stats --json           # machine-readable aggregate
 # Cross-repo install
 python studio/run_phase.py init --target /path/to/project
 python studio/run_phase.py check-install --target /path/to/project
-python studio/run_phase.py update --target /path/to/project
+python studio/run_phase.py update --target /path/to/project          # add --force to overwrite locally-edited snapshot files
 
 # Preview / execute storage cleanup
 python studio/run_phase.py cleanup --dry-run
@@ -322,14 +322,16 @@ studio/
   cleanup.py                # TTL + budget-based artifact cleanup + loose file removal
   rerun.py                  # Rejection context injection for iterate-on-failure
   verdict.py                # APPROVED/REJECTED extraction
+  impl_loop.py              # Implementation writer/editor loop config (LoopConfig + python -m impl_loop)
   integrations/             # Outbound run-digest webhooks (slack_digest.py → Slack/n8n)
   validators/               # DocumentValidator + CodeValidator
-  studio.manifest.json      # Role definitions (13 disciplines)
+  studio.manifest.json      # Role definitions (14 disciplines)
   role_packs/*.json          # Curated role sets (studio_core, etc.)
   config/scopes.toml         # Default scope configuration
   config/studio_settings.toml # Cleanup settings
+  config/implementation_loop.toml # Implementation writer/editor loop defaults
   docs/                     # Guides, role prompts, architecture
-  tests/                    # 585 tests (pytest)
+  tests/                    # 621 tests (pytest)
 ```
 
 ---
@@ -340,7 +342,7 @@ studio/
 cd studio && python -m pytest tests/ -v
 ```
 
-585 tests covering: prepare/finalize lifecycle, role resolution with dependency injection, TTL/budget cleanup with boundary conditions, loose file cleanup, scope allocation, rerun detection, fresh-run/cross-phase context reset, verdict extraction, document validation, code validation, decision point parsing, clarity scoring, role overrides, phase persona overrides, cross-repo artifact routing, install/update workflows (incl. stale-snapshot resolution), CLAUDE.md principles injection, agent metrics tracking, quality ratings and cross-run stats, CLAUDE.md offload analysis, unstale audit configuration, setup wizard configuration, and Slack/n8n run-digest webhooks.
+621 tests covering: prepare/finalize lifecycle, role resolution with dependency injection, TTL/budget cleanup with boundary conditions, loose file cleanup, scope allocation, rerun detection, fresh-run/cross-phase context reset, verdict extraction, document validation, code validation, decision point parsing, clarity scoring, role overrides, phase persona overrides, cross-repo artifact routing, install/update workflows (incl. stale-snapshot resolution), CLAUDE.md principles injection, agent metrics tracking, quality ratings and cross-run stats, CLAUDE.md offload analysis, unstale audit configuration, setup wizard configuration, and Slack/n8n run-digest webhooks.
 
 Python 3.10+ required. stdlib only, plus `tomli` on Python 3.10 (see `pyproject.toml`).
 

--- a/studio/docs/AGENTS_REFERENCE.md
+++ b/studio/docs/AGENTS_REFERENCE.md
@@ -34,7 +34,7 @@ The non-studio phases each follow a single Advocate ↔ Contrarian loop, then ha
 
 ### Studio Phase (Role Packs)
 
-Studio phase now hosts as many Advocate↔Contrarian duos as needed. The full role menu (all 13 manifest roles) is below; the default `studio_core` pack uses the first seven — marketing, product, design, art, engineering, test_engineer, qa — and you add others with `--roles +<role>`:
+Studio phase now hosts as many Advocate↔Contrarian duos as needed. The full role menu (all 14 manifest roles) is below; the default `studio_core` pack uses the first seven — marketing, product, design, art, engineering, test_engineer, qa — and you add others with `--roles +<role>`:
 
 | Role Key | Title | Advocate Focus | Contrarian Focus | Deliverables (examples) |
 | --- | --- | --- | --- | --- |
@@ -45,6 +45,7 @@ Studio phase now hosts as many Advocate↔Contrarian duos as needed. The full ro
 | engineering | Principal Gameplay Engineer | Architecture, integrations, performance | Ops toil, technical risk | System outline, stack choices, ops checklist |
 | test_engineer | Staff Test Engineer — AI-TDD Integrity | Scenario-first test design, stack boundaries, mutation verification | Self-mocking tests, hallucinated assertions, green checkmark trap | Test spec (GWT), context boundary, mutation plan, anti-pattern audit |
 | qa | Release QA & Launch Ops Lead | Validation strategy, telemetry | Coverage breadth, environment readiness, support gaps | Test matrix, rollback plan, instrumentation gaps |
+| web_product | Director of Product — Web Platforms & Creator Tools | Opportunity framing (ICP, JTBD, positioning), build-vs-fork-vs-buy, monetization/licensing fit, MVI roadmap | Undifferentiated positioning, vague ICP, licensing/IP traps, MVI violations | Opportunity framing, build-vs-fork-vs-buy recommendation, phased MVI roadmap, success/kill metrics |
 | web_engineering | Lead Web Engineer — Next.js & Static Export | Architecture for App Router, static export, route structure | Hydration mismatches, route conflicts, static export limitations | Architecture evaluation, route validation, export verification |
 | web_test_engineer | Staff Test Engineer — Web & Static Export | Scenario-first testing for static export, route generation | False-confidence tests, dev-only passes, missing content verification | Static export test spec, route accessibility plan, SEO checklist |
 | web_qa | Release QA Lead — Static Site Deployment | GitHub Pages validation, route resolution, asset loading | Missing routes, broken asset paths, cache invalidation gaps | Deployment smoke test matrix, export completeness checklist |

--- a/studio/docs/API.md
+++ b/studio/docs/API.md
@@ -31,8 +31,8 @@ Supported commands:
 | `stats` | Cross-run diagnostics dashboard: verdict/approval rate, avg + lowest human ratings, token/cost efficiency, decision priority mix + answer rate, and prepare-usage counts. Supports `--phase`, `--json`, `--artifact-root`. |
 | `offload` | Analyzes CLAUDE.md for content safe to offload to companion docs. Classifies sections, scores pointer strength, generates reports. |
 | `init` | Installs Studio into a target project directory. |
-| `check-install` | Checks if installed Studio is up to date. |
-| `update` | Updates installed Studio from source. |
+| `check-install` | Checks if installed Studio is up to date. Also previews any locally-edited snapshot files that an `update` would overwrite. |
+| `update` | Updates installed Studio from source. Refuses to overwrite locally-edited snapshot files unless `--force` is passed (clobber guard). |
 | `setup` | Configure Studio for a project — role pack selection, role + phase-persona customization (`.studio/personas.toml`), unstale audit config (`.studio/unstale.toml`), scope tuning, cleanup settings. Supports `--status`, `--defaults`, `--answers`, `--role-pack`. |
 | `notify` | Posts a run digest to enabled Slack/n8n webhooks (config in `.studio/integrations.toml`). Auto-fires on `finalize` when a target is enabled (soft-fail). Supports `--run-dir`, `--dry-run`, `--artifact-root`. |
 

--- a/studio/docs/INTEGRATION_GUIDE.md
+++ b/studio/docs/INTEGRATION_GUIDE.md
@@ -176,7 +176,6 @@ Commit these helpers to dependent repos if you want reproducible ergonomics; oth
 ## 6. Reference Docs
 
 - [README.md](../../README.md) – top-level overview and testing notes.
-- [CLAUDE_CODE_USAGE.md](./CLAUDE_CODE_USAGE.md) – Claude Code slash commands and workflow.
 - [CLAUDE_CODE_USAGE.md](./CLAUDE_CODE_USAGE.md) – Claude Code slash commands and agent workflow.
 - [windsurf/USAGE.md](./windsurf/USAGE.md) – Windsurf/Cascade-specific workflow.
 - [API.md](./API.md) – command/JSON schema for `run_phase.py`, metadata, and logs.

--- a/studio/docs/tickets/TICKET-slack-n8n-digest.md
+++ b/studio/docs/tickets/TICKET-slack-n8n-digest.md
@@ -125,15 +125,15 @@ Each step is independently verifiable; land them in this order.
 
 ## Acceptance criteria
 
-- [ ] `studio/integrations/__init__.py` + `slack_digest.py` exist; stdlib-only imports.
-- [ ] `notify` subcommand prepares + posts digest for a finalized run; `--dry-run` prints payloads.
-- [ ] Slack payload renders as a Block Kit digest (verified in Block Kit Builder).
-- [ ] n8n payload is flat JSON addressable as `$json.body.<field>`; optional auth header sent when configured.
-- [ ] Webhook failure / timeout / 429 is handled soft (logged, returns False, no exception escapes).
-- [ ] No secret in repo: URL read from env var named in `.studio/integrations.toml`.
-- [ ] `studio/tests/test_slack_digest.py` covers: payload build, success, HTTP error, timeout, 429 retry, disabled/no-config no-op — all with `urllib` mocked.
-- [ ] Docs updated: `CLAUDE.md` CLI list + a short `studio/docs/INTEGRATIONS.md`.
-- [ ] All existing tests still pass (`cd studio && python -m pytest tests/ -v`).
+- [x] `studio/integrations/__init__.py` + `slack_digest.py` exist; stdlib-only imports.
+- [x] `notify` subcommand prepares + posts digest for a finalized run; `--dry-run` prints payloads.
+- [x] Slack payload renders as a Block Kit digest (verified in Block Kit Builder).
+- [x] n8n payload is flat JSON addressable as `$json.body.<field>`; optional auth header sent when configured.
+- [x] Webhook failure / timeout / 429 is handled soft (logged, returns False, no exception escapes).
+- [x] No secret in repo: URL read from env var named in `.studio/integrations.toml`.
+- [x] `studio/tests/test_slack_digest.py` covers: payload build, success, HTTP error, timeout, 429 retry, disabled/no-config no-op — all with `urllib` mocked.
+- [x] Docs updated: `CLAUDE.md` CLI list + a short `studio/docs/INTEGRATIONS.md`.
+- [x] All existing tests still pass (`cd studio && python -m pytest tests/ -v`).
 
 ## References
 


### PR DESCRIPTION
Output of a `/unstale` staleness audit (5 parallel agents: docs, code comments, memory, cross-refs, tracking). Code comments came back clean; these are the doc/tracking fixes.

## Fixed
- **`web_product` role** (the 14th manifest discipline) was missing from the CLAUDE.md role list, README's "13 disciplines" count, and the `AGENTS_REFERENCE.md` role table — added in all three.
- **Counts:** test count `585 → 621`; disciplines `13 → 14`; added `impl_loop.py` and `config/implementation_loop.toml` to the README project structure (were shipped but undocumented).
- **`update --force`** (the clobber-guard bypass from #41) documented in `API.md`, `CLAUDE.md`, and `README.md`.
- **Duplicate** `CLAUDE_CODE_USAGE.md` reference removed in `INTEGRATION_GUIDE.md`.
- **`TICKET-slack-n8n-digest.md`** marked shipped but had all acceptance-criteria boxes unchecked — checked them.

Memory files (MEMORY.md status line, slash-command list, implementation-loop phase status) were also refreshed locally; not in this PR.

## Not changed (verified clean / intentionally preserved)
- All Python docstrings/comments current (agent found zero drift, zero stale TODOs).
- Historical changelog/PR-note counts left as-is (accurate at their version).
- The 4 open stats/n8n-activation tickets are correctly still open.

Docs only — **621 tests still pass**. Stacked on #41 because the `--force` feature it documents lives there; rebase to main once #41 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)