### PR TITLE
chore: record the three approved specs as approved

### DIFF
--- a/specs/prompt-feature-verification.md
+++ b/specs/prompt-feature-verification.md
@@ -2,7 +2,7 @@
 feature: Pre-committed Verification for Prompt-Shaped Features
 slug: prompt-feature-verification
 ticket: none
-status: draft
+status: approved
 studio_run: .studio/output/tech/run_tech_20260728_192832
 ---
 

--- a/specs/unit-acceptance-criteria.md
+++ b/specs/unit-acceptance-criteria.md
@@ -2,7 +2,7 @@
 feature: Unit Acceptance Criteria from the Approved Spec
 slug: unit-acceptance-criteria
 ticket: none
-status: draft
+status: approved
 studio_run: .studio/output/tech/run_tech_20260728_211955
 ---
 

--- a/specs/writer-escalation-channel.md
+++ b/specs/writer-escalation-channel.md
@@ -2,7 +2,7 @@
 feature: Writer Escalation Channel
 slug: writer-escalation-channel
 ticket: none
-status: draft
+status: approved
 studio_run: .studio/output/tech/run_tech_20260728_155545
 ---
 


### PR DESCRIPTION
Three specs were approved and merged today — the writer escalation channel (#77), pre-committed verification for prompt-shaped features (#79), and unit acceptance criteria (#80). Their frontmatter still said `status: draft`.

That field is not decoration. It is the one place a spec records whether it is the source of truth to build against, and #80's own design makes it load-bearing: a `status: draft` spec is supposed to pause `/forge` as a decision point. Left as-is, all three approved specs would have tripped that pause, and #79's spec puts the same field under test with a three-value lifecycle.

Three lines, one per spec. Nothing else changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)