### PR TITLE
docs: human-voice principle (§6) + plainer install docs + count sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to TheGameStudio are documented here.
 - `No Merge Conflicts` CI workflow (`.github/workflows/no-merge-conflicts.yml`) to satisfy branch ruleset
 
 ### Fixed
-- Clobber guard now covers the verbatim `.claude/` commands & workflows, not just `.studio/source/` files — the install manifest checksums `.claude/commands/*` and `.claude/workflows/*` too, so a locally-edited slash command or workflow is reported by `check-install` and blocks `update` (unless `--force`) instead of being silently overwritten
+- `update` no longer silently overwrites your local edits to slash commands or workflows. It already protected the Studio source files; now it also tracks the installed `.claude/commands/*` and `.claude/workflows/*`, so `check-install` flags an edit you've made to one of them and `update` stops before overwriting it (pass `--force` to overwrite anyway)
 - `check-install`/`update` stale-snapshot detection (#20) — run through the installed snapshot, both compared it against its own manifest and always reported "up to date", silently blocking updates. Now resolves the live upstream from `VERSION.source_path`, warning loudly when it can't
 - Installer omitted the `integrations` subpackage — `init`/`update` shipped without `integrations/__init__.py` + `slack_digest.py`, breaking every command in installed projects
 - Slack digest body now includes the run summary + final-doc pointer, prefers a plain-language `digest.md` over the dense `summary.md`, and renders markdown as Slack `mrkdwn`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,25 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
+### 5. Git & PR Etiquette
+
+**Open pull requests as drafts first.**
+
+A new PR starts as a **draft**, not ready-for-review. Mark it ready only when the work is complete, tests pass, and you actually want a human to review and merge it. Opening as a draft prevents two failure modes: accidental early merges (a not-yet-finished PR getting merged by mistake) and reviewer churn (reviewers spending attention on a still-moving target). Flip to ready when it's genuinely ready for eyes.
+
+### 6. Write Docs & Comments for Humans
+
+**A person reads your docs and comments. Write for that person.**
+
+This covers everything you write for humans rather than the compiler: doc files, code comments, docstrings, commit messages, and PR descriptions.
+
+- Use plain language. If a term of art is unavoidable, define it the first time or pick a simpler word.
+- Say what a thing does and why it matters, not just its name. "Refuses to overwrite your local edits" beats "enforces the clobber-guard precondition."
+- Cut the tells of machine-written prose: inflated phrasing, filler, hedging, and padding add length without adding meaning.
+- Match the voice already in the file instead of importing your own.
+
+The test: could a teammate who is new to the code read it once and understand it, without asking you to translate?
+
 ---
 
 *Adapted from [Andrej Karpathy's coding principles](https://github.com/forrestchang/andrej-karpathy-skills).*
@@ -157,8 +176,8 @@ python studio/run_phase.py notify --run-dir <run_dir> --dry-run  # print payload
 
 # Cross-repo install (installs slash commands + source into any project)
 python studio/run_phase.py init --target /path/to/project
-python studio/run_phase.py check-install --target /path/to/project   # previews locally-edited snapshot files an update would clobber
-python studio/run_phase.py update --target /path/to/project          # add --force to overwrite locally-edited snapshot files
+python studio/run_phase.py check-install --target /path/to/project   # shows which of your local edits an update would overwrite
+python studio/run_phase.py update --target /path/to/project          # add --force to overwrite files you've edited locally
 
 # Setup wizard (configure roles, scopes, cleanup after install)
 python studio/run_phase.py setup --target . --status
@@ -190,7 +209,7 @@ All source lives under `studio/`. `run_phase.py` is the sole entrypoint using on
 - **`decision_points.py`** — Parses and formats inline decision points (P0/P1/P2 blockquotes) from agent output. Extracts decisions from completed runs into a consolidated log.
 - **`clarity.py`** — Per-topic Clarity Score tracking. Computes confidence from answered decisions, controls agent question density, persists to `clarity.json`. CLI: `show-clarity`, `set-clarity`, `recompute-clarity`.
 - **`verdict.py`** — Extracts APPROVED/REJECTED/UNKNOWN verdict from text.
-- **`install.py`** — Cross-repo installer: `init`/`check-install`/`update` copies source + slash commands into any project. Also injects coding principles into the target's `CLAUDE.md` via sentinel markers for safe updates.
+- **`install.py`** — Cross-repo installer: `init`/`check-install`/`update` copies the Studio source, slash commands, and workflows into any project. Tracks every copied file's checksum so `update` warns you (and stops, unless `--force`) before overwriting a file you've edited locally. Also injects coding principles into the target's `CLAUDE.md` via sentinel markers for safe updates.
 - **`offload.py`** — CLAUDE.md analyzer: classifies sections, detects embedded constraints, scores pointer strength, generates offload reports and manages canary tokens.
 - **`setup.py`** — Setup wizard: project configuration after install. Tracks setup state in `.studio/SETUP.json`, generates role overrides, scopes, and cleanup config. Supports incremental re-configuration when new features are added.
 - **`impl_loop.py`** — Implementation-loop config: `LoopConfig` dataclass + `load_loop_config()` (tomllib/tomli fallback, resolution chain explicit → `.studio/` → shipped → defaults, patterned on `scopes.py`). `runtime_knobs()` + a `python -m impl_loop` JSON CLI project the resolved config into the knobs the `.claude/workflows/implementation-loop.js` Workflow consumes (editor on/off, read scope, output budget, mutation/static gates). The only Python piece of the writer/editor implementation loop; see `studio/docs/IMPLEMENTATION_LOOP_SPEC.md`.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ python studio/run_phase.py stats --json           # machine-readable aggregate
 # Cross-repo install
 python studio/run_phase.py init --target /path/to/project
 python studio/run_phase.py check-install --target /path/to/project
-python studio/run_phase.py update --target /path/to/project          # add --force to overwrite locally-edited snapshot files
+python studio/run_phase.py update --target /path/to/project          # add --force to overwrite files you've edited locally
 
 # Preview / execute storage cleanup
 python studio/run_phase.py cleanup --dry-run
@@ -331,7 +331,7 @@ studio/
   config/studio_settings.toml # Cleanup settings
   config/implementation_loop.toml # Implementation writer/editor loop defaults
   docs/                     # Guides, role prompts, architecture
-  tests/                    # 621 tests (pytest)
+  tests/                    # 624 tests (pytest)
 ```
 
 ---
@@ -342,7 +342,7 @@ studio/
 cd studio && python -m pytest tests/ -v
 ```
 
-621 tests covering: prepare/finalize lifecycle, role resolution with dependency injection, TTL/budget cleanup with boundary conditions, loose file cleanup, scope allocation, rerun detection, fresh-run/cross-phase context reset, verdict extraction, document validation, code validation, decision point parsing, clarity scoring, role overrides, phase persona overrides, cross-repo artifact routing, install/update workflows (incl. stale-snapshot resolution), CLAUDE.md principles injection, agent metrics tracking, quality ratings and cross-run stats, CLAUDE.md offload analysis, unstale audit configuration, setup wizard configuration, and Slack/n8n run-digest webhooks.
+624 tests covering: prepare/finalize lifecycle, role resolution with dependency injection, TTL/budget cleanup with boundary conditions, loose file cleanup, scope allocation, rerun detection, fresh-run/cross-phase context reset, verdict extraction, document validation, code validation, decision point parsing, clarity scoring, role overrides, phase persona overrides, cross-repo artifact routing, install/update workflows (incl. stale-snapshot resolution), CLAUDE.md principles injection, agent metrics tracking, quality ratings and cross-run stats, CLAUDE.md offload analysis, unstale audit configuration, setup wizard configuration, and Slack/n8n run-digest webhooks.
 
 Python 3.10+ required. stdlib only, plus `tomli` on Python 3.10 (see `pyproject.toml`).
 

--- a/studio/docs/API.md
+++ b/studio/docs/API.md
@@ -31,8 +31,8 @@ Supported commands:
 | `stats` | Cross-run diagnostics dashboard: verdict/approval rate, avg + lowest human ratings, token/cost efficiency, decision priority mix + answer rate, and prepare-usage counts. Supports `--phase`, `--json`, `--artifact-root`. |
 | `offload` | Analyzes CLAUDE.md for content safe to offload to companion docs. Classifies sections, scores pointer strength, generates reports. |
 | `init` | Installs Studio into a target project directory. |
-| `check-install` | Checks if installed Studio is up to date. Also previews any locally-edited snapshot files that an `update` would overwrite. |
-| `update` | Updates installed Studio from source. Refuses to overwrite locally-edited snapshot files unless `--force` is passed (clobber guard). |
+| `check-install` | Checks whether the installed Studio is up to date, and shows any files you've edited locally that an `update` would overwrite: both the Studio source and the installed slash commands and workflows. |
+| `update` | Updates the installed Studio from source. If you've edited any installed file locally, it stops instead of overwriting your work; pass `--force` to overwrite anyway. This covers the Studio source as well as the installed slash commands and workflows. |
 | `setup` | Configure Studio for a project — role pack selection, role + phase-persona customization (`.studio/personas.toml`), unstale audit config (`.studio/unstale.toml`), scope tuning, cleanup settings. Supports `--status`, `--defaults`, `--answers`, `--role-pack`. |
 | `notify` | Posts a run digest to enabled Slack/n8n webhooks (config in `.studio/integrations.toml`). Auto-fires on `finalize` when a target is enabled (soft-fail). Supports `--run-dir`, `--dry-run`, `--artifact-root`. |
 

--- a/studio/docs/CODING_PRINCIPLES.md
+++ b/studio/docs/CODING_PRINCIPLES.md
@@ -66,6 +66,19 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 
 A new PR starts as a **draft**, not ready-for-review. Mark it ready only when the work is complete, tests pass, and you actually want a human to review and merge it. Opening as a draft prevents two failure modes: accidental early merges (a not-yet-finished PR getting merged by mistake) and reviewer churn (reviewers spending attention on a still-moving target). Flip to ready when it's genuinely ready for eyes.
 
+## 6. Write Docs & Comments for Humans
+
+**A person reads your docs and comments. Write for that person.**
+
+This covers everything you write for humans rather than the compiler: doc files, code comments, docstrings, commit messages, and PR descriptions.
+
+- Use plain language. If a term of art is unavoidable, define it the first time or pick a simpler word.
+- Say what a thing does and why it matters, not just its name. "Refuses to overwrite your local edits" beats "enforces the clobber-guard precondition."
+- Cut the tells of machine-written prose: inflated phrasing, filler, hedging, and padding add length without adding meaning.
+- Match the voice already in the file instead of importing your own.
+
+The test: could a teammate who is new to the code read it once and understand it, without asking you to translate?
+
 ---
 
 *These guidelines are working if:* fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.


### PR DESCRIPTION
## What & why

You asked for two things: doc/comment prose aimed at a human reader (less jargon), and for that to become a standing default for both me and every Studio consumer. This does both, and folds in the leftover `/unstale` count drift from PR #43.

### 1. New principle: "Write Docs & Comments for Humans"

Added as **§6** to `studio/docs/CODING_PRINCIPLES.md`, which Studio injects into every consumer repo's `CLAUDE.md` on install — so the guideline travels to consumers, not just this repo. Mirrored into this repo's own `CLAUDE.md`.

While doing that I found the project `CLAUDE.md` principles had **drifted**: it stopped at §4 and was missing **§5 (Git & PR Etiquette)**, which PR #41 added to the shipped `CODING_PRINCIPLES.md` but never synced back. So this adds §5 and §6 together to bring them level.

### 2. Plainer clobber-guard docs

The install protection from #41/#43 was described in insider shorthand ("clobber guard", "snapshot files"). Rewrote those spots for a human reader and ran a humanizer pass (no em-dashes in the new prose, no jargon left undefined):

- `CLAUDE.md`, `README.md` inline comments → "overwrite files you've edited locally"
- `API.md` `check-install`/`update` rows → plain description, names what's covered (Studio source + slash commands + workflows)
- `install.py` module blurb → mentions workflows + the checksum protection
- `CHANGELOG.md` `[Unreleased]` entry → reads as plain English

### 3. Count sync

`README.md` 621 → 624 tests (two spots); PR #43 added 3 tests after #42 last synced the docs.

## Notes

- No code changed — docs only. Install tests still green (37/37; full suite 624).
- Memory updates (test count, a note on #43, and a feedback entry codifying the human-voice default) were made locally and are intentionally not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)