### PR TITLE
feat: borrow two critique mechanisms from gstack

### DIFF
--- a/.claude/commands/forge.md
+++ b/.claude/commands/forge.md
@@ -120,14 +120,18 @@ wait for the completion notification.
 
 ### Step 5: Report the result
 
-The workflow returns `{ delivered, flagged, editorRan, finalVersion, writer, editor }`. Summarize
-for the user:
+The workflow returns `{ delivered, flagged, editorRan, finalVersion, reviewerConcerns, writer, editor }`.
+Summarize for the user:
 
 - **What was built** + final test status (`editor.tests` / `writer.tests`).
 - **What the editor changed** (`editor.edits`): the cuts/merges/restructures, or "nothing to cut".
 - **MVI verdict** (`editor.mvi_verdict`): call out explicitly if the editor *overturned* the
   writer's `mvi_claimed` (unit not actually usable → it's flagged, not silently shipped).
 - **Reverted?** (`editor.reverted`): if an edit broke green and was rolled back to `writer_sha`.
+- **Reviewer concerns** (`reviewerConcerns`): if non-empty, list them — these are real problems the
+  editor found but couldn't fix this pass (would break green, is load-bearing, or out of unit scope).
+  They are NOT blockers on delivery, but they are the loop's most useful output when the editor had
+  to revert. Point at `.studio/output/impl_loop/<unit_id>/reviewer-concerns.md`.
 - Point to the handoff records under `.studio/output/impl_loop/<unit_id>/`.
 
 If `flagged` is true, make clear the unit did NOT pass the full gate (delivered for inspection,

--- a/.claude/workflows/implementation-loop.js
+++ b/.claude/workflows/implementation-loop.js
@@ -98,6 +98,24 @@ const EDITOR_HANDOFF = {
     mvi_verdict: { type: 'boolean', description: 'AUTHORITATIVE: could someone use this unit? Overturns writer.mvi_claimed.' },
     edits: { type: 'string', description: 'what was cut / merged / renamed, and what (if anything) was lost' },
     reverted: { type: 'boolean', description: 'true if the editor reset to writer_sha because an edit broke green or hit a load_bearing item' },
+    // Reviewer Concerns — the third path between "edit it" and "silently drop it". A real problem the
+    // editor spotted but could NOT resolve within the tests-green + load_bearing + read-scope bounds.
+    // The loop is one-way (no re-run debate), so without this the critique evaporates on revert. Persisted
+    // so it surfaces to the human / the next unit instead of being lost.
+    unresolved_concerns: {
+      type: 'array',
+      description: 'problems the editor could not safely act on this pass; empty if none',
+      items: {
+        type: 'object',
+        required: ['concern', 'why_unresolved'],
+        additionalProperties: false,
+        properties: {
+          concern: { type: 'string', description: 'the specific problem, quoting the thing it is about' },
+          why_unresolved: { type: 'string', enum: ['breaks_green', 'load_bearing', 'out_of_unit_scope'], description: 'why it could not be fixed in this pass' },
+          suggested_followup: { type: 'string', description: 'the smallest next step that would resolve it' },
+        },
+      },
+    },
     stage: { type: 'string', enum: ['editor'] },
   },
 }
@@ -146,6 +164,15 @@ function editorPrompt(u, writer) {
     `- Do NOT remove a load_bearing item (${JSON.stringify(writer.load_bearing || [])}) without escalating.`,
     `- If an edit breaks tests, or you must touch a load_bearing item, REVERT: \`git reset --hard ${writer.writer_sha}\``,
     `  and set reverted=true. Never deliver red code from an edit.`,
+    ``,
+    `Reviewer Concerns — the third path. When you spot a REAL problem you cannot safely fix in this pass —`,
+    `an edit that would break green, a load_bearing item you'd need to touch, or something genuinely wrong that`,
+    `sits outside this unit's scope — do NOT force a breaking edit and do NOT let the concern evaporate on a`,
+    `revert. Record it in unresolved_concerns: the concern (quote the thing it's about), why_unresolved`,
+    `(breaks_green | load_bearing | out_of_unit_scope), and the smallest suggested_followup that would resolve`,
+    `it. This loop does not hand work back and forth, so this list is the ONLY place a valid-but-unactionable`,
+    `critique survives. Leave it empty if there is genuinely nothing. If it is non-empty, also write it as a`,
+    `readable checklist to ${runDir(u)}/reviewer-concerns.md (one item per section: concern, why, follow-up).`,
     ``,
     `Then render mvi_verdict: AUTHORITATIVELY judge "if we stopped here, could someone use this unit?" against`,
     `the title "${u.title}". This can overturn the writer's claim.`,
@@ -232,12 +259,17 @@ if (editHeld && editor && !editor.committed) {
   editor.committed = true
 }
 
-log(`Done. editorRan=${!!editor} editHeld=${editHeld} mvi_verdict=${editor?.mvi_verdict} reverted=${editor?.reverted} committed=${editor?.committed}`)
+const reviewerConcerns = (editor && Array.isArray(editor.unresolved_concerns)) ? editor.unresolved_concerns : []
+if (reviewerConcerns.length) {
+  log(`Editor logged ${reviewerConcerns.length} unresolved concern(s) → ${runDir(unit)}/reviewer-concerns.md`)
+}
+log(`Done. editorRan=${!!editor} editHeld=${editHeld} mvi_verdict=${editor?.mvi_verdict} reverted=${editor?.reverted} committed=${editor?.committed} concerns=${reviewerConcerns.length}`)
 return {
   delivered: true,
   flagged: !exitGate,                // delivered, but editor couldn't confirm a usable green unit
   editorRan: true,
   finalVersion: editHeld ? 'editor' : 'writer',
+  reviewerConcerns,                  // valid-but-unactionable critiques the one-way loop would otherwise lose
   writer,
   editor,
 }

--- a/studio/docs/GSTACK_COMPARISON.md
+++ b/studio/docs/GSTACK_COMPARISON.md
@@ -1,0 +1,103 @@
+# gstack vs Studio — what we learned and what we took
+
+A study of [garrytan/gstack](https://github.com/garrytan/gstack) (Garry Tan's open-source
+"virtual engineering team" of ~60 Claude Code skills), read against Studio to find ideas worth
+borrowing. This doc is the record of that comparison and the roadmap it produced. It is reference
+material, not a spec — the roadmap items below become their own specs when we build them.
+
+## The two systems, in one breath
+
+Both make the same bet: markdown skills + the filesystem as the bus + advocate/contrarian energy,
+no runtime, all intelligence in the assistant's execution. gstack built it out to production depth
+(real-browser QA, a persistent memory layer, cross-model review), pointed at general product
+shipping. Studio went deep on one mechanism — the structured advocate/contrarian debate — pointed
+at game development. Neither is a copy of the other; they converged on the same shape from opposite
+directions, which is why the differences are the interesting part.
+
+## The philosophical fork: "Boil the Ocean" vs "Simplicity First"
+
+gstack's first ethos principle is **Boil the Ocean**: because AI makes the marginal cost of
+completeness near-zero, do the *complete* thing every time — all edge cases, all error paths, tests
+included. Studio's CODING_PRINCIPLES §2 is the opposite instinct: **Simplicity First** — minimum
+code, nothing speculative.
+
+They are not actually in conflict, and the reconciliation is worth keeping in mind:
+
+- **Simplicity First governs *structure*** — the number of moving parts, concepts, abstractions.
+  Its target is the LLM's habit of over-engineering (200 lines of machinery for a 50-line problem).
+- **Boil the Ocean governs *coverage*** — how many of the real paths you actually handle. Its
+  target is the opposite LLM habit: stopping at 90%, deferring the tests, skipping the error path.
+
+A unit can be simple (few parts) *and* complete (all paths). §2 already says "remove concepts, not
+characters"; Boil the Ocean is the coverage-side complement to that. Where we lean toward cutting,
+it is worth being explicit that we cut *concepts*, not *thoroughness*.
+
+## The critique architecture — the core contrast
+
+Studio assigns two agents fixed roles (advocate piles on, contrarian-as-editor cuts), runs a
+scoped debate (alignment → depth → polish → integrator duel), and synthesizes a verdict. gstack
+deliberately **avoids fixed adversarial roles** and gets its "adversarial" signal four other ways:
+
+1. **Model diversity as the adversary** — Claude vs Codex (OpenAI), reconciled in a
+   CONFIRMED/DISAGREE consensus table, rather than one model arguing with itself.
+2. **Context asymmetry as the independence mechanism** — one reviewer primed with all prior
+   findings, the other a *cold* fresh subagent, to break groupthink.
+3. **Disagreement is never auto-resolved** — every DISAGREE routes to the human. Their whole ethos
+   is "models recommend, users decide"; even unanimous cross-model agreement is "strong signal, not
+   permission to act."
+4. **A meta-adversary aimed at the reviewer, not the plan** — a final pass whose only job is "find
+   what the review MISSED."
+
+Two mechanisms of theirs that a two-agent debate structurally lacks, and that we found most worth
+taking:
+
+- **The lone-critical override** — "a single critical finding from one voice is flagged
+  regardless." Consensus-seeking must never bury one serious concern.
+- **The convergence guard** — cap the writer/editor loop, and when they deadlock, *persist the
+  disagreement into the artifact* instead of looping forever.
+
+Where Studio is genuinely ahead: the structured *scoped* debate (theirs is a parallel panel, not a
+staged process), and the clarity score + canonical decision-point protocol as first-class,
+single-owner mechanisms (theirs surface decisions ad hoc via AskUserQuestion).
+
+## What we took (shipped)
+
+Two mechanisms ported directly, plus this doc:
+
+1. **Quote-to-promote + confidence bands in the contrarian's finding discipline**
+   (`scopes.py`, `CONTRARIAN_MANDATE`). Every flaw the contrarian raises must quote the exact thing
+   it critiques; if it cannot, the finding is marked `(unverified)` and demoted. Findings carry a
+   confidence, and the confidence sets how loudly they are raised (high → stated plainly; medium →
+   "verify this"; low/unverified → a separate "Lower-confidence notes" list, or dropped unless it
+   would be fatal). This is gstack's "#1539" gate — the cheapest known way to kill hallucinated
+   critiques — adapted to our critic role. Flows to every deliverable contrarian prompt; suppressed
+   in `--mode questions` (where cutting is wrong).
+
+2. **Reviewer Concerns in the `/forge` writer/editor loop**
+   (`implementation-loop.js`, `IMPLEMENTATION_LOOP_SPEC.md`, `forge.md`). Studio's loop is one-way
+   by design — it never hands work back, which is what keeps it from thrashing (the convergence
+   guard, already structural). The missing half was the *other* half of gstack's mechanism: a real
+   critique the editor can't act on this pass (would break green, hits a `load_bearing` item, or is
+   out of unit scope) used to evaporate on revert. The editor now records these in
+   `unresolved_concerns` and writes a `reviewer-concerns.md` artifact, so the second agent's most
+   valuable output survives instead of being lost.
+
+## Roadmap — the rest of the steal-list
+
+Ranked by leverage for Studio. Each becomes its own `/spec` when picked up.
+
+| # | Idea | What it buys | Rough effort | Notes |
+|---|------|--------------|--------------|-------|
+| R1 | **Independent verifier subagent** for contrarian findings | A finding is confirmed by a fresh agent that sees only the quoted `file:line` + the demote rules, *not* the original reasoning (anti-anchoring); +1 confidence when two agree. The verification arm behind the quote-to-promote gate we just shipped. | M | Natural next step after the confidence gate; pairs with it. |
+| R2 | **Compile skills/commands from templates + CI freshness gate** | Kills doc-rot structurally: `gen --dry-run \| git diff --exit-code` fails CI if a committed command doc drifts from source. This is what `/unstale` chases by hand. | L | Biggest architectural lift. gstack's own caution: don't hardcode install paths in generated output — resolve the root at runtime. |
+| R3 | **Named failure-mode citations as prompt anchors** | Encode past regressions directly in prompts ("this is the precise failure of the all-decisions-pause bug"). We keep these scars in memory; gstack keeps them in the prompt where they actually fire. | S | Cheap, high-value. Start with the decision-pause and impl-loop-in-worktree scars. |
+| R4 | **Delta-based alerts with N-consecutive-check persistence** | For any run-over-run comparison (ratings, session health, stats trends): alert on *changes* not absolutes, and only when a pattern persists 2+ checks. Best anti-noise rule they have. | S | Fits `stats.py` / session-health trends. |
+| R5 | **Lone-critical override in the scoped debate** | Don't let the integrator's synthesis bury a single serious contrarian finding just because the room didn't reach consensus on it. | S | Small change to integrator/polish guidance. |
+| R6 | **AI-slop blacklist + "would a designer be embarrassed?" self-gate** | A concrete rejection list for the design phase (and any UI work), plus an anti-convergence directive (vary the look across generations). Directly useful for game UI/marketing output. | M | Adapt their 11-item list to game dev. |
+| R7 | **Goodwill Reservoir UX score** | A UX heuristic that starts at 70 and is docked for dark patterns / credited for good behavior — makes "taste" a debuggable number. | M | Design-phase deliverable. |
+| R8 | **Secret-sink test harness with positive controls** | If Studio ever handles credentials: seed a fake secret, assert it never leaks to stdout/files/telemetry, *and* keep controls that deliberately leak to prove the detector works. | M | Only if/when we touch secrets (currently env-only webhooks). Lower priority. |
+
+## Source
+
+Full analysis (all four skill clusters) is captured in the memory note
+`reference_gstack_analysis`. Repo studied: https://github.com/garrytan/gstack (MIT), v1.60.x.

--- a/studio/docs/IMPLEMENTATION_LOOP_SPEC.md
+++ b/studio/docs/IMPLEMENTATION_LOOP_SPEC.md
@@ -87,7 +87,8 @@ The **editor** returns the same shape with `stage: "editor"`, its own `writer_sh
 diffs against the writer's), updated `tests` (re-run after its edits), an `edits` summary of what
 was cut / merged / renamed (and what, if anything, was lost), and `mvi_verdict`: its
 **authoritative** judgment of whether the unit is a usable interaction, which can overturn the
-writer's `mvi_claimed`. It does **not** carry a
+writer's `mvi_claimed`. It also carries `unresolved_concerns`: valid critiques it could not act on
+this pass (see "Reviewer Concerns" below), empty when there are none. It does **not** carry a
 separate `behavior_preserved` flag: "tests stay green" plus the `load_bearing` escalation already
 encode that invariant, so a third self-attested boolean was cut as redundant.
 
@@ -161,6 +162,17 @@ shallow-merges over (mirrors `persona_overrides.py` and `role_overrides.py`).
   `git reset --hard <writer_sha>` (or `git checkout <writer_sha> -- <files_touched>`) and records
   the disagreement in `edits`. Without that commit there is nothing to revert to: the snapshot
   is what makes "keep the writer's version" executable at all.
+
+- **Reviewer Concerns (persist the disagreement, don't loop on it):** the pipeline is one-way by
+  design — it never hands work back for another round, which is what keeps it from thrashing. The
+  cost of that is a real critique the editor *can't* act on this pass (it would break green, hit a
+  `load_bearing` item, or falls outside the unit) would simply vanish on revert. So the editor
+  records each such critique in `unresolved_concerns` — the concern (quoting what it's about), why
+  it couldn't be resolved (`breaks_green` | `load_bearing` | `out_of_unit_scope`), and the smallest
+  follow-up that would — and writes them to `reviewer-concerns.md` in the run directory. This is the
+  same move gstack's plan-review loop makes when a writer/editor pair deadlocks: stop looping,
+  persist the unresolved issue into the artifact so a human (or the next unit) sees it. It keeps the
+  loop one-way without throwing away the second agent's most valuable output.
 
 ### 4. Config: `implementation_loop.toml`
 

--- a/studio/run_phase.py
+++ b/studio/run_phase.py
@@ -974,6 +974,8 @@ def build_instruction_doc(
             "",
             "When you encounter a gap, ambiguity, or fork that could meaningfully change your approach, flag it as a decision point. Do NOT silently assume — surface it. This applies to **every pass** — the pre-flight front-loads the obvious questions, but each later pass must keep raising new ones as they surface.",
             "",
+            "> **Known failure mode — do not repeat.** An earlier version let agents hold their decisions and present them in a batch at the end (or leave them for the integrator). By then the run had already built on top of the unasked question, so the answer arrived too late to matter. Surface each decision the moment you hit it, per agent, inline — never collect them into a closing section and never defer them downstream.",
+            "",
             "### Format",
             "",
             "Use a markdown blockquote with a bold DECISION header:",
@@ -1097,6 +1099,7 @@ def build_instruction_doc(
                     "2. Add `### Integrator Contrarian` critiquing feasibility, ops risk, and sequencing. End with `VERDICT: APPROVED/REJECTED`.",
                     "3. If REJECTED, adjust with one additional mini-iteration (max 2 total) before continuing.",
                     "4. Close with `### Integrated Plan` that synthesizes both perspectives and lists next steps.",
+                    "   **Lone-critical override:** a single serious finding from one role's contrarian must not be dropped just because it wasn't the consensus or another role disagreed. Carry it into the plan — either resolved, or explicitly logged as an accepted risk with the reason. Synthesis reconciles findings; it never quietly buries the inconvenient one.",
                 ]
             )
 

--- a/studio/scopes.py
+++ b/studio/scopes.py
@@ -34,6 +34,14 @@ CONTRARIAN_MANDATE = [
     "- **Collapse, don't accumulate.** Prefer merging two things into one over adding a third. Prefer removing an option over adding configuration to support it.",
     "- **Guard the essence.** Cutting serves clarity and the core problem — never amputate what the problem genuinely requires. If a cut would break the core, say so and stop.",
     "- **Cut concepts, not clarity.** Remove features, layers, and options — but never compress readable code into dense or clever code to save lines. Explicit names and obvious steps are part of the essence you protect, not fat to trim.",
+    "",
+    "**Findings must earn their place — quote first, then rate.**",
+    "",
+    "Hunting flaws only helps when the flaws are real. A confident-sounding critique that turns out to be wrong wastes the room's attention and makes every later finding easier to wave off. So gate each flaw on evidence before you raise it:",
+    "",
+    "- **Quote before you claim.** For every flaw or objection, quote the exact thing you are critiquing — the specific claim, feature, step, or line from the advocate's proposal. If you cannot point at the exact thing, you have not verified it: mark the finding `(unverified)` and treat it as low-confidence.",
+    "- **Rate your confidence, and let the rating set how loudly you raise it.** *High* — you quoted the exact thing and showed concretely why it breaks: state it plainly as a finding. *Medium* — a real pattern you cannot fully prove here: raise it, tagged \"verify this.\" *Low / unverified* — no quote, or a hunch: collect these under a short **Lower-confidence notes** list at the end, kept out of your main findings; drop one entirely unless, if it were true, it would be fatal (a P0).",
+    "- **A vibe is not a finding.** \"This looks off\" or \"this might not scale\" earns nothing on its own. Either cite the evidence, or leave it out.",
 ]
 
 

--- a/studio/scopes.py
+++ b/studio/scopes.py
@@ -374,6 +374,8 @@ def generate_scope_prompt(
         "- **P1 (Important):** State your assumption and continue, but flag it.",
         "- **P2 (Context):** Nice-to-know, logged for completeness.",
         "",
+        "> **Known failure mode — do not repeat.** Do not hold decisions for a closing section or defer them to the integrator. By the time a batched decision surfaces, the run has already assumed past it. Flag each one inline, the moment you hit it.",
+        "",
     ])
 
     if stance == "advocate":


### PR DESCRIPTION
Two critique mechanisms borrowed from a study of [garrytan/gstack](https://github.com/garrytan/gstack), a ~60-skill Claude Code "virtual engineering team." The full comparison and the roadmap for the rest live in the new `studio/docs/GSTACK_COMPARISON.md`.

## What's here

**1. Quote-to-promote + confidence bands** (`studio/scopes.py`, `CONTRARIAN_MANDATE`)
The contrarian must now quote the exact thing it critiques or mark the finding `(unverified)`, and every finding carries a confidence that sets how loudly it's raised (high → stated plainly; medium → "verify this"; low/unverified → a separate notes list, or dropped unless it would be fatal). This is gstack's cheapest anti-hallucination gate, adapted to our critic role. Flows to every deliverable contrarian prompt; suppressed in `--mode questions`.

**2. Reviewer Concerns in `/forge`** (`.claude/workflows/implementation-loop.js`, spec, `forge.md`)
The writer/editor loop is one-way by design (no re-run debate — that's the convergence guard, already structural). The missing half: a real critique the editor can't act on this pass (breaks green, load-bearing, out of unit scope) used to vanish on revert. The editor now records these in `unresolved_concerns` and writes a `reviewer-concerns.md` artifact, so the second agent's most valuable output survives.

## Verification
- Full suite **755 passed**; `ruff` clean; workflow JS parses.
- Existing `CONTRARIAN_MANDATE` tests still green (they assert membership, so the added bullets are covered).

## Notes
- Docs updated per the documentation contract (`IMPLEMENTATION_LOOP_SPEC.md` + `forge.md`).
- Found (not touched): `test_decision_points.py::TestInstructionDocDecisionSection` fails only in a *partial* test selection due to cwd pollution between test files — pre-existing, invisible in the full-suite run.
- Roadmap R1–R8 for the remaining gstack borrowings is in `GSTACK_COMPARISON.md`; R3 + R5 (quick debate-sharpening wins) are next, on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
