### PR TITLE
feat(R2): doc-parity tests (reframed from rejected codegen)

### DIFF
--- a/specs/doc-parity-tests.md
+++ b/specs/doc-parity-tests.md
@@ -1,0 +1,119 @@
+---
+feature: Doc-parity tests (Studio roadmap R2, reframed)
+slug: doc-parity-tests
+ticket: none (roadmap item R2 — see studio/docs/GSTACK_COMPARISON.md)
+status: approved
+studio_run: .studio/output/tech/run_tech_20260716_181851
+---
+
+# Doc-Parity Tests — Architecture Spec
+
+## In Plain Language
+
+Studio's reference docs list things the code defines: the CLI subcommands, the config knobs. When
+someone adds a command or a config field and forgets to document it (or renames one and leaves a
+stale doc entry), the docs quietly go wrong. That's the doc-rot `/unstale` chases by hand.
+
+R2 started as "generate those docs from the code" — copied from gstack. The `/spec` debate
+**rejected that** for Studio, and the reason is worth recording: gstack generates its docs from
+source because *there* the source is the richer thing. In Studio it's the opposite — the reference
+docs are **intentionally richer than the code**. `check-updates`'s argparse `help=` is one line;
+its API.md entry is a ~180-word explainer of TTL caching and exit-0 safety that lives *nowhere* in
+the code. Generating that table from argparse would **delete** the authored prose. That's not
+drift-prevention, it's drift-infliction.
+
+So the shape that actually fits Studio is not generation — it's **assertion**. A handful of tests
+check that every name the code defines is documented, and that no documented name is stale. The
+hand-written prose stays exactly where it is and stays human-owned; the tests only guard the
+*names*. When you add a command or a config field, a test fails until you document it — the
+`/unstale` chore, made automatic and free, with zero risk to the prose.
+
+## Architecture at a Glance
+
+```mermaid
+flowchart LR
+    subgraph Source of truth
+        P[build_parser subcommands]
+        S[ScopeConfig fields]
+        L[LoopConfig fields]
+    end
+    subgraph Docs
+        A[API.md command table]
+        SG[SCOPES_GUIDE.md]
+        IL[IMPLEMENTATION_LOOP_SPEC.md]
+    end
+    P -->|names must match| A
+    S -->|fields must be documented| SG
+    L -->|fields must be documented| IL
+    T[test_doc_parity.py] -.asserts.-> P
+    T -.asserts.-> A
+    T -.asserts.-> S
+    T -.asserts.-> L
+```
+
+The tests read the code (the authoritative names) and the docs (the committed text), and assert the
+names line up. No generator, no new CLI, no CI wiring beyond the existing `pytest` run.
+
+## How It Works (Technical)
+
+One new file, `studio/tests/test_doc_parity.py`, pure stdlib, three checks:
+
+- **CLI command parity (both directions).** Import `build_parser()`, pull the sub-command names from
+  its `_SubParsersAction.choices`. Parse the `Command | Description` table in `docs/API.md` (the
+  rows under that header, first column, backtick-stripped). Assert the two sets are equal — a new
+  command with no row *and* a stale row with no command both fail. This is the clean two-way check
+  because API.md has a real, parseable command table.
+- **ScopeConfig field coverage (forward).** `dataclasses.fields(ScopeConfig)` minus `name` (which is
+  the TOML *section* name `[scopes.<name>]`, not a row key). Assert each remaining field appears as a
+  backticked token in `docs/SCOPES_GUIDE.md`. Forward-only (does the doc mention the field?) because
+  the reverse would need fragile prose parsing; the high-value drift is "new field, undocumented."
+- **LoopConfig field coverage (forward).** `dataclasses.fields(LoopConfig)`; assert each appears as a
+  backticked token in `docs/IMPLEMENTATION_LOOP_SPEC.md` (its §4 TOML block is the canonical list).
+
+**Interfaces:** the only "contract" is the API.md command-table header (`| Command | Description |`)
+and the backtick convention for names in the config docs — both already the house style. If a doc's
+structure changes, the parser helper in the test is the single place to adjust.
+
+**Dependencies:** `build_parser` (run_phase.py), `ScopeConfig` (scopes.py), `LoopConfig`
+(impl_loop.py), and the three doc files. Stdlib `dataclasses` + `re` only.
+
+## Key Decisions
+
+- **Assert, don't generate** (the debate's core reversal). Studio's docs are richer than the code, so
+  generation destroys value; parity assertion catches the real drift (add/rename/remove of *names*)
+  while leaving every hand-authored sentence untouched.
+- **`build_parser()`, not `_actions` introspection.** It's a real importable function; only
+  `_SubParsersAction.choices` (the command names) is needed — the brittle `_actions` walk the
+  original plan flagged is unnecessary.
+- **Two-way for commands, forward-only for config.** API.md has a clean command table, so both
+  directions are cheap and robust. Config keys are sprinkled through prose, so forward-only ("field
+  is documented") avoids fragile reverse parsing while still catching the common failure.
+- **No new module, CLI, or CI step.** The checks live in the existing `pytest` suite that CI already
+  runs. This is the contrarian's cut, kept.
+
+## Non-Goals / Cut Scope
+
+- **No codegen / `docgen` module / `--check`/`--write` CLI / CI wiring** — rejected; it would delete
+  authored prose and over-builds for the problem.
+- **No generating descriptions**, ever — descriptions stay human.
+- **No cross-repo generation** — the docs ship as static artifacts via `install.py` already; nothing
+  runs downstream, so the install-path trap never applies.
+- **No reverse check on config keys** — fragile against prose; not worth it for the MVI.
+
+## Risks & Open Questions
+
+- **A doc restructure breaks the parser helper.** Mitigation: one small, well-named helper per
+  surface; a failure points straight at it. This is strictly better than the status quo (silent
+  drift).
+- **Forward-only config checks miss a *stale* documented key** (renamed field, old name lingers).
+  Accepted for the MVI; it's the rarer, lower-cost drift. Revisit if it bites.
+- **First run may fail on real, existing drift** — that's the test earning its keep. If so, fix the
+  doc (add the missing row/key) as part of landing this; do not weaken the test to pass.
+
+## Build Plan
+
+One MVI unit (small enough to build directly, not via `/forge`):
+
+1. **`studio/tests/test_doc_parity.py`** — the three checks above, with a small table/token parser
+   per surface. If any check fails on the current tree, fix the drifted doc in the same change.
+   *Usable immediately:* the next undocumented command or config field fails CI.

--- a/studio/tests/test_doc_parity.py
+++ b/studio/tests/test_doc_parity.py
@@ -1,0 +1,100 @@
+"""Doc-parity tests (Studio roadmap R2, reframed — see specs/doc-parity-tests.md).
+
+Studio's reference docs are intentionally *richer* than the code, so we do NOT
+generate them from source (that would delete authored prose). Instead we assert
+that every name the code defines — CLI subcommands, config fields — is
+documented, and, where a clean table exists, that no documented name is stale.
+Hand-written prose stays untouched; only the names are guarded. Add a command or
+a config field and forget the doc, and a test here fails — the /unstale chore,
+made automatic and free.
+"""
+import argparse
+import dataclasses
+import re
+from pathlib import Path
+
+from impl_loop import LoopConfig
+from run_phase import build_parser
+from scopes import ScopeConfig
+
+_DOCS = Path(__file__).resolve().parent.parent / "docs"
+
+
+def _cli_command_names() -> set[str]:
+    """The CLI subcommand names, straight from the argparse parser."""
+    parser = build_parser()
+    subparsers = next(
+        action
+        for action in parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+    )
+    return set(subparsers.choices)
+
+
+def _api_md_command_names() -> set[str]:
+    """Command names in the `Command | Description` table of docs/API.md."""
+    names: set[str] = set()
+    in_table = False
+    for line in (_DOCS / "API.md").read_text(encoding="utf-8").splitlines():
+        if line.strip().startswith("| Command | Description |"):
+            in_table = True
+            continue
+        if in_table:
+            if not line.strip().startswith("|"):
+                break  # the table ended
+            match = re.match(r"\|\s*`([^`]+)`\s*\|", line)
+            if match:
+                names.add(match.group(1))
+    return names
+
+
+def _undocumented(doc_name: str, names: set[str]) -> set[str]:
+    """Names not mentioned in a doc. A config key counts as documented if its
+    name appears as a whole word anywhere — a TOML example (`key = value`), a
+    backticked mention, or prose all count; only a genuinely absent name fails."""
+    text = (_DOCS / doc_name).read_text(encoding="utf-8")
+    return {
+        name for name in names
+        if not re.search(rf"\b{re.escape(name)}\b", text)
+    }
+
+
+class TestCliCommandParity:
+    """API.md's command table must match the parser's subcommands, both ways."""
+
+    def test_commands_and_api_md_table_match(self):
+        code = _cli_command_names()
+        docs = _api_md_command_names()
+        assert docs, "no `Command | Description` table found in API.md"
+        undocumented = code - docs
+        stale = docs - code
+        assert not undocumented, (
+            f"CLI commands missing from API.md's command table: {sorted(undocumented)}"
+        )
+        assert not stale, (
+            f"API.md documents commands that no longer exist: {sorted(stale)}"
+        )
+
+
+class TestScopeConfigParity:
+    """Every ScopeConfig knob must be documented in SCOPES_GUIDE.md."""
+
+    def test_fields_documented(self):
+        # `name` is the `[scopes.<name>]` TOML section name, not a row key.
+        fields = {f.name for f in dataclasses.fields(ScopeConfig)} - {"name"}
+        missing = _undocumented("SCOPES_GUIDE.md", fields)
+        assert not missing, (
+            f"ScopeConfig fields undocumented in SCOPES_GUIDE.md: {sorted(missing)}"
+        )
+
+
+class TestLoopConfigParity:
+    """Every LoopConfig knob must be documented in IMPLEMENTATION_LOOP_SPEC.md."""
+
+    def test_fields_documented(self):
+        fields = {f.name for f in dataclasses.fields(LoopConfig)}
+        missing = _undocumented("IMPLEMENTATION_LOOP_SPEC.md", fields)
+        assert not missing, (
+            "LoopConfig fields undocumented in IMPLEMENTATION_LOOP_SPEC.md: "
+            f"{sorted(missing)}"
+        )


### PR DESCRIPTION
Roadmap **R2**, reframed by the `/spec` debate. Started as gstack's doc-codegen; the debate **rejected the codegen premise for Studio** and produced a smaller, non-destructive design instead.

## Why codegen was rejected (the valuable part)

gstack generates its docs from source because *there* the source is the richer thing. In Studio it's **reversed** — the reference docs are *intentionally richer than the code*:
- `check-updates` / `update` in API.md are **hundred-word hand-authored explainers** (TTL caching, opt-out sentinels, exit-0 safety) that exist nowhere in argparse `help=`.

Generating that table from argparse would **delete** the authored prose — drift-*infliction*, not prevention. And the CLI surface is already audited by `/unstale` (`run_phase.py --help`) for free, with no evidence the table ever drifted. Full write-up + why gstack's mechanism doesn't transplant: `specs/doc-parity-tests.md`.

## What ships instead: assert, don't generate

`studio/tests/test_doc_parity.py` — three checks that guard the source-of-truth **names** while leaving every hand-authored sentence untouched:

1. **CLI commands, both directions** — `build_parser()` subcommands ↔ the `Command | Description` table in API.md. A new command with no row *and* a stale row with no command both fail.
2. **ScopeConfig fields** documented in `SCOPES_GUIDE.md`.
3. **LoopConfig fields** documented in `IMPLEMENTATION_LOOP_SPEC.md`.

No `docgen` module, no new CLI, no CI wiring — the checks ride the existing `pytest` run.

## Verification

- All 3 parity checks **green today** (no current drift); full suite **805 passed**.
- Confirmed they bite: an earlier iteration of the config check flagged all 8 LoopConfig fields as "missing" (my scan was backtick-only; the keys live in a TOML block) — fixed to a whole-word presence check.

## Not in scope (deliberate)

No codegen / description generation / cross-repo generation (docs ship as static artifacts, so the install-path trap never applies); no reverse check on config keys (fragile against prose — the forward "is it documented?" catches the common failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
