### PR TITLE
feat(R4): delta-based trend alerts in stats

### DIFF
--- a/studio/run_phase.py
+++ b/studio/run_phase.py
@@ -89,6 +89,7 @@ from stats import (
     _parse_usage_log,
     _summarize_metrics,
     aggregate_stats,
+    detect_trend_alerts,
     format_stats,
     summarize_outcomes,
     summarize_session_health,
@@ -2859,6 +2860,11 @@ def show_stats(args: argparse.Namespace) -> None:
 
     agg = aggregate_stats(runs)
 
+    # Trend alerts: run-over-run regressions that persist across 2+ consecutive
+    # runs (rating falling, tokens/cost climbing). detect_trend_alerts orders by
+    # created_iso itself, so the raw run list is fine to hand over.
+    trend_alerts = detect_trend_alerts(runs)
+
     # Session health: the automatic finalize records, oldest first so the
     # recent-vs-earlier trend split is chronological. The --phase filter above
     # already narrowed `runs`, so this respects it.
@@ -2876,7 +2882,10 @@ def show_stats(args: argparse.Namespace) -> None:
     outcomes = summarize_outcomes(outcome_records)
 
     if getattr(args, "json", False):
-        print(json.dumps({**agg, "outcomes": outcomes, "session_health": session_health}, indent=2))
+        print(json.dumps(
+            {**agg, "outcomes": outcomes, "session_health": session_health, "trend_alerts": trend_alerts},
+            indent=2,
+        ))
         return
 
     usage = None
@@ -2892,7 +2901,10 @@ def show_stats(args: argparse.Namespace) -> None:
     if snapshot is not None and snapshot.topics:
         clarity_note = f"{len(snapshot.topics)} topics tracked (run 'show-clarity' for the table)"
 
-    print(format_stats(agg, usage=usage, clarity_note=clarity_note, outcomes=outcomes, session_health=session_health))
+    print(format_stats(
+        agg, usage=usage, clarity_note=clarity_note, outcomes=outcomes,
+        session_health=session_health, trend_alerts=trend_alerts,
+    ))
 
 
 def inject_context(args: argparse.Namespace) -> None:

--- a/studio/stats.py
+++ b/studio/stats.py
@@ -204,6 +204,128 @@ def summarize_session_health(session_records: List[Dict]) -> Dict:
     return summary
 
 
+# gstack's best anti-noise monitoring rule: alert on a persistent worsening
+# trend, never a single-run blip. A regression must hold across at least this
+# many consecutive run-over-run steps before it is allowed to fire.
+MIN_CONSECUTIVE_REGRESSIONS = 2
+
+# Run-over-run wobble smaller than this relative move does not count as a
+# worsening step. It keeps ordinary noise (a rating nudged by 2%, a few hundred
+# tokens) from tripping an alert; only a real move in the bad direction counts.
+MIN_RELATIVE_CHANGE = 0.05
+
+
+def _rating_score(run: Dict) -> Optional[float]:
+    """Per-run human rating (1-5), or None when the run is unrated."""
+    rating = run.get("_rating")
+    if isinstance(rating, dict) and _is_number(rating.get("score")):
+        return rating["score"]
+    return None
+
+
+def _run_tokens(run: Dict) -> Optional[float]:
+    """Per-run token spend, or None when no token metric was recorded."""
+    tokens = (run.get("metrics") or {}).get("total_tokens")
+    return tokens if _is_number(tokens) else None
+
+
+def _run_cost(run: Dict) -> Optional[float]:
+    """Per-run dollar cost, or None when no cost was recorded."""
+    cost = run.get("cost")
+    return cost if _is_number(cost) else None
+
+
+# Each tracked metric already lives on the per-run record that aggregate_stats
+# reads. "worse" names the bad direction: "down" for a rating that should stay
+# high, "up" for a spend that should stay low.
+_TREND_METRICS = (
+    {"key": "rating", "label": "Human rating", "worse": "down", "extract": _rating_score},
+    {"key": "tokens", "label": "Tokens per run", "worse": "up", "extract": _run_tokens},
+    {"key": "cost", "label": "Cost per run", "worse": "up", "extract": _run_cost},
+)
+
+
+def _trailing_regression_streak(values: List[float], worse: str) -> int:
+    """Count consecutive worsening steps at the tail of a value series.
+
+    ``values`` is oldest-first, with missing runs already dropped. ``worse`` is
+    "up" when a higher number is the regression (tokens, cost) or "down" when a
+    lower number is (a rating). We walk backward from the newest run and count
+    each run-over-run step that moved in the bad direction by at least
+    MIN_RELATIVE_CHANGE. The first step that is flat or improving ends the
+    streak, so only an unbroken run of regressions at the very end is counted.
+    """
+    streak = 0
+    for index in range(len(values) - 1, 0, -1):
+        previous = values[index - 1]
+        current = values[index]
+        if previous == 0:
+            break  # no meaningful relative change off a zero baseline
+        relative_change = (current - previous) / abs(previous)
+        if worse == "up":
+            worsened = relative_change >= MIN_RELATIVE_CHANGE
+        else:
+            worsened = relative_change <= -MIN_RELATIVE_CHANGE
+        if not worsened:
+            break
+        streak += 1
+    return streak
+
+
+def detect_trend_alerts(runs: List[Dict]) -> List[Dict]:
+    """Flag metrics that have worsened across 2+ consecutive runs.
+
+    Brings gstack's anti-noise monitoring rule to the dashboard: alert on the
+    *direction* a metric is moving, not whether it crossed some absolute line,
+    and only once the regression has persisted across at least two consecutive
+    run-over-run steps. A single-run dip is a blip and never alerts.
+
+    Takes the same enriched run dicts aggregate_stats consumes (each may carry
+    ``created_iso``, ``_rating``, ``metrics``, ``cost``). Runs are ordered oldest
+    first by ``created_iso`` so the trend reads chronologically. For each tracked
+    metric we build its per-run series (runs missing that metric drop out), then
+    keep only metrics whose newest runs form an unbroken worsening streak of
+    MIN_CONSECUTIVE_REGRESSIONS or more.
+
+    Pure: data in, a list of alert dicts out (empty when nothing is regressing).
+    """
+    ordered = sorted(
+        [run for run in runs if isinstance(run, dict)],
+        key=lambda run: run.get("created_iso") or "",
+    )
+
+    alerts: List[Dict] = []
+    for metric in _TREND_METRICS:
+        series: List[tuple] = []  # (run label, value), oldest first
+        for run in ordered:
+            value = metric["extract"](run)
+            if value is not None:
+                series.append((run.get("run_id") or run.get("run_dir") or "?", value))
+
+        values = [value for _, value in series]
+        streak = _trailing_regression_streak(values, metric["worse"])
+        if streak < MIN_CONSECUTIVE_REGRESSIONS:
+            continue
+
+        # The streak counts steps; it spans streak + 1 runs. Report from the
+        # first run in that window (where the slide began) to the newest.
+        window = series[-(streak + 1):]
+        from_value = window[0][1]
+        to_value = window[-1][1]
+        pct_change = (to_value - from_value) / abs(from_value) if from_value else None
+        alerts.append({
+            "metric": metric["key"],
+            "label": metric["label"],
+            "direction": metric["worse"],
+            "consecutive": streak,
+            "runs": [label for label, _ in window],
+            "from_value": from_value,
+            "to_value": to_value,
+            "pct_change": pct_change,
+        })
+    return alerts
+
+
 def _summarize_metrics(entries: List[Dict]) -> Dict:
     """Aggregate metrics entries into a summary."""
     total_tokens = sum(e.get("total_tokens", 0) for e in entries)
@@ -465,12 +587,40 @@ def _format_session_health(health: Dict) -> List[str]:
     return lines
 
 
+def _fmt_metric_value(value: float) -> str:
+    """Format a trend value: whole numbers get thousands separators, else :g."""
+    if isinstance(value, float) and not value.is_integer():
+        return f"{value:g}"
+    return f"{value:,.0f}"
+
+
+def _format_trend_alerts(alerts: List[Dict]) -> List[str]:
+    """Render the Trend Alerts block: metrics sliding the wrong way, run over run.
+
+    Only called when there is at least one alert. Each line names the metric,
+    which way it is moving, and how far it has slid across the consecutive runs
+    that tripped it, so a reader sees the regression without opening any run.
+    """
+    lines = ["", "Trend Alerts (regressions persisting across 2+ consecutive runs):"]
+    for alert in alerts:
+        direction_word = "rising" if alert["direction"] == "up" else "falling"
+        pct = alert["pct_change"]
+        pct_str = f"{pct*100:+.0f}%" if pct is not None else "n/a"
+        lines.append(
+            f"  {alert['label']} {direction_word} across {alert['consecutive']} "
+            f"consecutive runs: {_fmt_metric_value(alert['from_value'])} -> "
+            f"{_fmt_metric_value(alert['to_value'])} ({pct_str})"
+        )
+    return lines
+
+
 def format_stats(
     agg: Dict,
     usage: Optional[Dict] = None,
     clarity_note: Optional[str] = None,
     outcomes: Optional[Dict] = None,
     session_health: Optional[Dict] = None,
+    trend_alerts: Optional[List[Dict]] = None,
 ) -> str:
     """Render an aggregate_stats() result as a terminal dashboard."""
     bar = "=" * 60
@@ -488,6 +638,11 @@ def format_stats(
     lines.append(f"Total runs: {agg['total_runs']}")
     lines.append("  By phase:  " + ", ".join(f"{k}={v}" for k, v in sorted(agg["by_phase"].items())))
     lines.append("  By status: " + ", ".join(f"{k}={v}" for k, v in sorted(agg["by_status"].items())))
+
+    # Surface regressions up top, where a reader scanning the dashboard sees
+    # them first. Omitted entirely when nothing is trending the wrong way.
+    if trend_alerts:
+        lines.extend(_format_trend_alerts(trend_alerts))
 
     v = agg["verdicts"]
     lines.append("")

--- a/studio/tests/test_run_phase.py
+++ b/studio/tests/test_run_phase.py
@@ -869,6 +869,157 @@ def test_format_stats_omits_session_health_when_empty():
     assert "Session health" not in out
 
 
+# --- Trend alerts (delta-based, 2+-consecutive-run persistence) ---
+
+def _trend_run(created_iso, *, score=None, tokens=None, cost=None, run_id=None):
+    """Build a minimal enriched run dict for detect_trend_alerts tests.
+
+    created_iso orders the runs; score/tokens/cost each become a per-run point in
+    that metric's series (left off when None, mirroring an unrated or unmetered
+    run).
+    """
+    run = {"run_id": run_id or f"run_{created_iso}", "created_iso": created_iso}
+    if score is not None:
+        run["_rating"] = {"score": score}
+    if tokens is not None:
+        run["metrics"] = {"total_tokens": tokens}
+    if cost is not None:
+        run["cost"] = cost
+    return run
+
+
+def test_detect_trend_alerts_empty():
+    """No runs yields no alerts and does not crash."""
+    from stats import detect_trend_alerts
+    assert detect_trend_alerts([]) == []
+
+
+def test_detect_trend_alerts_single_dip_is_a_blip():
+    """One worsening step (a single-run dip) must NOT alert."""
+    from stats import detect_trend_alerts
+    runs = [
+        _trend_run("2026-01-01", score=5),
+        _trend_run("2026-01-02", score=4),  # one dip only
+    ]
+    assert detect_trend_alerts(runs) == []
+
+
+def test_detect_trend_alerts_two_consecutive_regressions_fire():
+    """A rating falling across 2+ consecutive runs alerts with the slide window."""
+    from stats import detect_trend_alerts
+    runs = [
+        _trend_run("2026-01-01", score=5),
+        _trend_run("2026-01-02", score=4),
+        _trend_run("2026-01-03", score=3),
+    ]
+    alerts = detect_trend_alerts(runs)
+    assert len(alerts) == 1
+    alert = alerts[0]
+    assert alert["metric"] == "rating"
+    assert alert["direction"] == "down"
+    assert alert["consecutive"] == 2
+    assert alert["from_value"] == 5
+    assert alert["to_value"] == 3
+    assert alert["pct_change"] == pytest.approx(-0.4)
+    assert alert["runs"] == ["run_2026-01-01", "run_2026-01-02", "run_2026-01-03"]
+
+
+def test_detect_trend_alerts_improving_never_fires():
+    """A metric moving the good way (rating up, tokens down) raises no alert."""
+    from stats import detect_trend_alerts
+    runs = [
+        _trend_run("2026-01-01", score=3, tokens=30000),
+        _trend_run("2026-01-02", score=4, tokens=20000),
+        _trend_run("2026-01-03", score=5, tokens=10000),
+    ]
+    assert detect_trend_alerts(runs) == []
+
+
+def test_detect_trend_alerts_recovery_breaks_the_streak():
+    """A dip that recovers on the newest run is not a persistent regression."""
+    from stats import detect_trend_alerts
+    runs = [
+        _trend_run("2026-01-01", score=5),
+        _trend_run("2026-01-02", score=3),  # dipped
+        _trend_run("2026-01-03", score=4),  # recovered — streak broken at the tail
+    ]
+    assert detect_trend_alerts(runs) == []
+
+
+def test_detect_trend_alerts_not_enough_history():
+    """A single rated run cannot form a run-over-run trend; no alert, no crash."""
+    from stats import detect_trend_alerts
+    assert detect_trend_alerts([_trend_run("2026-01-01", score=2)]) == []
+
+
+def test_detect_trend_alerts_tokens_rising_fire():
+    """Tokens climbing across 2+ consecutive runs alerts with direction up."""
+    from stats import detect_trend_alerts
+    runs = [
+        _trend_run("2026-01-01", tokens=10000),
+        _trend_run("2026-01-02", tokens=12000),
+        _trend_run("2026-01-03", tokens=15000),
+    ]
+    alerts = detect_trend_alerts(runs)
+    assert len(alerts) == 1
+    assert alerts[0]["metric"] == "tokens"
+    assert alerts[0]["direction"] == "up"
+    assert alerts[0]["from_value"] == 10000
+    assert alerts[0]["to_value"] == 15000
+
+
+def test_detect_trend_alerts_ignores_sub_threshold_noise():
+    """Moves below the relative-change floor are noise, not a regression."""
+    from stats import detect_trend_alerts
+    runs = [
+        _trend_run("2026-01-01", tokens=10000),
+        _trend_run("2026-01-02", tokens=10100),  # +1%
+        _trend_run("2026-01-03", tokens=10200),  # +1%
+    ]
+    assert detect_trend_alerts(runs) == []
+
+
+def test_detect_trend_alerts_orders_by_created_iso():
+    """Out-of-order input is sorted chronologically before the trend is read."""
+    from stats import detect_trend_alerts
+    runs = [
+        _trend_run("2026-01-03", score=3),
+        _trend_run("2026-01-01", score=5),
+        _trend_run("2026-01-02", score=4),
+    ]
+    alerts = detect_trend_alerts(runs)
+    assert len(alerts) == 1
+    assert alerts[0]["from_value"] == 5
+    assert alerts[0]["to_value"] == 3
+
+
+def test_format_stats_renders_trend_alerts():
+    """format_stats shows the Trend Alerts block when alerts are present."""
+    from stats import detect_trend_alerts
+    agg = run_phase.aggregate_stats([
+        {"run_id": "r1", "phase": "market", "status": "COMPLETED",
+         "verdict": "APPROVED", "metrics": {}, "_rating": None, "_decisions": []},
+    ])
+    alerts = detect_trend_alerts([
+        _trend_run("2026-01-01", score=5),
+        _trend_run("2026-01-02", score=4),
+        _trend_run("2026-01-03", score=3),
+    ])
+    out = run_phase.format_stats(agg, trend_alerts=alerts)
+    assert "Trend Alerts" in out
+    assert "Human rating falling" in out
+
+
+def test_format_stats_omits_trend_alerts_when_empty():
+    """No alerts means no Trend Alerts block."""
+    agg = run_phase.aggregate_stats([
+        {"run_id": "r1", "phase": "market", "status": "COMPLETED",
+         "verdict": "APPROVED", "metrics": {}, "_rating": None, "_decisions": []},
+    ])
+    out = run_phase.format_stats(agg, trend_alerts=[])
+    assert "Trend Alerts" not in out
+
+
 class _FakeStdin:
     def __init__(self, tty):
         self._tty = tty


### PR DESCRIPTION
Roadmap **R4** — brings gstack's best anti-noise monitoring rule to Studio's cross-run `stats` dashboard: **alert on the direction a metric is moving, not an absolute threshold, and only once the regression has persisted across 2+ consecutive runs.** A single-run dip is a blip and never alerts.

## What's here

`detect_trend_alerts(runs)` in `studio/stats.py` — pure, stdlib, takes the same enriched run dicts `aggregate_stats` consumes:
- Orders runs oldest-first by `created_iso`, builds a per-run series for each tracked metric (runs missing a metric drop out).
- Flags a metric only when its newest runs form an unbroken worsening streak of **≥2 consecutive run-over-run steps**, each moving in the bad direction by **≥5% relative** (`_trailing_regression_streak`).
- Metrics tracked (all have a genuine per-run value — no invented data): **human rating** (falling), **tokens/run** (rising), **cost/run** (rising).

Surfaces as a **"Trend Alerts"** block near the top of the dashboard (omitted entirely when nothing is regressing) and as a top-level `trend_alerts` key in `--json`. `show_stats` computes it once and hands it to both paths.

**Deliberately not included:** ship/approval *rates* — those are aggregates, not a per-run series; a windowed rate-trend would be extra machinery inventing structure the data doesn't have. Easy to add later.

## Verification
Full suite **813 passed** (11 new tests: single-dip-no-alert, 2-consecutive-fires, improving-no-alert, recovery-breaks-streak, insufficient-history, tokens-rising, sub-threshold-noise, out-of-order input, render + omit). `ruff` clean.

Built in an isolated worktree; reviewed before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
