### PR TITLE
fix: clear error on out-of-range verdict index in apply_verdicts_to_run

### DIFF
--- a/studio/tests/test_verifier.py
+++ b/studio/tests/test_verifier.py
@@ -139,6 +139,14 @@ class TestApplyVerdictsToRun:
         assert reloaded[0].verdict is None
         assert reloaded[0].verified_confidence is None
 
+    def test_out_of_range_index_raises_clear_error(self, tmp_path):
+        # A stale index (e.g. findings.json shrank between select and write-back)
+        # should fail with a clear message, not a bare IndexError.
+        save_findings_json(tmp_path, [_finding("medium"), _finding("high")])
+
+        with pytest.raises(ValueError, match="out of range"):
+            apply_verdicts_to_run(tmp_path, [{"index": 5, "verdict": "confirmed"}])
+
 
 # ---------------------------------------------------------------------------
 # The Select step — the real Python the JS shell shells out to. Covering it here

--- a/studio/verifier.py
+++ b/studio/verifier.py
@@ -109,6 +109,12 @@ def apply_verdicts_to_run(run_dir, verdicts: list[dict]) -> list[Finding]:
     findings = load_findings_json(run_dir)
     for verdict_record in verdicts:
         index = verdict_record["index"]
+        if not 0 <= index < len(findings):
+            raise ValueError(
+                f"verdict index {index} is out of range for "
+                f"{len(findings)} finding(s); findings.json may have changed "
+                f"since the verdicts were selected"
+            )
         apply_verdict(findings[index], verdict_record["verdict"])
     save_findings_json(run_dir, findings)
     return findings


### PR DESCRIPTION
Reported while reviewing a downstream Studio-update PR.

`apply_verdicts_to_run` indexed `findings[index]` straight from each verdict record. A stale or out-of-range index — e.g. if `findings.json` was edited or shrank between selecting verdicts and writing them back — raised a bare `IndexError`, a rougher failure than the rest of the module's `ValueError` style.

**Fix:** bounds-check the index and raise a `ValueError` that names the offending index and points at the likely cause (findings.json changed since selection). Adds a test for the out-of-range case.

All 15 `test_verifier.py` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)