### PR TITLE
feat(install): extend clobber guard to .claude/ commands & workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to TheGameStudio are documented here.
 - `No Merge Conflicts` CI workflow (`.github/workflows/no-merge-conflicts.yml`) to satisfy branch ruleset
 
 ### Fixed
+- Clobber guard now covers the verbatim `.claude/` commands & workflows, not just `.studio/source/` files — the install manifest checksums `.claude/commands/*` and `.claude/workflows/*` too, so a locally-edited slash command or workflow is reported by `check-install` and blocks `update` (unless `--force`) instead of being silently overwritten
 - `check-install`/`update` stale-snapshot detection (#20) — run through the installed snapshot, both compared it against its own manifest and always reported "up to date", silently blocking updates. Now resolves the live upstream from `VERSION.source_path`, warning loudly when it can't
 - Installer omitted the `integrations` subpackage — `init`/`update` shipped without `integrations/__init__.py` + `slack_digest.py`, breaking every command in installed projects
 - Slack digest body now includes the run summary + final-doc pointer, prefers a plain-language `digest.md` over the dense `summary.md`, and renders markdown as Slack `mrkdwn`

--- a/studio/install.py
+++ b/studio/install.py
@@ -214,16 +214,54 @@ def _collect_source_files(studio_dir: Path) -> List[Path]:
 
 
 
+def _claude_manifest_keys(studio_dir: Path) -> List[str]:
+    """Manifest keys for the verbatim ``.claude/`` commands + workflows.
+
+    These install OUTSIDE ``.studio/source/`` (into ``.claude/commands/`` and
+    ``.claude/workflows/``), so they're keyed by their repo-root-relative install
+    path (``.claude/commands/run-phase.md``) to distinguish them from source files
+    (keyed bare, relative to ``.studio/source/``). Including them in the manifest
+    is what lets the clobber guard notice local edits to a command or workflow.
+    """
+    repo_root = studio_dir.parent
+    keys: List[str] = []
+    for name in SLASH_COMMANDS:
+        if (repo_root / ".claude" / "commands" / name).is_file():
+            keys.append(f".claude/commands/{name}")
+    for name in WORKFLOW_FILES:
+        if (repo_root / ".claude" / "workflows" / name).is_file():
+            keys.append(f".claude/workflows/{name}")
+    return keys
+
+
+def _manifest_source_path(studio_dir: Path, key: str) -> Path:
+    """Map a manifest key to its file in the live source tree."""
+    if key.startswith(".claude/"):
+        return studio_dir.parent / key
+    return studio_dir / key
+
+
+def _manifest_installed_path(target: Path, key: str) -> Path:
+    """Map a manifest key to its installed file in the target."""
+    if key.startswith(".claude/"):
+        return target / key
+    return target / ".studio" / "source" / key
+
+
 def _build_manifest(
-    source_files: List[Path],
+    manifest_keys: List[str],
     studio_dir: Path,
 ) -> Dict[str, str]:
-    """Build install manifest: {relative_path: sha256}."""
+    """Build install manifest: {key: sha256}.
+
+    Keys are resolved to their live-source path via ``_manifest_source_path`` so
+    source files and the verbatim ``.claude/`` files share one flat manifest.
+    """
     manifest: Dict[str, str] = {}
-    for rel in source_files:
-        full = studio_dir / rel
+    for key in manifest_keys:
+        full = _manifest_source_path(studio_dir, str(key))
         if full.is_file():
-            manifest[str(rel)] = _sha256(full)
+            manifest[str(key)] = _sha256(full)
     return manifest
 
 
@@ -349,8 +387,9 @@ def install_studio(target: Path, studio_dir: Optional[Path] = None) -> Path:
     (dot_studio / "output").mkdir(parents=True, exist_ok=True)
     (dot_studio / "knowledge").mkdir(parents=True, exist_ok=True)
 
-    # Build and write manifest
-    manifest = _build_manifest(source_files, studio_dir)
+    # Build and write manifest (source files + verbatim .claude/ commands & workflows)
+    manifest_keys = [str(p) for p in source_files] + _claude_manifest_keys(studio_dir)
+    manifest = _build_manifest(manifest_keys, studio_dir)
     manifest_path = dot_studio / "MANIFEST.json"
     manifest_path.write_text(
         json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8"
@@ -396,9 +435,10 @@ def check_studio(target: Path, studio_dir: Optional[Path] = None) -> dict:
         changed: list[str] — files where upstream differs from what was installed (update available)
         missing: list[str] — files in source but not installed
         extra: list[str] — files installed but not in source
-        locally_modified: list[str] — installed source files whose ON-DISK content has
+        locally_modified: list[str] — installed files whose ON-DISK content has
             drifted from the checksum recorded at install — i.e. local edits that an
-            `update` would OVERWRITE (the clobber set; commonly an edited snapshot config)
+            `update` would OVERWRITE (the clobber set; spans both .studio/source/
+            files and the verbatim .claude/ commands/workflows)
         warning: str | None — set when the live source could not be resolved
             (e.g. run from a stale snapshot), so the result may be unreliable
     """
@@ -420,9 +460,10 @@ def check_studio(target: Path, studio_dir: Optional[Path] = None) -> dict:
         except (json.JSONDecodeError, ValueError):
             installed_manifest = {}
 
-    # Build current source manifest
+    # Build current source manifest (source files + verbatim .claude/ files)
     source_files = _collect_source_files(studio_dir)
-    source_manifest = _build_manifest(source_files, studio_dir)
+    manifest_keys = [str(p) for p in source_files] + _claude_manifest_keys(studio_dir)
+    source_manifest = _build_manifest(manifest_keys, studio_dir)
 
     changed: List[str] = []
     missing: List[str] = []
@@ -440,12 +481,12 @@ def check_studio(target: Path, studio_dir: Optional[Path] = None) -> dict:
         if rel not in source_manifest:
             extra.append(rel)
 
-    # Local modifications: installed source file on disk differs from what was recorded
-    # at install. These are the files an `update` re-install would clobber.
-    source_dest = dot_studio / "source"
+    # Local modifications: installed file on disk differs from what was recorded
+    # at install. These are the files an `update` re-install would clobber —
+    # source files under .studio/source/ AND the verbatim .claude/ commands/workflows.
     locally_modified: List[str] = []
     for rel, recorded_sha in installed_manifest.items():
-        f = source_dest / rel
+        f = _manifest_installed_path(target, rel)
         if f.is_file() and _sha256(f) != recorded_sha:
             locally_modified.append(rel)
     locally_modified.sort()

--- a/studio/tests/test_install.py
+++ b/studio/tests/test_install.py
@@ -78,6 +78,19 @@ class TestInstallStudio:
         assert "run_phase.py" in manifest
         assert len(manifest["run_phase.py"]) == 64  # SHA-256 hex
 
+    def test_manifest_covers_claude_commands_and_workflows(self, target_dir, studio_dir):
+        """Manifest checksums the verbatim .claude/ commands + workflows too, so the
+        clobber guard can see local edits to them — not just .studio/source/ files."""
+        install_studio(target_dir, studio_dir)
+        manifest = json.loads((target_dir / ".studio" / "MANIFEST.json").read_text())
+        assert ".claude/commands/run-phase.md" in manifest
+        assert ".claude/workflows/implementation-loop.js" in manifest
+        # Recorded checksum matches the installed file on disk.
+        wf = target_dir / ".claude" / "workflows" / "implementation-loop.js"
+        import hashlib
+        assert manifest[".claude/workflows/implementation-loop.js"] == \
+            hashlib.sha256(wf.read_bytes()).hexdigest()
+
     def test_creates_output_and_knowledge_dirs(self, target_dir, studio_dir):
         """Install creates .studio/output/ and .studio/knowledge/."""
         install_studio(target_dir, studio_dir)
@@ -191,6 +204,14 @@ class TestCheckStudio:
         assert "config/scopes.toml" in status["locally_modified"]
         assert "run_phase.py" not in status["locally_modified"]  # untouched → not flagged
 
+    def test_check_reports_locally_modified_command(self, target_dir, studio_dir):
+        """A locally-edited .claude/ command/workflow is in the clobber set too."""
+        install_studio(target_dir, studio_dir)
+        cmd = target_dir / ".claude" / "commands" / "run-phase.md"
+        cmd.write_text(cmd.read_text() + "\n<!-- local edit -->\n", encoding="utf-8")
+        status = check_studio(target_dir, studio_dir)
+        assert ".claude/commands/run-phase.md" in status["locally_modified"]
+
 
 class TestUpdateStudio:
     """Tests for update_studio()."""
@@ -261,6 +282,26 @@ class TestUpdateStudio:
         forced = update_studio(target_dir, studio_dir, force=True)
         assert not forced.get("blocked")
         assert "# my local tweak" not in cfg.read_text()
+
+    def test_update_blocked_on_locally_modified_command(self, target_dir, studio_dir):
+        """An edited .claude/ command blocks update (clobber guard); --force overwrites it."""
+        install_studio(target_dir, studio_dir)
+        cmd = target_dir / ".claude" / "commands" / "run-phase.md"
+        cmd.write_text(cmd.read_text() + "\n<!-- my command tweak -->\n", encoding="utf-8")
+        # Make an update appear pending by dropping an unrelated file from the manifest.
+        manifest_path = target_dir / ".studio" / "MANIFEST.json"
+        manifest = json.loads(manifest_path.read_text())
+        del manifest["verdict.py"]
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        result = update_studio(target_dir, studio_dir)
+        assert result.get("blocked") is True
+        assert ".claude/commands/run-phase.md" in result["locally_modified"]
+        assert "<!-- my command tweak -->" in cmd.read_text()  # edit survived
+
+        forced = update_studio(target_dir, studio_dir, force=True)
+        assert not forced.get("blocked")
+        assert "<!-- my command tweak -->" not in cmd.read_text()
 
 
 class TestSnapshotStaleDetection:


### PR DESCRIPTION
## Why

PR #41 added a clobber guard: `update` refuses to overwrite installed files that a user has locally edited (drifted from their recorded checksum). But the install **MANIFEST.json only checksummed `.studio/source/` files** — the verbatim `.claude/commands/*` and `.claude/workflows/*` were copied on every install yet never tracked. So a user who locally edited a slash command or the `implementation-loop.js` workflow had that edit **silently overwritten** on the next `update`, with no warning. This closes that altitude gap from #41.

## What

Track the `.claude/` commands & workflows in the same flat manifest:

- **`_claude_manifest_keys()`** — collect keys for the shipped commands + workflows that exist, keyed by their repo-root install path (`.claude/commands/run-phase.md`) to distinguish them from bare source keys (`run_phase.py`, relative to `.studio/source/`).
- **`_manifest_source_path()` / `_manifest_installed_path()`** — location-aware resolution so source files (`.studio/source/…`) and `.claude/` files (`.claude/…`) share one manifest. Keys starting with `.claude/` resolve against repo-root (source) and target-root (install); everything else against `.studio/source/` as before.
- `install_studio` and `check_studio` now feed both key sets into `_build_manifest`; the `locally_modified` scan resolves each key's on-disk path via the helper.

Result: `check-install` reports a locally-edited command/workflow, and `update` blocks on it (unless `--force`) exactly like a source file.

## Tests (+3, 624 total green)

- `test_manifest_covers_claude_commands_and_workflows` — manifest contains `.claude/commands/*` + `.claude/workflows/*` keys with correct checksums
- `test_check_reports_locally_modified_command` — edited command shows up in the clobber set
- `test_update_blocked_on_locally_modified_command` — update blocks on an edited command; `--force` overwrites it

Verified end-to-end against a real temp install: 8 commands + 1 workflow tracked, workflow edit detected, update blocked, edit survived.

## Notes

- **Transition gap (by design):** existing installs have no recorded baseline for `.claude/` files yet, so the *first* `update` after this lands can't protect a pre-existing command edit — there's no checksum to compare against (same situation source files were in before the manifest existed). After that first reinstall writes the baseline, future edits are protected.
- The user-facing `--force` doc currently says "snapshot files" (in #42, unmerged). Once #42 merges I'll rebase and broaden that wording to "installed files (source + commands/workflows)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)