### PR TITLE
fix: /spec template's inner mermaid fence breaks the outer code block

### DIFF
--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -100,9 +100,10 @@ into the spec as a known risk. A rejected architecture should not silently becom
 From the approved advocate proposal, the contrarian's critique, and the recorded decisions
 (`{run_dir}/decisions.md` if present), write the spec to the path from Step 1. Write it for two
 readers at once — a newcomer who needs to understand the feature, and an engineer who has to build
-it. Use this structure:
+it. Use this structure (the outer fence is four backticks so the inner ` ```mermaid ` block
+below doesn't close it early — the spec file you write uses a normal three-backtick fence):
 
-```markdown
+````markdown
 ---
 feature: <human title>
 slug: <slug>
@@ -156,7 +157,7 @@ spec that hides its soft spots is worse than one that names them.
 How this maps to buildable units — ideally a short list of MVI units (each a complete, usable
 interaction; "build a skateboard, not a wheel"), in dependency order. This is the bridge to
 `/studio-implement`.
-```
+````
 
 Keep the writing human (Coding Principles §6): plain language, say what a thing does and why it
 matters, match a calm engineering voice. The diagram is required, not optional — if the feature


### PR DESCRIPTION
## The bug

In `.claude/commands/spec.md`, the spec-template section wraps a sample document in a ` ```markdown ` fence, and that sample contains a ` ```mermaid ` diagram block. Most Markdown renderers close a fenced block at the **first** inner ` ``` ` line — so the outer fence terminates early at the mermaid block, and the second half of the template (everything from the diagram onward) spills out as broken plain text.

## The fix

Bump the outer template fence to **four backticks**. Per CommonMark, a fence is only closed by a line with the same or greater number of backticks, so the inner three-backtick mermaid block no longer ends it. Added a one-line note that the actual spec file `/spec` writes still uses a normal three-backtick fence.

Docs-only change to one command file. No code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)