### PR TITLE
feat(R1): independent verifier for contrarian findings

### DIFF
--- a/.claude/workflows/finding-verifier.js
+++ b/.claude/workflows/finding-verifier.js
@@ -52,19 +52,11 @@ const VERIFIER_HANDOFF = {
 // the ONLY thing the per-finding verifier is allowed to see.
 // ---------------------------------------------------------------------------
 phase('Select')
-const SELECT_SNIPPET = [
-  'import json, sys',
-  'from findings import load_findings_json',
-  'from verifier import select_findings_to_verify',
-  'run_dir = sys.argv[1]',
-  'findings = load_findings_json(run_dir)',
-  'rows = [',
-  '    {"index": i, "quote": f.quote}',
-  '    for i, f in enumerate(findings)',
-  '    if f in select_findings_to_verify(findings)',
-  ']',
-  'print(json.dumps(rows))',
-].join('; ')
+// The whole selector is one real Python function (verifier.select_rows_for_run), so this stays a
+// single valid statement-per-`;` line. The earlier form built a multi-line list comprehension and
+// joined it with '; ', which is a SyntaxError — it only ran because the agent hand-fixed it.
+const SELECT_SNIPPET =
+  'import json, sys; from verifier import select_rows_for_run; print(json.dumps(select_rows_for_run(sys.argv[1])))'
 const selected = await agent(
   [
     `List the Medium-confidence findings eligible for verification in the run directory \`${runDir}\`.`,

--- a/.claude/workflows/finding-verifier.js
+++ b/.claude/workflows/finding-verifier.js
@@ -39,7 +39,9 @@ const VERIFIER_HANDOFF = {
   properties: {
     finding_id: { type: 'integer', description: 'index of the finding in the ordered findings.json list' },
     verdict: { type: 'string', enum: ['confirmed', 'unconfirmed', 'uncertain'] },
-    resulting_confidence: { type: 'string', enum: ['high', 'medium', 'low'], description: 'optional; derived from the verdict when omitted' },
+    // No resulting_confidence override: confidence tracks veracity (two voices agree -> promote),
+    // never severity. The write-back always derives it from the verdict — confirmed promotes,
+    // unconfirmed demotes, uncertain leaves it. Whether a real flaw is *minor* is a separate axis.
     one_line_reason: { type: 'string', description: 'one line, from the verifier\'s own read of the code — not the contrarian\'s argument (it never saw it)' },
   },
 }
@@ -111,11 +113,11 @@ for (const item of eligible) {
       `The quote is \`file:line\` — "exact code/text". You MAY open that file at that line and read the`,
       `surrounding code to judge it. Do NOT go looking for any review notes, comments, or argument about it.`,
       ``,
-      `Demotion rules — return a verdict:`,
-      `- "confirmed": you independently see a real problem in this code -> resulting_confidence "high".`,
-      `- "unconfirmed": you read the code and cannot find the alleged problem -> resulting_confidence "low".`,
-      `- "uncertain": the quote (even with the code) doesn't give you enough to judge -> confidence unchanged.`,
-      `You may omit resulting_confidence to let the write-back derive it from the verdict.`,
+      `Return a verdict on whether the flaw is real (this is a veracity judgment, not a severity one —`,
+      `do not weigh how minor or major it is, only whether it is real):`,
+      `- "confirmed": you independently see a real problem in this code.`,
+      `- "unconfirmed": you read the code and cannot find the alleged problem.`,
+      `- "uncertain": the quote (even with the code) doesn't give you enough to judge.`,
       ``,
       `Set finding_id to ${item.index}. Give a one-line reason from YOUR OWN read of the code.`,
     ].join('\n'),
@@ -125,7 +127,6 @@ for (const item of eligible) {
     verdicts.push({
       index: item.index,
       verdict: verdict.verdict,
-      resulting_confidence: verdict.resulting_confidence,
     })
     log(`Finding #${item.index}: ${verdict.verdict}`)
   }

--- a/.claude/workflows/finding-verifier.js
+++ b/.claude/workflows/finding-verifier.js
@@ -71,16 +71,18 @@ const selected = await agent(
     `  cd studio && python -c '${SELECT_SNIPPET}' "${runDir}"`,
     ``,
     `(If this Workflow runs in an installed repo, the modules live under .studio/source/ — cd there instead.)`,
-    `Return exactly the JSON array it prints: a list of { index, quote } objects. If it prints [], return [].`,
+    `Return a JSON object { "findings": [...] } wrapping the array it prints (a list of { index, quote } objects). If it prints [], return { "findings": [] }.`,
   ].join('\n'),
   {
-    schema: { type: 'array', items: { type: 'object', required: ['index', 'quote'], additionalProperties: false, properties: { index: { type: 'integer' }, quote: { type: 'string' } } } },
+    // NOTE: a custom tool's top-level input schema MUST be an object — the Anthropic API rejects a
+    // bare top-level array (400 input_schema.type). So the array of findings is wrapped in `findings`.
+    schema: { type: 'object', additionalProperties: false, required: ['findings'], properties: { findings: { type: 'array', items: { type: 'object', required: ['index', 'quote'], additionalProperties: false, properties: { index: { type: 'integer' }, quote: { type: 'string' } } } } } },
     label: 'select-medium-findings',
     phase: 'Select',
   },
 )
 
-const eligible = Array.isArray(selected) ? selected : []
+const eligible = (selected && Array.isArray(selected.findings)) ? selected.findings : []
 log(`Eligible Medium findings: ${eligible.length}`)
 if (eligible.length === 0) {
   return { verified: 0, confirmed: 0, demoted: 0, uncertain: 0 }

--- a/.claude/workflows/finding-verifier.js
+++ b/.claude/workflows/finding-verifier.js
@@ -1,0 +1,166 @@
+export const meta = {
+  name: 'finding-verifier',
+  description: 'Independent second opinion on contrarian findings — a fresh agent re-checks each Medium-confidence finding from ONLY its quote (never the contrarian\'s reasoning) and writes adjusted confidence back to findings.json. See specs/contrarian-finding-verifier.md.',
+  whenToUse: 'After a run produced findings.json, get its Medium-confidence findings an independent second opinion. Pass the run directory via args.',
+  phases: [
+    { title: 'Select', detail: 'load findings.json; pick the Medium-confidence findings' },
+    { title: 'Verify', detail: 'one fresh agent per finding — sees ONLY the quote + demotion rules' },
+    { title: 'Write-back', detail: 'aggregate verdicts; write adjusted confidence back to findings.json' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// args = the run directory containing findings.json. A bare string path is
+// accepted; a { run_dir } object also works. The runtime forwards args as a
+// JSON-encoded STRING, so normalize before use (same as implementation-loop.js).
+// ---------------------------------------------------------------------------
+let parsedArgs = args
+if (typeof parsedArgs === 'string') {
+  try { parsedArgs = JSON.parse(parsedArgs) } catch { /* leave as a raw path string */ }
+}
+const runDir = (parsedArgs && typeof parsedArgs === 'object' && !Array.isArray(parsedArgs))
+  ? parsedArgs.run_dir
+  : parsedArgs
+if (!runDir) {
+  log('No run_dir given — pass the run directory containing findings.json.')
+  return { verified: 0, reason: 'no_run_dir' }
+}
+log(`Run dir: ${runDir}`)
+
+// ---------------------------------------------------------------------------
+// Handoff schema — the typed baton from each fresh verifier agent. finding_id is
+// the finding's position (index) in the ordered findings.json list, which is how
+// the write-back matches a verdict back to its Finding.
+// ---------------------------------------------------------------------------
+const VERIFIER_HANDOFF = {
+  type: 'object',
+  required: ['finding_id', 'verdict', 'one_line_reason'],
+  additionalProperties: false,
+  properties: {
+    finding_id: { type: 'integer', description: 'index of the finding in the ordered findings.json list' },
+    verdict: { type: 'string', enum: ['confirmed', 'unconfirmed', 'uncertain'] },
+    resulting_confidence: { type: 'string', enum: ['high', 'medium', 'low'], description: 'optional; derived from the verdict when omitted' },
+    one_line_reason: { type: 'string', description: 'one line, from the verifier\'s own read of the code — not the contrarian\'s argument (it never saw it)' },
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Select — an agent runs the Python core to list the Medium findings as JSON.
+// Each row carries the index (position in findings.json) + the quote, which is
+// the ONLY thing the per-finding verifier is allowed to see.
+// ---------------------------------------------------------------------------
+phase('Select')
+const SELECT_SNIPPET = [
+  'import json, sys',
+  'from findings import load_findings_json',
+  'from verifier import select_findings_to_verify',
+  'run_dir = sys.argv[1]',
+  'findings = load_findings_json(run_dir)',
+  'rows = [',
+  '    {"index": i, "quote": f.quote}',
+  '    for i, f in enumerate(findings)',
+  '    if f in select_findings_to_verify(findings)',
+  ']',
+  'print(json.dumps(rows))',
+].join('; ')
+const selected = await agent(
+  [
+    `List the Medium-confidence findings eligible for verification in the run directory \`${runDir}\`.`,
+    `From the repo root, run (findings.py / verifier.py live under studio/, so run from there):`,
+    ``,
+    `  cd studio && python -c '${SELECT_SNIPPET}' "${runDir}"`,
+    ``,
+    `(If this Workflow runs in an installed repo, the modules live under .studio/source/ — cd there instead.)`,
+    `Return exactly the JSON array it prints: a list of { index, quote } objects. If it prints [], return [].`,
+  ].join('\n'),
+  {
+    schema: { type: 'array', items: { type: 'object', required: ['index', 'quote'], additionalProperties: false, properties: { index: { type: 'integer' }, quote: { type: 'string' } } } },
+    label: 'select-medium-findings',
+    phase: 'Select',
+  },
+)
+
+const eligible = Array.isArray(selected) ? selected : []
+log(`Eligible Medium findings: ${eligible.length}`)
+if (eligible.length === 0) {
+  return { verified: 0, confirmed: 0, demoted: 0, uncertain: 0 }
+}
+
+// ---------------------------------------------------------------------------
+// Verify — one FRESH agent per finding. THE FIREWALL: the prompt carries ONLY
+// the finding's quote (the `file:line` + the quoted text) and the demotion
+// rules. The contrarian's flaw description and reasoning are deliberately absent
+// — that anchoring is exactly what this feature exists to avoid. The verifier
+// MAY open the real code at file:line and judge it independently; it must never
+// be handed the argument for why the code is wrong.
+// ---------------------------------------------------------------------------
+phase('Verify')
+const verdicts = []
+for (const item of eligible) {
+  const verdict = await agent(
+    [
+      `You are an INDEPENDENT verifier. Below is a single quoted claim pulled from a code review.`,
+      `You are NOT told what anyone thinks is wrong with it, and you must not guess at their reasoning.`,
+      `Judge only this: reading the real code at the cited location, does this quoted code actually have a problem?`,
+      ``,
+      `QUOTE (finding #${item.finding_id ?? item.index}):`,
+      `${item.quote}`,
+      ``,
+      `The quote is \`file:line\` — "exact code/text". You MAY open that file at that line and read the`,
+      `surrounding code to judge it. Do NOT go looking for any review notes, comments, or argument about it.`,
+      ``,
+      `Demotion rules — return a verdict:`,
+      `- "confirmed": you independently see a real problem in this code -> resulting_confidence "high".`,
+      `- "unconfirmed": you read the code and cannot find the alleged problem -> resulting_confidence "low".`,
+      `- "uncertain": the quote (even with the code) doesn't give you enough to judge -> confidence unchanged.`,
+      `You may omit resulting_confidence to let the write-back derive it from the verdict.`,
+      ``,
+      `Set finding_id to ${item.index}. Give a one-line reason from YOUR OWN read of the code.`,
+    ].join('\n'),
+    { schema: VERIFIER_HANDOFF, label: `verify-finding-${item.index}`, phase: 'Verify' },
+  )
+  if (verdict) {
+    verdicts.push({
+      index: item.index,
+      verdict: verdict.verdict,
+      resulting_confidence: verdict.resulting_confidence,
+    })
+    log(`Finding #${item.index}: ${verdict.verdict}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Write-back — apply every verdict to findings.json via the Python core. The
+// finding record IS the overlay (no separate verifier artifact); apply_verdicts_
+// to_run loads, applies, and saves in place.
+// ---------------------------------------------------------------------------
+phase('Write-back')
+const verdictsJson = JSON.stringify(verdicts)
+const WRITEBACK_SNIPPET = [
+  'import json, sys',
+  'from verifier import apply_verdicts_to_run',
+  'run_dir, verdicts = sys.argv[1], json.loads(sys.argv[2])',
+  'updated = apply_verdicts_to_run(run_dir, verdicts)',
+  'print(f"wrote {len(updated)} findings back to findings.json")',
+].join('; ')
+await agent(
+  [
+    `Write the verifier verdicts back into findings.json in \`${runDir}\`.`,
+    `From the repo root, run (single-quote the code, pass the JSON as a separate arg):`,
+    ``,
+    `  cd studio && python -c '${WRITEBACK_SNIPPET}' "${runDir}" '${verdictsJson}'`,
+    ``,
+    `(Installed repos: cd into .studio/source/ instead, where verifier.py lives.)`,
+    `Return a one-line confirmation of what it printed.`,
+  ].join('\n'),
+  { label: 'write-back-verdicts', phase: 'Write-back' },
+)
+
+const summary = {
+  verified: verdicts.length,
+  confirmed: verdicts.filter((v) => v.verdict === 'confirmed').length,
+  demoted: verdicts.filter((v) => v.verdict === 'unconfirmed').length,
+  uncertain: verdicts.filter((v) => v.verdict === 'uncertain').length,
+}
+log(`Done. verified=${summary.verified} confirmed=${summary.confirmed} demoted=${summary.demoted} uncertain=${summary.uncertain}`)
+return summary

--- a/.claude/workflows/implementation-loop.js
+++ b/.claude/workflows/implementation-loop.js
@@ -259,7 +259,14 @@ if (editHeld && editor && !editor.committed) {
   editor.committed = true
 }
 
-const reviewerConcerns = (editor && Array.isArray(editor.unresolved_concerns)) ? editor.unresolved_concerns : []
+// Pure aggregation, extracted into a named function so the reviewerConcerns contract is
+// unit-testable without running the workflow. The Workflow sandbox can't be imported (no fs/module
+// access), so .claude/workflows/lib/workflow-shells.test.mjs loads THIS function from source and
+// exercises it — the test drives the real code, not a copy.
+function collectReviewerConcerns(editor) {
+  return (editor && Array.isArray(editor.unresolved_concerns)) ? editor.unresolved_concerns : []
+}
+const reviewerConcerns = collectReviewerConcerns(editor)
 if (reviewerConcerns.length) {
   log(`Editor logged ${reviewerConcerns.length} unresolved concern(s) → ${runDir(unit)}/reviewer-concerns.md`)
 }

--- a/.claude/workflows/implementation-loop.js
+++ b/.claude/workflows/implementation-loop.js
@@ -261,7 +261,7 @@ if (editHeld && editor && !editor.committed) {
 
 // Pure aggregation, extracted into a named function so the reviewerConcerns contract is
 // unit-testable without running the workflow. The Workflow sandbox can't be imported (no fs/module
-// access), so .claude/workflows/lib/workflow-shells.test.mjs loads THIS function from source and
+// access), so .claude/workflows/tests/workflow-shells.test.mjs loads THIS function from source and
 // exercises it — the test drives the real code, not a copy.
 function collectReviewerConcerns(editor) {
   return (editor && Array.isArray(editor.unresolved_concerns)) ? editor.unresolved_concerns : []

--- a/.claude/workflows/tests/workflow-shells.test.mjs
+++ b/.claude/workflows/tests/workflow-shells.test.mjs
@@ -1,0 +1,46 @@
+// Unit tests for the Workflow shells' pure helpers.
+//
+// The Workflow sandbox has no filesystem/module access, so these shells cannot be imported and run
+// directly. Instead we read the shell source, extract the pure helper by name, and rebuild it with
+// `new Function` — so the assertions exercise the REAL code from the file, not a maintained copy.
+//
+// Run via `node --test .claude/workflows/tests` (the pytest suite does this in test_workflow_shells.py).
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+function loadFunction(relSource, name) {
+  const src = readFileSync(new URL(relSource, import.meta.url), 'utf8')
+  const re = new RegExp(`function ${name}\\(([^)]*)\\)\\s*\\{([\\s\\S]*?)\\n\\}`)
+  const m = src.match(re)
+  assert.ok(m, `${name} must be defined in ${relSource}`)
+  return new Function(m[1], m[2])
+}
+
+// implementation-loop.js — reviewerConcerns aggregation (the #65 review follow-up: pin that a
+// returned unresolved_concerns payload is actually surfaced).
+const collectReviewerConcerns = loadFunction('../implementation-loop.js', 'collectReviewerConcerns')
+
+test('collectReviewerConcerns surfaces the editor\'s unresolved_concerns', () => {
+  const concerns = [
+    { concern: 'ships engine without shell', why_unresolved: 'out_of_unit_scope', suggested_followup: 'add to WORKFLOW_FILES' },
+    { concern: 'x', why_unresolved: 'load_bearing' },
+  ]
+  assert.deepEqual(collectReviewerConcerns({ unresolved_concerns: concerns }), concerns)
+})
+
+test('collectReviewerConcerns is empty when there are none', () => {
+  assert.deepEqual(collectReviewerConcerns({ unresolved_concerns: [] }), [])
+})
+
+test('collectReviewerConcerns defaults safely on a missing/absent field', () => {
+  assert.deepEqual(collectReviewerConcerns({}), [])
+  assert.deepEqual(collectReviewerConcerns(null), [])
+  assert.deepEqual(collectReviewerConcerns(undefined), [])
+})
+
+test('collectReviewerConcerns defaults safely on a non-array field (never crashes)', () => {
+  assert.deepEqual(collectReviewerConcerns({ unresolved_concerns: 'nope' }), [])
+  assert.deepEqual(collectReviewerConcerns({ unresolved_concerns: null }), [])
+  assert.deepEqual(collectReviewerConcerns({ unresolved_concerns: 42 }), [])
+})

--- a/specs/contrarian-finding-verifier.md
+++ b/specs/contrarian-finding-verifier.md
@@ -1,0 +1,176 @@
+---
+feature: Independent Verifier for Contrarian Findings (Studio roadmap R1)
+slug: contrarian-finding-verifier
+ticket: none (roadmap item R1 — see studio/docs/GSTACK_COMPARISON.md)
+status: approved
+studio_run: .studio/output/tech/run_tech_20260716_163522
+---
+
+# Independent Verifier for Contrarian Findings — Architecture Spec
+
+## In Plain Language
+
+Studio's contrarian already has to back up its criticisms: when it flags a flaw it must quote the
+exact thing it's objecting to, and mark how sure it is (High / Medium / Low). That's the gate we
+just shipped. But the contrarian still grades its own homework — nothing checks whether a
+"Medium-confidence" flaw is actually real.
+
+This feature adds a second opinion. After the contrarian writes its findings, a **fresh, separate
+agent** re-checks the shaky ones. The trick that makes it worth anything: the checker is shown
+**only the quoted claim and the rules for judging it — never the contrarian's own reasoning**. It
+can't just nod along, because it never saw the argument. If the checker independently agrees, the
+finding gets more trustworthy (its confidence goes up). If it can't confirm the flaw, the finding
+gets demoted out of the main list. Two independent voices agreeing is a much stronger signal than
+one voice being confident.
+
+The debate that produced this spec turned up two things that reshaped it, so it's worth being clear
+about them up front:
+
+1. A verifier is only meaningful if it's genuinely **independent**. If the same assistant just
+   role-plays "contrarian" and then "verifier" in one breath, it already knows the reasoning it's
+   supposed to ignore — that's theater, not verification. Real independence needs a real separate
+   agent with its own fresh context.
+2. Today the contrarian's findings are **free-form prose**. To hand a checker "just the quoted
+   claim" cleanly, findings first need a **machine-readable form** — otherwise the hand-off leaks
+   the reasoning and the whole point is lost.
+
+So this is built as **two units in sequence**: first give findings a structured form (useful on its
+own), then build the independent checker on top of it.
+
+## Architecture at a Glance
+
+```mermaid
+flowchart TD
+    subgraph Unit1[Unit 1 — Structured findings]
+        C[Contrarian pass] -->|emits FINDING blocks| P[parse_findings]
+        P --> FJ[(findings.json)]
+    end
+    subgraph Unit2[Unit 2 — Independent verifier Workflow]
+        FJ -->|Medium findings + P0-flippers| SEL{select eligible}
+        SEL -->|per finding| V["fresh agent() verifier<br/>sees ONLY quote + rules"]
+        V -->|confirmed / unconfirmed| AGG[aggregate verdicts]
+        AGG -->|+1 conf or demote| FJ2[(findings.json, updated)]
+    end
+    FJ2 --> R[verdict / integrator / stats read adjusted confidence]
+```
+
+The firewall is the load-bearing part: the verifier reads the finding's quoted `file:line` (so it
+can look at the real code) and the demotion rules — but the contrarian's argument for why the code
+is wrong never enters the verifier's context. Independence comes from the process boundary (a
+separate `agent()` call with fresh context), not from asking one agent to "be objective."
+
+## How It Works (Technical)
+
+### Unit 1 — Structured findings (`findings.json`)
+
+The goal: make a contrarian finding a parseable record, the same way `decision_points.py` already
+makes a decision one.
+
+- **New canonical finding block** the contrarian emits alongside its prose (single source of truth,
+  emitted-and-parsed, mirroring `DECISION_BLOCK_TEMPLATE`):
+
+  ```
+  > **FINDING [confidence: medium]:** <the flaw, one line>
+  > **Quote:** `path/to/file.py:42` — "<the exact text/claim being critiqued>"
+  > **Impact:** <what breaks if it's real>
+  ```
+
+- **New module `studio/findings.py`** patterned on `decision_points.py`: a `Finding` dataclass
+  (`confidence`, `flaw`, `quote`, `impact`, `source_file`, plus a later-filled `verdict` /
+  `verified_confidence`), `parse_findings(text)`, `save_findings_json` / `load_findings_json`, and
+  `extract_findings_from_run(run_dir)`.
+- **`CONTRARIAN_MANDATE` addition** (`scopes.py`): the evidence-gate bullets already tell the
+  contrarian to quote and rate; this adds "emit each finding as a FINDING block so it's captured."
+  It extends — does not rewrite — the shipped gate.
+- **Contract:** `findings.json` is a list of `Finding` records keyed by a stable `finding_id`
+  (`source_file` + index). It is the artifact both the verifier (Unit 2) and any future stats/dedup
+  consumer read.
+
+Unit 1 is usable on its own the moment it lands: the confidence gate becomes machine-readable, so
+`stats` can count/trend findings and dedup them across iterations — value even if Unit 2 never
+ships.
+
+### Unit 2 — Independent verifier Workflow
+
+A Claude Code Workflow, `.claude/workflows/finding-verifier.js`, built the same way as
+`implementation-loop.js` (orchestration-only shell; behavior in prompts + a typed handoff).
+
+- **Input:** a run directory (or `findings.json` path).
+- **Selection:** eligible = findings at `confidence: medium`, plus any finding whose demotion would
+  flip a P0 decision. High is skipped (the self-gate already defines High as "quoted + shown");
+  Low/unverified already live in the demoted list.
+- **Per-finding verification:** one `agent()` call per eligible finding — a genuinely fresh context.
+  Its prompt contains **only** the finding's `quote` (with the `file:line`, so it can read the real
+  code) and the demotion rules. It returns a `VERIFIER_HANDOFF`:
+
+  ```jsonc
+  { "finding_id": "contrarian_1.md#3",
+    "verdict": "confirmed | unconfirmed | uncertain",
+    "resulting_confidence": "high | medium | low",
+    "one_line_reason": "..." }
+  ```
+
+- **Aggregation → write-back:** `confirmed` → confidence +1 band (Medium→High) and tag
+  "verified — two voices agree"; `unconfirmed` → demote (Medium→Low, moved to lower-confidence
+  notes); `uncertain` → leave as-is, note it. The Workflow updates `findings.json` in place (no
+  separate `verifier.md` parser-with-no-reader — the finding record *is* the overlay) and returns a
+  summary `{ verified, confirmed, demoted, cost_findings }`.
+- **Cost control:** a config knob (small `verifier` table or reuse of the loop-config pattern) caps
+  which tiers are verified (default: `medium`) and the max findings per run.
+- **Trigger:** a `/verify-findings <run-dir>` command for the MVI; folding it automatically into the
+  run flow after the contrarian pass is a later step, once the one path is proven.
+
+## Key Decisions
+
+- **Sequenced into two units, not one build** (user decision, this run). Structuring findings is a
+  real prerequisite *and* independently useful, so it ships first; the verifier builds on it.
+- **Real independence via a Workflow, not an honor-system instructions.md pass** (contrarian P0).
+  One assistant role-playing both roles in one context cannot be independent — it already holds the
+  reasoning it's told to ignore. A separate `agent()` call is the only mechanism that delivers the
+  fresh context the feature depends on. This mirrors `/forge`'s writer/editor separation.
+- **Verify Medium (+ P0-flippers) only, not High** (contrarian cut). High is already the
+  most-self-gated tier; re-checking it duplicates the shipped gate. Medium is the tier literally
+  tagged "verify this."
+- **Write back into `findings.json`; no standalone verifier artifact** (contrarian cut). The finding
+  record carries its own verified confidence; a separate parsed file with no distinct reader was cut
+  as speculative machinery.
+- **The verifier reads the code, not the argument.** It gets the `file:line` so it can look at the
+  real source; it never gets the contrarian's reasoning. Independence is the process boundary.
+
+## Non-Goals / Cut Scope
+
+- **No honor-system / same-context verifier** — rejected as theater.
+- **No High-confidence verification** — redundant with the shipped self-gate.
+- **No `verifier.md` parser** — findings.json is the single record.
+- **Not wired into every phase/scope at once** — prove it on one path (studio depth) before
+  generalizing to single-phase and other scopes.
+- **No automatic post-contrarian trigger in the MVI** — start with an explicit `/verify-findings`
+  invocation; auto-wiring comes after the path is proven.
+
+## Risks & Open Questions
+
+- **Unit 2 is Claude-Code-only.** The finding format + `findings.json` (Unit 1) are portable; only
+  the verifier *executor* is Claude-specific — the same trade `/forge` already accepts. A port
+  rewrites only the thin Workflow shell.
+- **A "cold" quote may be too starved.** A quote with no context might be unfairly unconfirmable.
+  Mitigation: always include the `file:line` so the verifier can read the actual code; withhold only
+  the contrarian's reasoning, not the code itself. Watch for verifiers that return `uncertain` a lot
+  — that's the signal the quote isn't carrying enough.
+- **Double-counting confidence.** The +1/demote semantics must not silently re-grade what the
+  contrarian's self-rating already set; the write-back records "verified" as a distinct, additive
+  signal.
+- **Cost.** Even Medium-only verification adds one `agent()` per eligible finding; the per-run cap is
+  the guard, and the success metric (does verification change enough verdicts to earn its tokens?)
+  should be watched the way `/forge`'s editor pass is.
+
+## Build Plan
+
+Two MVI units, in dependency order (each a complete, usable thing — build a skateboard, not a
+wheel), both buildable via `/forge`:
+
+1. **Unit 1 — `findings.json`.** The FINDING block format + `studio/findings.py` parser +
+   `CONTRARIAN_MANDATE` emitting it + loader tests (mirror the `decision_points` tests). *Usable
+   alone:* the confidence gate is now machine-readable — `stats` can count and dedup findings.
+2. **Unit 2 — verifier Workflow.** `.claude/workflows/finding-verifier.js` + the `/verify-findings`
+   trigger + the confidence write-back. *Usable:* Medium-confidence findings get an independent
+   second opinion; agreement promotes, non-confirmation demotes.

--- a/specs/contrarian-finding-verifier.md
+++ b/specs/contrarian-finding-verifier.md
@@ -136,6 +136,13 @@ A Claude Code Workflow, `.claude/workflows/finding-verifier.js`, built the same 
   as speculative machinery.
 - **The verifier reads the code, not the argument.** It gets the `file:line` so it can look at the
   real source; it never gets the contrarian's reasoning. Independence is the process boundary.
+- **Confidence tracks veracity, not severity — so confirmed always promotes** (decided from the live
+  smoke). The verify agent returns only a verdict; the write-back derives confidence (confirmed →
+  high, unconfirmed → low, uncertain → unchanged). It cannot override confidence to "hold a real but
+  minor flaw at medium" — that blends *is it real* with *is it bad*, which neither gstack (separate
+  severity + confidence numbers) nor Studio (priority separate from confidence) does anywhere else.
+  Whether a real flaw is minor is a severity axis; `Finding` has no severity field today, and adding
+  one is out of scope for R1.
 
 ## Non-Goals / Cut Scope
 

--- a/studio/findings.py
+++ b/studio/findings.py
@@ -170,8 +170,9 @@ def extract_findings_from_run(run_dir: Path) -> list[Finding]:
     return results
 
 
-def save_findings_json(run_dir: Path, findings: list[Finding]) -> Path:
+def save_findings_json(run_dir: Path | str, findings: list[Finding]) -> Path:
     """Save findings to findings.json in the run directory. Returns the path."""
+    run_dir = Path(run_dir)  # accept a str path too (the Workflow shell passes sys.argv[1])
     data = [
         {
             "confidence": f.confidence,
@@ -189,8 +190,9 @@ def save_findings_json(run_dir: Path, findings: list[Finding]) -> Path:
     return path
 
 
-def load_findings_json(run_dir: Path) -> list[Finding]:
+def load_findings_json(run_dir: Path | str) -> list[Finding]:
     """Load findings from findings.json. Returns empty list if file missing."""
+    run_dir = Path(run_dir)  # accept a str path too (the Workflow shell passes sys.argv[1])
     path = run_dir / "findings.json"
     try:
         data = json.loads(path.read_text(encoding="utf-8"))

--- a/studio/findings.py
+++ b/studio/findings.py
@@ -22,9 +22,8 @@ from __future__ import annotations
 import itertools
 import json
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 
 # --- Canonical emit format (single source of truth) --------------------------
@@ -82,9 +81,9 @@ class Finding:
     flaw: str
     quote: str
     impact: str
-    source_file: Optional[str] = field(default=None)
-    verdict: Optional[str] = field(default=None)
-    verified_confidence: Optional[str] = field(default=None)
+    source_file: str | None = None
+    verdict: str | None = None
+    verified_confidence: str | None = None
 
 
 def parse_findings(text: str, source_file: str | None = None) -> list[Finding]:

--- a/studio/findings.py
+++ b/studio/findings.py
@@ -1,0 +1,211 @@
+"""
+Contrarian finding parsing and formatting for Studio runs.
+
+The contrarian flags each flaw it raises as a machine-readable FINDING block,
+mirroring how decision_points.py captures inline decision points. The format is
+a markdown blockquote — readable by humans, AI agents, and any assistant that
+handles standard markdown — so a finding can travel from the contrarian's prose
+into findings.json and back without losing its shape.
+
+Example finding in contrarian output::
+
+    > **FINDING [confidence: medium]:** The retry loop never backs off.
+    > **Quote:** `worker.py:88` — "for attempt in range(retries): call()"
+    > **Impact:** A flapping dependency turns into a tight hammering loop.
+
+Mostly a pure function library. The exceptions touch the filesystem:
+extract_findings_from_run reads a run directory, and
+save_findings_json/load_findings_json write and read findings.json.
+"""
+from __future__ import annotations
+
+import itertools
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+# --- Canonical emit format (single source of truth) --------------------------
+# The contrarian is TOLD to emit this exact blockquote shape, and parse_findings
+# READS it back. scopes.py imports FINDING_BLOCK_TEMPLATE into the contrarian's
+# instructions instead of hand-writing the format, so "what we ask the contrarian
+# to emit" and "what we parse" cannot silently drift apart: the failure mode
+# where a doc tweak quietly makes every extraction return nothing. The round-trip
+# test in tests/test_findings.py parses both of these (and the output of
+# format_finding) to prove they stay in sync.
+FINDING_BLOCK_TEMPLATE = (
+    "> **FINDING [confidence: medium]:** [the flaw, one line]\n"
+    "> **Quote:** `path/to/file.py:42` — \"[the exact text/claim being critiqued]\"\n"
+    "> **Impact:** [what breaks if it is real]"
+)
+
+FINDING_BLOCK_EXAMPLE = (
+    "> **FINDING [confidence: medium]:** The retry loop never backs off between attempts.\n"
+    "> **Quote:** `worker.py:88` — \"for attempt in range(retries): call()\"\n"
+    "> **Impact:** A flapping dependency turns into a tight hammering loop that makes the outage worse."
+)
+
+# Regex to capture a finding blockquote.
+# Matches lines starting with "> " where the first line has
+# **FINDING [confidence: high|medium|low]:. Handles the two variants agents
+# produce, exactly like the DECISION parser:
+#   > **FINDING [confidence: medium]:** flaw text     (canonical: colon outside bold)
+#   > **FINDING [confidence: medium]: flaw text**      (natural: flaw inside bold)
+# and continues as long as lines start with "> ".
+_BLOCK_RE = re.compile(
+    r"^> \*\*FINDING \[confidence:\s*(high|medium|low)\s*\]:\*\*\s*(.+)\n"
+    r"((?:> .+\n?)*)",
+    re.MULTILINE | re.IGNORECASE,
+)
+_BLOCK_RE_ALT = re.compile(
+    r"^> \*\*FINDING \[confidence:\s*(high|medium|low)\s*\]:\s*(.+?)\*\*\s*\n"
+    r"((?:> .+\n?)*)",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+# Field extractors inside blockquote body lines (after stripping "> " prefix).
+_QUOTE_RE = re.compile(r"\*\*Quote:\*\*\s*(.+)", re.IGNORECASE)
+_IMPACT_RE = re.compile(r"\*\*Impact:\*\*\s*(.+)", re.IGNORECASE)
+
+
+@dataclass
+class Finding:
+    """A single contrarian finding extracted from agent output.
+
+    verdict and verified_confidence are placeholders the independent verifier
+    (Unit 2) fills in later; parse leaves them unset.
+    """
+
+    confidence: str  # high, medium, or low
+    flaw: str
+    quote: str
+    impact: str
+    source_file: Optional[str] = field(default=None)
+    verdict: Optional[str] = field(default=None)
+    verified_confidence: Optional[str] = field(default=None)
+
+
+def parse_findings(text: str, source_file: str | None = None) -> list[Finding]:
+    """Parse all findings from contrarian output text.
+
+    Handles extra whitespace, a missing Impact field, and mixed-case tags.
+    Returns findings in the order they appear in the text.
+    """
+    results: list[Finding] = []
+    seen_spans: set[tuple[int, int]] = set()
+
+    matches = sorted(
+        itertools.chain(_BLOCK_RE.finditer(text), _BLOCK_RE_ALT.finditer(text)),
+        key=lambda m: m.start(),
+    )
+    for match in matches:
+        span = (match.start(), match.end())
+        if span in seen_spans:
+            continue
+        seen_spans.add(span)
+        confidence = match.group(1).lower()
+        flaw = match.group(2).strip()
+        body_lines = match.group(3)
+
+        # Strip "> " prefix from body lines
+        body = "\n".join(
+            line[2:] if line.startswith("> ") else line
+            for line in body_lines.splitlines()
+        )
+
+        quote_m = _QUOTE_RE.search(body)
+        quote = quote_m.group(1).strip() if quote_m else ""
+
+        impact_m = _IMPACT_RE.search(body)
+        impact = impact_m.group(1).strip() if impact_m else ""
+
+        results.append(
+            Finding(
+                confidence=confidence,
+                flaw=flaw,
+                quote=quote,
+                impact=impact,
+                source_file=source_file,
+            )
+        )
+
+    return results
+
+
+def format_finding(f: Finding) -> str:
+    """Render a Finding back to the standard blockquote format."""
+    lines = [
+        f"> **FINDING [confidence: {f.confidence}]:** {f.flaw}",
+        f"> **Quote:** {f.quote}",
+    ]
+    if f.impact:
+        lines.append(f"> **Impact:** {f.impact}")
+    return "\n".join(lines)
+
+
+def extract_findings_from_run(run_dir: Path) -> list[Finding]:
+    """Scan contrarian output files in a run directory for findings.
+
+    Reads contrarian_*.md and their studio variants (contrarian--role--NN.md,
+    contrarian--role--S1-NN.md). Findings come only from the contrarian, so
+    advocate files are skipped. Annotates each Finding with its source file name.
+    """
+    results: list[Finding] = []
+    run_path = Path(run_dir)
+
+    if not run_path.is_dir():
+        return results
+
+    for md_file in sorted(run_path.glob("*.md")):
+        name = md_file.name
+        # Match simple (contrarian_1.md) and studio (contrarian--role--01.md) names.
+        if not name.startswith("contrarian"):
+            continue
+
+        text = md_file.read_text(encoding="utf-8")
+        findings = parse_findings(text, source_file=name)
+        results.extend(findings)
+
+    return results
+
+
+def save_findings_json(run_dir: Path, findings: list[Finding]) -> Path:
+    """Save findings to findings.json in the run directory. Returns the path."""
+    data = [
+        {
+            "confidence": f.confidence,
+            "flaw": f.flaw,
+            "quote": f.quote,
+            "impact": f.impact,
+            "source_file": f.source_file,
+            "verdict": f.verdict,
+            "verified_confidence": f.verified_confidence,
+        }
+        for f in findings
+    ]
+    path = run_dir / "findings.json"
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return path
+
+
+def load_findings_json(run_dir: Path) -> list[Finding]:
+    """Load findings from findings.json. Returns empty list if file missing."""
+    path = run_dir / "findings.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return []
+    return [
+        Finding(
+            confidence=d["confidence"],
+            flaw=d["flaw"],
+            quote=d["quote"],
+            impact=d["impact"],
+            source_file=d.get("source_file"),
+            verdict=d.get("verdict"),
+            verified_confidence=d.get("verified_confidence"),
+        )
+        for d in data
+    ]

--- a/studio/install.py
+++ b/studio/install.py
@@ -40,6 +40,7 @@ SOURCE_FILES = [
     "persona_overrides.py",
     "decision_points.py",
     "findings.py",
+    "verifier.py",
     "question_mode.py",
     "scopes.py",
     "cleanup.py",

--- a/studio/install.py
+++ b/studio/install.py
@@ -89,6 +89,7 @@ SLASH_COMMANDS = [
 # Claude Code Workflows to copy to {target}/.claude/workflows/ (verbatim, like commands)
 WORKFLOW_FILES = [
     "implementation-loop.js",
+    "finding-verifier.js",
 ]
 
 # Sentinels for CLAUDE.md injection: update replaces content between these markers

--- a/studio/install.py
+++ b/studio/install.py
@@ -39,6 +39,7 @@ SOURCE_FILES = [
     "role_overrides.py",
     "persona_overrides.py",
     "decision_points.py",
+    "findings.py",
     "question_mode.py",
     "scopes.py",
     "cleanup.py",

--- a/studio/scopes.py
+++ b/studio/scopes.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Dict, List
 
 from decision_points import DECISION_BLOCK_TEMPLATE
+from findings import FINDING_BLOCK_TEMPLATE
 
 
 VALID_DEBATE_MODES = {"all_roles", "per_role"}
@@ -42,6 +43,9 @@ CONTRARIAN_MANDATE = [
     "- **Quote before you claim.** For every flaw or objection, quote the exact thing you are critiquing — the specific claim, feature, step, or line from the advocate's proposal. If you cannot point at the exact thing, you have not verified it: mark the finding `(unverified)` and treat it as low-confidence.",
     "- **Rate your confidence, and let the rating set how loudly you raise it.** *High* — you quoted the exact thing and showed concretely why it breaks: state it plainly as a finding. *Medium* — a real pattern you cannot fully prove here: raise it, tagged \"verify this.\" *Low / unverified* — no quote, or a hunch: collect these under a short **Lower-confidence notes** list at the end, kept out of your main findings; drop one entirely unless, if it were true, it would be fatal (a P0).",
     "- **A vibe is not a finding.** \"This looks off\" or \"this might not scale\" earns nothing on its own. Either cite the evidence, or leave it out.",
+    "- **Also emit each finding as a FINDING block so it is captured.** Alongside your prose, write every finding that clears this gate as the block below — same quote-and-rate content, in a form that parses into findings.json for stats, dedup, and independent verification:",
+    "",
+    *FINDING_BLOCK_TEMPLATE.splitlines(),
 ]
 
 

--- a/studio/setup.cfg
+++ b/studio/setup.cfg
@@ -10,6 +10,6 @@
 # Or target one file:  mutmut run --paths-to-mutate stats.py
 # Then inspect survivors: mutmut results  /  mutmut show <id>
 [mutmut]
-paths_to_mutate=verdict.py,config_loading.py,decision_points.py,scopes.py,stats.py,clarity.py,impl_loop.py,question_mode.py,persona_overrides.py,role_overrides.py
+paths_to_mutate=verdict.py,config_loading.py,decision_points.py,findings.py,scopes.py,stats.py,clarity.py,impl_loop.py,question_mode.py,persona_overrides.py,role_overrides.py
 runner=python -m pytest -q -x
 tests_dir=tests/

--- a/studio/tests/test_findings.py
+++ b/studio/tests/test_findings.py
@@ -1,0 +1,374 @@
+"""Tests for contrarian finding parsing, formatting, and extraction.
+
+Tests cover:
+  - parse_findings: single/multiple/missing-Impact/malformed markers
+  - format_finding: round-trip of template, example, and formatted output
+  - confidence-band parsing (high/medium/low, mixed case)
+  - save_findings_json / load_findings_json: round trip and missing file
+  - extract_findings_from_run: contrarian-only scanning
+  - CONTRARIAN_MANDATE carries the FINDING emit instruction
+"""
+from findings import (
+    FINDING_BLOCK_EXAMPLE,
+    FINDING_BLOCK_TEMPLATE,
+    Finding,
+    extract_findings_from_run,
+    format_finding,
+    load_findings_json,
+    parse_findings,
+    save_findings_json,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sample finding text blocks (blockquote format)
+# ---------------------------------------------------------------------------
+
+SINGLE_MEDIUM = """\
+Some preamble text.
+
+> **FINDING [confidence: medium]:** The retry loop never backs off between attempts.
+> **Quote:** `worker.py:88` — "for attempt in range(retries): call()"
+> **Impact:** A flapping dependency turns into a tight hammering loop.
+
+Some trailing text.
+"""
+
+MULTI_CONFIDENCE = """\
+> **FINDING [confidence: low]:** Naming feels inconsistent across modules.
+> **Quote:** `util.py:12` — "def do_thing()"
+> **Impact:** Minor readability cost.
+
+> **FINDING [confidence: high]:** The token is logged in plaintext.
+> **Quote:** `auth.py:40` — "log.info(f'token={token}')"
+> **Impact:** Secrets leak into shared log storage.
+
+> **FINDING [confidence: medium]:** No timeout on the outbound call.
+> **Quote:** `client.py:5` — "requests.get(url)"
+> **Impact:** A hung upstream stalls every worker.
+"""
+
+MISSING_IMPACT = """\
+> **FINDING [confidence: high]:** Off-by-one in the slice bound.
+> **Quote:** `pager.py:22` — "items[start:end+1]"
+"""
+
+EXTRA_WHITESPACE = """\
+> **FINDING [confidence:  medium ]:**   The cache key ignores the tenant id.
+> **Quote:**    `cache.py:9` — "key = f'user:{user_id}'"
+> **Impact:**  Cross-tenant cache collisions.
+"""
+
+# Alternate format: flaw inside the bold markers (what agents naturally produce).
+# Leading prose forces the block to match mid-document, so the parser genuinely
+# needs re.MULTILINE rather than an accidental match at string start.
+ALT_FORMAT_INSIDE_BOLD = """\
+Preamble prose before the finding.
+
+> **FINDING [confidence: high]: The migration drops the column before copying it.**
+> **Quote:** `migrate.py:30` — "drop_column('email'); copy_email()"
+> **Impact:** Irreversible data loss on deploy.
+"""
+
+# Mixed-case tag
+MIXED_CASE_TAG = """\
+> **finding [CONFIDENCE: Medium]:** Pagination resets on every filter change.
+> **Quote:** `list.py:14` — "page = 1"
+> **Impact:** Users lose their place in long lists.
+"""
+
+# Malformed: no blockquote prefix — should not be parsed
+MALFORMED_NO_BLOCKQUOTE = """\
+**FINDING [confidence: high]:** Orphan finding without blockquote prefix
+**Quote:** `x.py:1` — "code"
+**Impact:** Nothing
+"""
+
+
+# ---------------------------------------------------------------------------
+# Parsing tests
+# ---------------------------------------------------------------------------
+
+class TestParseFindings:
+    """Tests for parse_findings()."""
+
+    def test_parse_single_medium(self):
+        results = parse_findings(SINGLE_MEDIUM)
+
+        assert len(results) == 1
+        f = results[0]
+        assert f.confidence == "medium"
+        assert "never backs off" in f.flaw
+        assert "worker.py:88" in f.quote
+        assert "hammering loop" in f.impact
+
+    def test_parse_multiple_in_document_order(self):
+        results = parse_findings(MULTI_CONFIDENCE)
+
+        assert len(results) == 3
+        assert [f.confidence for f in results] == ["low", "high", "medium"]
+
+    def test_parse_missing_impact_field(self):
+        results = parse_findings(MISSING_IMPACT)
+
+        assert len(results) == 1
+        f = results[0]
+        assert f.confidence == "high"
+        assert "Off-by-one" in f.flaw
+        assert "pager.py:22" in f.quote
+        assert f.impact == ""
+
+    def test_parse_extra_whitespace(self):
+        results = parse_findings(EXTRA_WHITESPACE)
+
+        assert len(results) == 1
+        f = results[0]
+        assert f.confidence == "medium"
+        assert "tenant id" in f.flaw
+        assert "cache.py:9" in f.quote
+        assert "collisions" in f.impact
+
+    def test_parse_alt_format_flaw_inside_bold(self):
+        results = parse_findings(ALT_FORMAT_INSIDE_BOLD)
+
+        assert len(results) == 1
+        f = results[0]
+        assert f.confidence == "high"
+        assert "drops the column" in f.flaw
+        assert "migrate.py:30" in f.quote
+
+    def test_parse_mixed_case_tag(self):
+        results = parse_findings(MIXED_CASE_TAG)
+
+        assert len(results) == 1
+        assert results[0].confidence == "medium"
+
+    def test_parse_missing_quote_field(self):
+        """A finding with no Quote line parses with an empty quote string."""
+        text = (
+            "> **FINDING [confidence: low]:** Something feels off in the layout.\n"
+            "> **Impact:** Minor visual glitch.\n"
+        )
+        results = parse_findings(text)
+        assert len(results) == 1
+        assert results[0].quote == ""
+        assert "visual glitch" in results[0].impact
+
+    def test_parse_no_findings(self):
+        assert parse_findings("Just a normal document with no markers.") == []
+
+    def test_parse_empty_string(self):
+        assert parse_findings("") == []
+
+    def test_parse_malformed_no_blockquote(self):
+        assert parse_findings(MALFORMED_NO_BLOCKQUOTE) == []
+
+    def test_source_file_attribution(self):
+        results = parse_findings(SINGLE_MEDIUM, source_file="contrarian--design--01.md")
+        assert results[0].source_file == "contrarian--design--01.md"
+
+    def test_source_file_default_none(self):
+        results = parse_findings(SINGLE_MEDIUM)
+        assert results[0].source_file is None
+
+    def test_verdict_fields_default_none(self):
+        """parse leaves the Unit 2 placeholder fields unset."""
+        f = parse_findings(SINGLE_MEDIUM)[0]
+        assert f.verdict is None
+        assert f.verified_confidence is None
+
+
+# ---------------------------------------------------------------------------
+# Format tests
+# ---------------------------------------------------------------------------
+
+class TestFormatFinding:
+    """Tests for format_finding()."""
+
+    def test_format_round_trip(self):
+        original = parse_findings(SINGLE_MEDIUM)
+        assert len(original) == 1
+
+        formatted = format_finding(original[0])
+        reparsed = parse_findings(formatted + "\n")
+
+        assert len(reparsed) == 1
+        assert reparsed[0].confidence == original[0].confidence
+        assert reparsed[0].flaw == original[0].flaw
+        assert reparsed[0].quote == original[0].quote
+        assert reparsed[0].impact == original[0].impact
+
+    def test_format_omits_impact_when_empty(self):
+        f = Finding(confidence="high", flaw="Bug", quote="`x.py:1` — \"code\"", impact="")
+        rendered = format_finding(f)
+        assert "Impact" not in rendered
+        reparsed = parse_findings(rendered + "\n")
+        assert len(reparsed) == 1
+        assert reparsed[0].impact == ""
+
+
+# ---------------------------------------------------------------------------
+# Canonical contract guard: emit format and parse format share one definition.
+# ---------------------------------------------------------------------------
+
+def test_canonical_example_parses():
+    """The shared FINDING_BLOCK_EXAMPLE must parse into exactly one finding."""
+    findings = parse_findings(FINDING_BLOCK_EXAMPLE)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.confidence == "medium"
+    assert "backs off" in f.flaw
+    assert "worker.py:88" in f.quote
+    assert f.impact
+
+
+def test_canonical_template_parses():
+    """The placeholder template is structurally valid too (parses as one block)."""
+    findings = parse_findings(FINDING_BLOCK_TEMPLATE)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.confidence == "medium"
+    # All three fields of the template must parse, so a stray edit to the Quote
+    # or Impact line of the canonical block fails loudly instead of silently.
+    assert f.flaw
+    assert "path/to/file.py:42" in f.quote
+    assert f.impact
+
+
+# ---------------------------------------------------------------------------
+# Run extraction tests
+# ---------------------------------------------------------------------------
+
+class TestExtractFindingsFromRun:
+    """Tests for extract_findings_from_run()."""
+
+    def _write_file(self, directory, name, content):
+        filepath = directory / name
+        filepath.write_text(content, encoding="utf-8")
+        return filepath
+
+    def test_extract_from_contrarian_files(self, tmp_path):
+        run_dir = tmp_path / "run_studio_20260716_100000"
+        run_dir.mkdir()
+
+        self._write_file(run_dir, "contrarian_1.md", SINGLE_MEDIUM)
+        self._write_file(run_dir, "contrarian--design--01.md", MISSING_IMPACT)
+
+        results = extract_findings_from_run(run_dir)
+
+        assert len(results) == 2
+        sources = {f.source_file for f in results}
+        assert "contrarian_1.md" in sources
+        assert "contrarian--design--01.md" in sources
+
+    def test_extract_ignores_advocate_files(self, tmp_path):
+        """Findings come only from the contrarian; advocate files are skipped."""
+        run_dir = tmp_path / "run_studio_20260716_100000"
+        run_dir.mkdir()
+
+        self._write_file(run_dir, "advocate_1.md", SINGLE_MEDIUM)
+        self._write_file(run_dir, "contrarian_1.md", MISSING_IMPACT)
+
+        results = extract_findings_from_run(run_dir)
+
+        assert len(results) == 1
+        assert results[0].source_file == "contrarian_1.md"
+
+    def test_extract_from_empty_run_directory(self, tmp_path):
+        run_dir = tmp_path / "run_studio_20260716_100000"
+        run_dir.mkdir()
+        assert extract_findings_from_run(run_dir) == []
+
+    def test_extract_missing_directory(self, tmp_path):
+        assert extract_findings_from_run(tmp_path / "does_not_exist") == []
+
+
+# ---------------------------------------------------------------------------
+# Save / load JSON tests
+# ---------------------------------------------------------------------------
+
+class TestSaveLoadFindingsJson:
+    """Tests for save_findings_json() and load_findings_json()."""
+
+    def test_save_and_load_round_trip(self, tmp_path):
+        findings = [
+            Finding(
+                confidence="medium",
+                flaw="No timeout on the call.",
+                quote="`client.py:5` — \"requests.get(url)\"",
+                impact="A hung upstream stalls every worker.",
+                source_file="contrarian_1.md",
+            ),
+            Finding(
+                confidence="high",
+                flaw="Token logged in plaintext.",
+                quote="`auth.py:40` — \"log.info(token)\"",
+                impact="Secrets leak.",
+            ),
+        ]
+        save_findings_json(tmp_path, findings)
+        loaded = load_findings_json(tmp_path)
+
+        assert len(loaded) == 2
+        assert loaded[0].confidence == "medium"
+        assert loaded[0].flaw == "No timeout on the call."
+        assert loaded[0].source_file == "contrarian_1.md"
+        assert loaded[1].confidence == "high"
+        assert loaded[1].source_file is None
+
+    def test_save_preserves_verifier_fields(self, tmp_path):
+        """verdict / verified_confidence persist for the Unit 2 write-back."""
+        findings = [
+            Finding(
+                confidence="medium",
+                flaw="Flaw",
+                quote="`x.py:1` — \"code\"",
+                impact="Breaks",
+                verdict="confirmed",
+                verified_confidence="high",
+            ),
+        ]
+        save_findings_json(tmp_path, findings)
+        loaded = load_findings_json(tmp_path)
+
+        assert loaded[0].verdict == "confirmed"
+        assert loaded[0].verified_confidence == "high"
+
+    def test_load_missing_file(self, tmp_path):
+        assert load_findings_json(tmp_path) == []
+
+    def test_load_without_verifier_fields(self, tmp_path):
+        """Old JSON without verdict/verified_confidence loads with None."""
+        import json
+        old_data = [
+            {
+                "confidence": "low",
+                "flaw": "Old finding",
+                "quote": "`x.py:1` — \"code\"",
+                "impact": "Something",
+                "source_file": None,
+            }
+        ]
+        (tmp_path / "findings.json").write_text(
+            json.dumps(old_data, indent=2), encoding="utf-8"
+        )
+        loaded = load_findings_json(tmp_path)
+
+        assert len(loaded) == 1
+        assert loaded[0].verdict is None
+        assert loaded[0].verified_confidence is None
+
+
+# ---------------------------------------------------------------------------
+# Contrarian mandate carries the emit instruction
+# ---------------------------------------------------------------------------
+
+def test_contrarian_mandate_contains_finding_emit_instruction():
+    """CONTRARIAN_MANDATE must tell the contrarian to emit FINDING blocks."""
+    from scopes import CONTRARIAN_MANDATE
+
+    text = "\n".join(CONTRARIAN_MANDATE)
+    assert "FINDING block" in text
+    # The canonical block itself is embedded, so the emit and parse formats
+    # cannot silently drift apart.
+    assert "**FINDING [confidence: medium]:**" in text

--- a/studio/tests/test_verifier.py
+++ b/studio/tests/test_verifier.py
@@ -1,0 +1,158 @@
+"""Tests for the independent finding verifier (Unit 2 core).
+
+Tests cover:
+  - select_findings_to_verify: filters to Medium only (High/Low skipped)
+  - apply_verdict: confirmed->high, unconfirmed->low, uncertain->unchanged,
+    explicit resulting_confidence override, unknown verdict rejected
+  - apply_verdicts_to_run: round trip through findings.json (write, apply, reload)
+"""
+import pytest
+
+from findings import Finding, load_findings_json, save_findings_json
+from verifier import (
+    apply_verdict,
+    apply_verdicts_to_run,
+    select_findings_to_verify,
+)
+
+
+def _finding(confidence, flaw="Some flaw"):
+    return Finding(
+        confidence=confidence,
+        flaw=flaw,
+        quote=f"`x.py:1` — \"{flaw}\"",
+        impact="Something breaks.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Selection
+# ---------------------------------------------------------------------------
+
+class TestSelectFindingsToVerify:
+    """Only Medium-confidence findings are eligible for a second opinion."""
+
+    def test_selects_only_medium(self):
+        findings = [
+            _finding("high", "high flaw"),
+            _finding("medium", "medium flaw"),
+            _finding("low", "low flaw"),
+            _finding("medium", "another medium"),
+        ]
+        selected = select_findings_to_verify(findings)
+
+        assert len(selected) == 2
+        assert [f.flaw for f in selected] == ["medium flaw", "another medium"]
+
+    def test_no_medium_returns_empty(self):
+        findings = [_finding("high"), _finding("low")]
+        assert select_findings_to_verify(findings) == []
+
+    def test_empty_input(self):
+        assert select_findings_to_verify([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Verdict application
+# ---------------------------------------------------------------------------
+
+class TestApplyVerdict:
+    """Verdict -> verified_confidence transitions."""
+
+    def test_confirmed_promotes_to_high(self):
+        f = _finding("medium")
+        apply_verdict(f, "confirmed")
+
+        assert f.verdict == "confirmed"
+        assert f.verified_confidence == "high"
+
+    def test_unconfirmed_demotes_to_low(self):
+        f = _finding("medium")
+        apply_verdict(f, "unconfirmed")
+
+        assert f.verdict == "unconfirmed"
+        assert f.verified_confidence == "low"
+
+    def test_uncertain_leaves_confidence_unchanged(self):
+        f = _finding("medium")
+        apply_verdict(f, "uncertain")
+
+        assert f.verdict == "uncertain"
+        # Original confidence is untouched, and verified mirrors it (stays medium).
+        assert f.confidence == "medium"
+        assert f.verified_confidence == "medium"
+
+    def test_explicit_resulting_confidence_wins(self):
+        f = _finding("medium")
+        apply_verdict(f, "confirmed", resulting_confidence="medium")
+
+        assert f.verdict == "confirmed"
+        # Explicit override beats the confirmed->high derivation.
+        assert f.verified_confidence == "medium"
+
+    def test_returns_same_finding(self):
+        f = _finding("medium")
+        assert apply_verdict(f, "confirmed") is f
+
+    def test_unknown_verdict_raises(self):
+        f = _finding("medium")
+        with pytest.raises(ValueError):
+            apply_verdict(f, "maybe")
+
+
+# ---------------------------------------------------------------------------
+# Write-back round trip
+# ---------------------------------------------------------------------------
+
+class TestApplyVerdictsToRun:
+    """apply_verdicts_to_run round-trips through findings.json."""
+
+    def test_round_trip_updates_verified_confidence(self, tmp_path):
+        findings = [
+            _finding("medium", "flaw zero"),
+            _finding("high", "flaw one"),
+            _finding("medium", "flaw two"),
+        ]
+        save_findings_json(tmp_path, findings)
+
+        verdicts = [
+            {"index": 0, "verdict": "confirmed"},
+            {"index": 2, "verdict": "unconfirmed"},
+        ]
+        returned = apply_verdicts_to_run(tmp_path, verdicts)
+
+        # Returned list reflects the applied verdicts.
+        assert returned[0].verified_confidence == "high"
+        assert returned[2].verified_confidence == "low"
+
+        # And the write-back persisted, so a fresh reload sees the same.
+        reloaded = load_findings_json(tmp_path)
+        assert reloaded[0].verdict == "confirmed"
+        assert reloaded[0].verified_confidence == "high"
+        assert reloaded[2].verdict == "unconfirmed"
+        assert reloaded[2].verified_confidence == "low"
+
+        # The untouched High finding keeps its unset verifier fields.
+        assert reloaded[1].verdict is None
+        assert reloaded[1].verified_confidence is None
+
+    def test_explicit_resulting_confidence_round_trips(self, tmp_path):
+        save_findings_json(tmp_path, [_finding("medium")])
+
+        apply_verdicts_to_run(
+            tmp_path,
+            [{"index": 0, "verdict": "uncertain", "resulting_confidence": "high"}],
+        )
+
+        reloaded = load_findings_json(tmp_path)
+        assert reloaded[0].verdict == "uncertain"
+        assert reloaded[0].verified_confidence == "high"
+
+    def test_no_verdicts_leaves_findings_untouched(self, tmp_path):
+        save_findings_json(tmp_path, [_finding("medium")])
+
+        apply_verdicts_to_run(tmp_path, [])
+
+        reloaded = load_findings_json(tmp_path)
+        assert reloaded[0].verdict is None
+        assert reloaded[0].verified_confidence is None

--- a/studio/tests/test_verifier.py
+++ b/studio/tests/test_verifier.py
@@ -13,6 +13,7 @@ from verifier import (
     apply_verdict,
     apply_verdicts_to_run,
     select_findings_to_verify,
+    select_rows_for_run,
 )
 
 
@@ -156,3 +157,46 @@ class TestApplyVerdictsToRun:
         reloaded = load_findings_json(tmp_path)
         assert reloaded[0].verdict is None
         assert reloaded[0].verified_confidence is None
+
+
+# ---------------------------------------------------------------------------
+# The Select step — the real Python the JS shell shells out to. Covering it here
+# is the point: the shell's generated `python -c` string cannot be unit-tested,
+# and the earlier inline version was invalid Python that only ran because the
+# Select agent hand-repaired it (PR #66 review).
+# ---------------------------------------------------------------------------
+
+class TestSelectRowsForRun:
+    """select_rows_for_run returns {index, quote} rows for the Medium findings."""
+
+    def test_returns_index_and_quote_for_medium_only(self, tmp_path):
+        save_findings_json(
+            tmp_path,
+            [
+                _finding("medium", "flaw zero"),
+                _finding("high", "flaw one"),
+                _finding("medium", "flaw two"),
+            ],
+        )
+        rows = select_rows_for_run(tmp_path)
+
+        # The High finding (index 1) is excluded; the Medium ones keep their
+        # original positions so the write-back can match verdicts back by index.
+        assert rows == [
+            {"index": 0, "quote": "`x.py:1` — \"flaw zero\""},
+            {"index": 2, "quote": "`x.py:1` — \"flaw two\""},
+        ]
+
+    def test_accepts_a_str_path(self, tmp_path):
+        # The Workflow shell passes sys.argv[1] — a str, not a Path. This is the
+        # regression for the TypeError ('str' / 'str') the direct command hit.
+        save_findings_json(tmp_path, [_finding("medium")])
+        rows = select_rows_for_run(str(tmp_path))
+        assert [r["index"] for r in rows] == [0]
+
+    def test_no_medium_returns_empty(self, tmp_path):
+        save_findings_json(tmp_path, [_finding("high"), _finding("low")])
+        assert select_rows_for_run(tmp_path) == []
+
+    def test_missing_findings_json_returns_empty(self, tmp_path):
+        assert select_rows_for_run(tmp_path) == []

--- a/studio/tests/test_workflow_shells.py
+++ b/studio/tests/test_workflow_shells.py
@@ -1,0 +1,100 @@
+"""Guards for the Claude Code Workflow shells (``.claude/workflows/*.js``).
+
+The workflow shells are orchestration JS that the Python suite otherwise never
+sees. Two failure modes have already bitten us and only surfaced at runtime
+against the live API:
+
+  - an ``agent()`` schema whose top-level ``type`` was ``'array'`` — the Anthropic
+    API rejects it (400 input_schema.type), so the verifier Select step failed
+    before verifying anything (PR #66 review), and
+  - the ``reviewerConcerns`` surfacing, which the pure Python tests can't reach.
+
+These guards catch the schema-shape class *statically* (no live API needed), pin
+the reviewerConcerns wiring, and run the JS unit tests (``node:test``) that
+exercise the shells' pure helpers against their real source.
+"""
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW_DIR = _REPO_ROOT / ".claude" / "workflows"
+
+
+def _workflow_files():
+    return sorted(_WORKFLOW_DIR.glob("*.js"))
+
+
+def _schema_top_level_types(src: str):
+    """Yield the top-level ``type`` of every ``agent()`` schema in a shell.
+
+    Schemas appear two ways: inline ``schema: { ... }`` in an agent() options
+    object, and named consts ``const X_HANDOFF = { ... }`` / ``X_SCHEMA``. In
+    this codebase a schema object always lists ``type`` as its first key, so the
+    first ``type: '...'`` after the opening brace is the top-level type.
+    """
+    anchors = [m.end() for m in re.finditer(r"schema:\s*\{", src)]
+    anchors += [
+        m.end()
+        for m in re.finditer(r"const\s+\w*(?:HANDOFF|SCHEMA)\w*\s*=\s*\{", src)
+    ]
+    for pos in anchors:
+        t = re.search(r"type:\s*['\"](\w+)['\"]", src[pos:])
+        if t:
+            yield t.group(1)
+
+
+class TestWorkflowSchemas:
+    def test_workflow_dir_has_shells(self):
+        assert _WORKFLOW_DIR.is_dir()
+        assert _workflow_files(), "expected at least one workflow .js file"
+
+    @pytest.mark.parametrize("wf", _workflow_files(), ids=lambda p: p.name)
+    def test_agent_schemas_are_objects(self, wf):
+        """A custom tool's top-level input schema must be an object; a top-level
+        array is a 400 from the Anthropic API (the PR #66 Select-schema bug)."""
+        types = list(_schema_top_level_types(wf.read_text()))
+        assert types, f"no agent() schema found in {wf.name} (parser drift?)"
+        non_object = [t for t in types if t != "object"]
+        assert not non_object, (
+            f"{wf.name}: agent() schema(s) with non-object top-level type "
+            f"{non_object} — the API rejects a top-level array/etc."
+        )
+
+
+class TestReviewerConcernsWiring:
+    """Pin that the /forge loop surfaces the editor's unresolved_concerns."""
+
+    def test_surfaced_in_return_with_safe_guard(self):
+        src = (_WORKFLOW_DIR / "implementation-loop.js").read_text()
+        assert "collectReviewerConcerns" in src
+        # Non-array / missing field must default to [], never crash.
+        assert "Array.isArray(editor.unresolved_concerns)" in src
+        # reviewerConcerns is part of the workflow's return payload.
+        assert re.search(r"return\s*\{[\s\S]*?reviewerConcerns[\s\S]*?\}", src), (
+            "reviewerConcerns must be in the workflow's return object"
+        )
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+def test_js_shell_unit_tests():
+    """Run the node:test suite exercising the shells' pure helpers.
+
+    These load helpers from the real shell source (the sandbox can't be
+    imported), so they drive the actual code — e.g. collectReviewerConcerns
+    against real unresolved_concerns payloads.
+    """
+    # Pass the test files explicitly: `node --test <dir>` tries to *load* the
+    # directory as a module rather than scan it.
+    test_files = sorted((_WORKFLOW_DIR / "tests").glob("*.test.mjs"))
+    assert test_files, "expected at least one workflow node:test file"
+    result = subprocess.run(
+        ["node", "--test", *(str(p) for p in test_files)],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/studio/verifier.py
+++ b/studio/verifier.py
@@ -41,6 +41,29 @@ def select_findings_to_verify(findings: list[Finding]) -> list[Finding]:
     return [f for f in findings if f.confidence == "medium"]
 
 
+def select_rows_for_run(run_dir) -> list[dict]:
+    """Select rows for the verifier Workflow's Select step.
+
+    Returns ``[{"index": i, "quote": f.quote}]`` for each Medium finding in
+    ``run_dir``'s findings.json. The index is the finding's position in the
+    ordered list — the key apply_verdicts_to_run uses to match a verdict back.
+    The quote is the ONLY thing the per-finding verifier is shown; the
+    anti-anchoring firewall itself lives in the Workflow shell.
+
+    This lives here, as real Python the gate can test, rather than as a
+    multi-line ``python -c`` string built inside the JS shell — that string form
+    silently produced invalid Python (a list comprehension joined by "; ") and
+    only limped through because the Select agent hand-repaired it at runtime.
+    """
+    findings = load_findings_json(run_dir)
+    eligible_ids = {id(f) for f in select_findings_to_verify(findings)}
+    return [
+        {"index": i, "quote": f.quote}
+        for i, f in enumerate(findings)
+        if id(f) in eligible_ids
+    ]
+
+
 def apply_verdict(
     finding: Finding,
     verdict: str,

--- a/studio/verifier.py
+++ b/studio/verifier.py
@@ -1,0 +1,96 @@
+"""
+Independent second opinion on contrarian findings (Studio roadmap R1, Unit 2).
+
+Unit 1 (findings.py) turned each contrarian flaw into a parseable Finding record
+in findings.json. This module is the tested seam of the verifier that re-checks
+the shaky ones. The rule that makes verification worth anything lives in the
+Workflow shell (.claude/workflows/finding-verifier.js), not here: the checker is
+a fresh agent shown ONLY the finding's quote and the demotion rules, never the
+contrarian's reasoning. This module holds the pure, gate-testable pieces around
+that firewall:
+
+  - which findings are eligible for a second opinion (Medium only),
+  - how a verdict maps to an adjusted confidence, and
+  - writing those adjusted confidences back into findings.json.
+
+Pure stdlib, patterned on findings.py / decision_points.py. The filesystem is
+touched only in apply_verdicts_to_run, which round-trips through findings.json.
+"""
+from __future__ import annotations
+
+from findings import Finding, load_findings_json, save_findings_json
+
+# Verdict -> resulting confidence band when the caller does not pass one
+# explicitly. 'uncertain' leaves the finding's own confidence untouched (it stays
+# Medium), so it maps to None here and the current confidence is carried through.
+_VERDICT_TO_CONFIDENCE: dict[str, str | None] = {
+    "confirmed": "high",     # two voices agree -> promote
+    "unconfirmed": "low",    # the second voice can't confirm the flaw -> demote
+    "uncertain": None,       # not enough to move it -> unchanged (stays medium)
+}
+
+
+def select_findings_to_verify(findings: list[Finding]) -> list[Finding]:
+    """Return only the findings eligible for an independent second opinion.
+
+    MVI = Medium confidence only. High is already the most self-gated tier (the
+    shipped contrarian gate defines High as "quoted and shown"), and Low is
+    already demoted out of the main list, so re-checking either duplicates work.
+    Medium is the tier literally tagged "verify this."
+    """
+    return [f for f in findings if f.confidence == "medium"]
+
+
+def apply_verdict(
+    finding: Finding,
+    verdict: str,
+    resulting_confidence: str | None = None,
+) -> Finding:
+    """Record a verifier's verdict on a finding and set its verified confidence.
+
+    verdict is one of 'confirmed' | 'unconfirmed' | 'uncertain'. The resulting
+    verified_confidence is the caller's resulting_confidence when passed, else it
+    is derived from the verdict: confirmed -> 'high' (promoted), unconfirmed ->
+    'low' (demoted), uncertain -> unchanged (the finding's current confidence).
+
+    Mutates and returns the same Finding, mirroring how the finding record is the
+    overlay that carries its own verified confidence (no separate artifact).
+    """
+    if verdict not in _VERDICT_TO_CONFIDENCE:
+        raise ValueError(
+            f"unknown verdict {verdict!r}; "
+            f"expected one of {sorted(_VERDICT_TO_CONFIDENCE)}"
+        )
+
+    finding.verdict = verdict
+    if resulting_confidence is not None:
+        finding.verified_confidence = resulting_confidence
+    else:
+        derived = _VERDICT_TO_CONFIDENCE[verdict]
+        # 'uncertain' derives None -> carry the finding's own confidence through,
+        # so verified_confidence is always populated after a verdict.
+        finding.verified_confidence = derived if derived is not None else finding.confidence
+    return finding
+
+
+def apply_verdicts_to_run(run_dir, verdicts: list[dict]) -> list[Finding]:
+    """Load findings.json, apply the verifier verdicts, and write it back.
+
+    verdicts is a list of records, each keyed to a finding by its position in the
+    ordered findings.json list::
+
+        {"index": 2, "verdict": "confirmed", "resulting_confidence": "high"}
+
+    resulting_confidence is optional; when omitted it is derived from the verdict
+    (see apply_verdict). Returns the updated Finding list (also persisted).
+    """
+    findings = load_findings_json(run_dir)
+    for verdict_record in verdicts:
+        index = verdict_record["index"]
+        apply_verdict(
+            findings[index],
+            verdict_record["verdict"],
+            verdict_record.get("resulting_confidence"),
+        )
+    save_findings_json(run_dir, findings)
+    return findings


### PR DESCRIPTION
Implements roadmap **R1** — an independent verifier for contrarian findings — from an approved architecture spec. Builds on the evidence gate shipped in #65 (now in `main`).

## The story

The gate in #65 makes the contrarian quote its evidence and self-rate confidence. But the contrarian still grades its own homework. R1 adds a **genuinely independent second opinion**: a fresh agent re-checks each Medium-confidence finding seeing **only the quoted claim + the judging rules — never the contrarian's reasoning** (the anti-anchoring firewall). Agreement promotes the finding; non-confirmation demotes it.

The `/spec` debate **rejected the naive scope** and reshaped it, which is the point of speccing first:
- An "independent" verifier that's one assistant role-playing both roles is theater → real independence needs a Workflow with separate `agent()` calls.
- Findings are prose today → they need a machine-readable form first.

So it's built as **two sequenced MVI units**.

## What's here

**Unit 1 — structured findings** (`studio/findings.py`): a `FINDING` block format + parser mirroring `decision_points.py`, `CONTRARIAN_MANDATE` now emits findings, `findings.json` load/save. Usable alone — makes the confidence gate machine-readable. (writer + editor pass; editor collapsed the dataclass and dropped dead imports.)

**Unit 2 — the verifier** (`studio/verifier.py` + `.claude/workflows/finding-verifier.js`): a tested Python core (select Medium findings → apply verdict → write adjusted confidence back to `findings.json`) plus a thin JS Workflow shell that spawns a fresh `agent()` per Medium finding with the quote-only firewall. The split keeps the logic testable without a JS harness.

**Fix** (`f32182a`): ships `finding-verifier.js` to installed repos — a gap the `/forge` editor's Reviewer Concerns surfaced on the Unit 2 run (the mechanism from #65 working on its first outing).

## Verification

- Full suite **793 passed**; ruff clean; both workflow JS files parse.
- Unit 2 mutation check: 20 assertions broken, all caught.
- **Known gap:** the Python core is tested; the JS Workflow shell's live end-to-end run is being smoke-tested separately (results to follow in a comment). Not merge-ready until that's confirmed.

## Not in scope (deliberate, per spec)

Verifying High findings (already self-gated); auto-wiring the verifier into the run loop (standalone `finding-verifier.js` invocation is the MVI); generalizing beyond the one path.

Spec: `specs/contrarian-finding-verifier.md`. Roadmap + comparison: `studio/docs/GSTACK_COMPARISON.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
