### PR TITLE
test: rule 4 — a shipped spec's evidence file must still carry every heading, answered

### DIFF
--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -228,8 +228,8 @@ the file (Coding Principles §8). Then:
   criterion, say so under "What this doesn't prove."
 
   Every placeholder below marks data that does not exist yet. Replacing one is the act of reporting.
-  Deleting one without replacing it — dropping a row or a section — is what these pre-written headings
-  make conspicuous in review; the test only counts placeholders, so deletion is on your honour.
+  Dropping a whole section, or clearing a placeholder and writing nothing under its heading, fails the
+  suite once this spec says `status: shipped` — every heading here needs an answer you wrote yourself.
 
   ## Pass criterion (written before the build)
   > _Copy the iff from the spec's Verification section, word for word._

--- a/specs/prompt-feature-verification-eval-results.md
+++ b/specs/prompt-feature-verification-eval-results.md
@@ -5,8 +5,8 @@ below was copied from that spec before anything was measured. Don't edit it to m
 if it turned out to be the wrong criterion, say so under "What this doesn't prove."
 
 Every placeholder below marks data that does not exist yet. Replacing one is the act of reporting.
-Deleting one without replacing it — dropping a row or a section — is what these pre-written headings
-make conspicuous in review; the test only counts placeholders, so deletion is on your honour.
+Dropping a whole section, or clearing a placeholder and writing nothing under its heading, fails the
+suite once this spec says `status: shipped` — every heading here needs an answer you wrote yourself.
 
 ## Pass criterion (written before the build)
 > This feature works if and only if the next prompt-shaped spec written after it

--- a/studio/tests/test_spec_verification.py
+++ b/studio/tests/test_spec_verification.py
@@ -109,15 +109,16 @@ def _skeleton_block(command_text: str) -> list[str]:
     return block
 
 
-def _printed_lines(command_text: str) -> frozenset[str]:
+def _printed_lines(skeleton_lines: list[str]) -> frozenset[str]:
     """Every non-blank, non-heading line /spec's evidence skeleton prints under a heading.
 
     These are the lines an evidence file is born with — the questions, the guidance, the empty
-    table, the placeholders. Not one of them is somebody's finding.
+    table, the placeholders. Not one of them is somebody's finding. Takes the block
+    ``_skeleton_block`` already found, so the fence scoping happens in exactly one place.
     """
     printed: set[str] = set()
     in_section = False
-    for line in _skeleton_block(command_text):
+    for line in skeleton_lines:
         if line.startswith("#"):
             # The title, and the preamble under it, sit outside every section.
             in_section = line.startswith("## ")
@@ -150,9 +151,8 @@ def _own_words(body: str, printed: frozenset[str]) -> bool:
     return any(line.strip() and line.strip() not in printed for line in body.splitlines())
 
 
-_COMMAND_TEXT = SPEC_COMMAND.read_text(encoding="utf-8")
-_SKELETON_LINES = _skeleton_block(_COMMAND_TEXT)
-_PRINTED_LINES = _printed_lines(_COMMAND_TEXT)
+_SKELETON_LINES = _skeleton_block(SPEC_COMMAND.read_text(encoding="utf-8"))
+_PRINTED_LINES = _printed_lines(_SKELETON_LINES)
 
 
 def _violations(

--- a/studio/tests/test_spec_verification.py
+++ b/studio/tests/test_spec_verification.py
@@ -6,7 +6,9 @@ permission to stop. No pytest can tell you those broke, so their specs carry a
 file beside the spec that has to be filled in before anyone says the feature works.
 
 This file is what makes that claim cost evidence. Flip a spec to ``status: shipped``
-while its results file still says ``FILL_ME`` and the suite goes red.
+while its results file still says ``FILL_ME`` and the suite goes red. So does dropping one
+of the pre-written headings, or clearing a placeholder and leaving the skeleton's own
+question sitting there with no answer under it.
 
 It is a separate file from ``test_doc_parity.py`` on purpose: that one asserts every
 name the code defines is documented, while this one compares two documents to each
@@ -24,11 +26,27 @@ import pytest
 
 # CI runs pytest with `working-directory: studio`, so relative paths are out.
 # parents[2] is the repo root — the same idiom test_claude_code.py uses.
-SPECS_DIR = Path(__file__).resolve().parents[2] / "specs"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPECS_DIR = REPO_ROOT / "specs"
+SPEC_COMMAND = REPO_ROOT / ".claude" / "commands" / "spec.md"
 
 _STATUSES = {"draft", "approved", "shipped"}
 _RESULTS_SUFFIX = "-eval-results.md"
 _FILL = "FILL_ME"
+
+# The four headings an evidence file is born with, stated once. /spec's skeleton prints these
+# and rule 4 below requires them; `test_the_skeleton_prints_exactly_the_required_headings`
+# holds the two lists to each other so neither side can drift out from under the other.
+_REQUIRED_HEADINGS = (
+    "## Pass criterion (written before the build)",
+    "## What happened",
+    "## What this doesn't prove",
+    "## Verdict",
+)
+
+# The line the evidence skeleton opens with inside spec.md. Extraction has to be scoped to
+# this block: spec.md also carries the *spec* template, whose headings are a different list.
+_SKELETON_TITLE = "# <Feature> — Verification Results"
 
 
 def _spec_files(specs_dir: Path) -> list[Path]:
@@ -72,6 +90,71 @@ def _section_of_first_fill(results_text: str) -> str:
     return heading
 
 
+def _skeleton_block(command_text: str) -> list[str]:
+    """The evidence skeleton /spec prints, lifted out of .claude/commands/spec.md.
+
+    Scoped to the fenced block that opens with the results title and stopping at that
+    fence's close, because spec.md also carries the spec template. Lines come back
+    stripped: the skeleton sits two spaces indented inside a bullet, and that same
+    normalization is what makes them comparable to an evidence file's own lines.
+    """
+    lines = [line.strip() for line in command_text.splitlines()]
+    if _SKELETON_TITLE not in lines:
+        return []
+    block: list[str] = []
+    for line in lines[lines.index(_SKELETON_TITLE):]:
+        if line.startswith("```"):
+            break
+        block.append(line)
+    return block
+
+
+def _printed_lines(command_text: str) -> frozenset[str]:
+    """Every non-blank, non-heading line /spec's evidence skeleton prints under a heading.
+
+    These are the lines an evidence file is born with — the questions, the guidance, the empty
+    table, the placeholders. Not one of them is somebody's finding.
+    """
+    printed: set[str] = set()
+    in_section = False
+    for line in _skeleton_block(command_text):
+        if line.startswith("#"):
+            # The title, and the preamble under it, sit outside every section.
+            in_section = line.startswith("## ")
+            continue
+        if in_section and line:
+            printed.add(line)
+    return frozenset(printed)
+
+
+def _section_body(results_text: str, heading: str) -> str | None:
+    """Everything under `heading` up to the next heading, or None if the heading isn't there."""
+    lines = results_text.splitlines()
+    stripped = [line.strip() for line in lines]
+    if heading not in stripped:
+        return None
+    body: list[str] = []
+    for line in lines[stripped.index(heading) + 1:]:
+        if line.strip().startswith("#"):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def _own_words(body: str, printed: frozenset[str]) -> bool:
+    """Whether anything under this heading was written by the reporter.
+
+    A line the skeleton printed is not a report; neither is a blank one. Whatever survives
+    that, someone typed on purpose.
+    """
+    return any(line.strip() and line.strip() not in printed for line in body.splitlines())
+
+
+_COMMAND_TEXT = SPEC_COMMAND.read_text(encoding="utf-8")
+_SKELETON_LINES = _skeleton_block(_COMMAND_TEXT)
+_PRINTED_LINES = _printed_lines(_COMMAND_TEXT)
+
+
 def _violations(
     spec_name: str,
     spec_text: str,
@@ -80,9 +163,9 @@ def _violations(
 ) -> list[str]:
     """Every way this spec breaks the convention, in plain sentences.
 
-    ``results_text`` is ``None`` when the results file does not exist. Three rules,
-    and rules 2 and 3 stay quiet unless the spec actually has a Verification section —
-    that tolerance is what leaves a spec with no prose-shaped behavior alone.
+    ``results_text`` is ``None`` when the results file does not exist. Four rules, and
+    rules 2 to 4 stay quiet unless the spec actually has a Verification section — that
+    tolerance is what leaves a spec with no prose-shaped behavior alone.
     """
     problems: list[str] = []
     status = _frontmatter_status(spec_text)
@@ -120,6 +203,30 @@ def _violations(
                 "spec back to `status: approved` and stop describing the feature as working."
             )
 
+    # Rule 4: a claim costs the whole shape. Every required heading must still be there, and
+    # each must carry at least one line the reporter wrote rather than one the skeleton printed.
+    # An independent `if`, not an `elif` after rule 3: this function returns a list precisely so
+    # one CI run tells you everything that is wrong. `approved` stays untouched — a hollow
+    # skeleton there is the pre-registration the whole convention rests on.
+    if promised_evidence and status == "shipped" and results_text is not None:
+        for heading in _REQUIRED_HEADINGS:
+            body = _section_body(results_text, heading)
+            if body is None:
+                problems.append(
+                    f"specs/{spec_name} is marked `status: shipped`, but {results_name} no longer "
+                    f"has '{heading}'. These headings were written before the data existed so they "
+                    "could not be dropped once the data turned out inconvenient. Either put the "
+                    "section back and answer it, or set this spec back to `status: approved`."
+                )
+            elif not _own_words(body, _PRINTED_LINES):
+                problems.append(
+                    f"specs/{spec_name} is marked `status: shipped`, but nothing under '{heading}' "
+                    f"in {results_name} was written by you — every line there is one /spec's "
+                    "skeleton printed, so the section is still asking its question with no answer "
+                    "under it. Either write what you actually found, or set this spec back to "
+                    "`status: approved`."
+                )
+
     return problems
 
 
@@ -151,21 +258,46 @@ _SKELETON = (
     f"| Baseline (feature off) | {_FILL} | {_FILL} |\n"
     f"| With the feature | {_FILL} | {_FILL} |\n\n"
     "## What this doesn't prove\n\n"
+    f"{_FILL}\n\n"
+    "## Verdict\n\n"
     f"{_FILL}\n"
 )
+
+# Pulled out so the fixtures below can swap one section at a time and stay readable.
+_FILLED_CRITERION = "This works if and only if something observable happens.\n"
+_FILLED_LIMITS = "Three runs is a small sample, and the same author read all six outputs.\n"
 
 _FILLED = (
     "# Synthetic — Verification Results\n\n"
     "## Pass criterion (written before the build)\n\n"
-    "This works if and only if something observable happens.\n\n"
+    f"{_FILLED_CRITERION}\n"
     "## What happened\n\n"
     "| Condition | What was run | Criterion met |\n"
     "|---|---|---|\n"
     "| Baseline (feature off) | three runs, feature off | no |\n"
     "| With the feature | three runs, feature on | yes |\n\n"
     "## What this doesn't prove\n\n"
-    "Three runs is a small sample, and the same author read all six outputs.\n"
+    f"{_FILLED_LIMITS}\n"
+    "## Verdict\n\n"
+    "Criterion met — the effect held in all three runs.\n"
 )
+
+# The skeleton's own guidance under "What this doesn't prove", with the placeholder cleared and
+# nothing written in its place. That is the easiest route to a green suite with nothing reported,
+# and the one rule 4 exists to close. Taken from the real skeleton rather than retyped, so the
+# hollow case below cannot quietly drift into a paraphrase that proves nothing.
+_SKELETON_TEXT = "\n".join(_SKELETON_LINES)
+_UNANSWERED = "".join(
+    f"{line}\n"
+    for line in (_section_body(_SKELETON_TEXT, "## What this doesn't prove") or "").splitlines()
+    if line.strip() and _FILL not in line
+)
+
+# Each of these differs from `_FILLED` in exactly one section, so the case it proves is obvious.
+_HOLLOW = _FILLED.replace(_FILLED_LIMITS, _UNANSWERED)
+_MISSING_HEADING = _FILLED.replace(f"## What this doesn't prove\n\n{_FILLED_LIMITS}\n", "")
+_ANSWER_AS_BLOCKQUOTE = _FILLED.replace(_FILLED_LIMITS, f"> {_FILLED_LIMITS}")
+_CRITERION_AS_BLOCKQUOTE = _FILLED.replace(_FILLED_CRITERION, f"> {_FILLED_CRITERION}")
 
 
 class TestRealSpecs:
@@ -199,6 +331,61 @@ class TestRealSpecs:
                 "must not fire on it"
             )
 
+    def test_the_skeleton_block_is_findable_and_prints_body_lines(self):
+        """Rule 4 leans on finding this block, and both ways of losing it are silent.
+
+        If extraction came back empty, every line in every evidence file would count as the
+        reporter's own words and rule 4 would stop firing while the suite stayed green. So
+        moving or renaming that fence has to turn the tree red instead.
+        """
+        assert _SKELETON_LINES, (
+            f"{_SKELETON_TITLE!r} is no longer in {SPEC_COMMAND.name} — has the evidence "
+            "skeleton moved or been retitled? Rule 4 cannot tell boilerplate from a report "
+            "without it, and would pass everything."
+        )
+        assert _PRINTED_LINES, (
+            f"the skeleton in {SPEC_COMMAND.name} was found but prints no lines under any of "
+            "its headings, so rule 4 would read every line of an evidence file as a finding."
+        )
+        assert _UNANSWERED.strip(), (
+            "the skeleton prints no guidance under \"What this doesn't prove\", so the "
+            "unanswered-section case below has nothing to be unanswered with."
+        )
+
+    def test_the_skeleton_prints_exactly_the_required_headings(self):
+        """The heading list, agreed both ways — two documents that must match.
+
+        A heading required here but no longer printed means every new evidence file is born
+        failing. A heading printed but not required here can be deleted for free at `shipped`.
+        """
+        printed_headings = [line for line in _SKELETON_LINES if line.startswith("## ")]
+        assert printed_headings == list(_REQUIRED_HEADINGS), (
+            f"the skeleton in {SPEC_COMMAND.name} prints {printed_headings}, but rule 4 "
+            f"requires {list(_REQUIRED_HEADINGS)}. Change both or neither."
+        )
+
+    def test_unfilled_sections_are_regenerable_from_the_skeleton(self):
+        """A section still holding a placeholder has not been reported in, so every other line
+        in it came from the template. One that didn't means this file was built from a skeleton
+        that has since changed — and rule 4 would read that stale line as somebody's finding.
+        """
+        for results in sorted(SPECS_DIR.glob(f"*{_RESULTS_SUFFIX}")):
+            text = results.read_text(encoding="utf-8")
+            for heading in _REQUIRED_HEADINGS:
+                body = _section_body(text, heading)
+                if body is None or _FILL not in body:
+                    continue
+                for line in body.splitlines():
+                    stray = line.strip()
+                    if not stray or stray in _PRINTED_LINES:
+                        continue
+                    pytest.fail(
+                        f"{results.name} still has {_FILL} under '{heading}', so nothing there "
+                        f"has been reported yet — but {stray!r} is not a line the skeleton in "
+                        f"{SPEC_COMMAND.name} prints. Rebuild that section from the skeleton as "
+                        "it stands now, or put the guidance line back the way it prints."
+                    )
+
 
 class TestSyntheticSpecs:
     """Each rule fires, and each rule stays quiet when it should.
@@ -213,11 +400,13 @@ class TestSyntheticSpecs:
             "synthetic.md", _synthetic_spec("shipped", verification=True),
             "synthetic-eval-results.md", _SKELETON,
         )
-        assert len(problems) == 1
-        assert _FILL in problems[0]
+        # Rule 4 also has plenty to say about an untouched skeleton at `shipped`, so pick out
+        # the placeholder complaint rather than asserting it is the only one.
+        placeholders = [problem for problem in problems if _FILL in problem]
+        assert len(placeholders) == 1
         # Two honest exits, so nobody is cornered into deleting this test to get green.
-        assert "fill it in" in problems[0]
-        assert "`status: approved`" in problems[0]
+        assert "fill it in" in placeholders[0]
+        assert "`status: approved`" in placeholders[0]
 
     def test_approved_with_missing_results_file_fails(self):
         problems = _violations(
@@ -266,4 +455,48 @@ class TestSyntheticSpecs:
         assert _violations(
             "synthetic.md", _synthetic_spec("shipped", verification=True),
             "synthetic-eval-results.md", _FILLED,
+        ) == []
+
+    def test_shipped_with_a_required_heading_deleted_fails(self):
+        """Deleting a section is the cheapest route past a rule that only counts placeholders."""
+        problems = _violations(
+            "synthetic.md", _synthetic_spec("shipped", verification=True),
+            "synthetic-eval-results.md", _MISSING_HEADING,
+        )
+        assert len(problems) == 1
+        assert "no longer has '## What this doesn't prove'" in problems[0]
+        # The same two honest exits rule 3 offers.
+        assert "put the section back and answer it" in problems[0]
+        assert "`status: approved`" in problems[0]
+
+    def test_shipped_with_an_unanswered_section_fails(self):
+        """The easier route: clear the placeholder, leave the skeleton's question, write nothing.
+
+        There is not a single placeholder left in this file, so rule 3 has nothing to say — the
+        heading is present and the section still looks full.
+        """
+        assert _FILL not in _HOLLOW
+        problems = _violations(
+            "synthetic.md", _synthetic_spec("shipped", verification=True),
+            "synthetic-eval-results.md", _HOLLOW,
+        )
+        assert len(problems) == 1
+        assert "nothing under '## What this doesn't prove'" in problems[0]
+        assert "was written by you" in problems[0]
+        assert "write what you actually found" in problems[0]
+        assert "`status: approved`" in problems[0]
+
+    def test_an_answer_written_as_a_blockquote_passes(self):
+        """Excluding blockquotes was designed and rejected: reporters are allowed the shape."""
+        assert _violations(
+            "synthetic.md", _synthetic_spec("shipped", verification=True),
+            "synthetic-eval-results.md", _ANSWER_AS_BLOCKQUOTE,
+        ) == []
+
+    def test_a_copied_criterion_written_as_a_blockquote_passes(self):
+        """The one real evidence file quotes its criterion, so the rule meant to protect it
+        must not fail it — the reason the blockquote exclusion was thrown out."""
+        assert _violations(
+            "synthetic.md", _synthetic_spec("shipped", verification=True),
+            "synthetic-eval-results.md", _CRITERION_AS_BLOCKQUOTE,
         ) == []


### PR DESCRIPTION
Unit 4 of the approved spec `specs/prompt-feature-verification.md` (rule 4, merged as PR #89).

## What this closes

Rules 1-3 count `FILL_ME` placeholders, so there were two ways to reach a green suite while reporting
nothing: delete a whole section, or clear a placeholder and write nothing under it. The second was the
easier one, because the file's own printed guidance keeps the section looking full.

**Rule 4:** with a `## Verification` section and `status: shipped`, every required heading must be
present in the evidence file, and each must carry at least one line the reporter wrote themselves. The
test asks the template what "themselves" means — any line `/spec`'s skeleton printed is not a report.

`approved` is untouched. A hollow skeleton there is the pre-registration the whole convention rests on.

## Verified by hand, not by report

Four mutations run independently of the agent that built it, each reverted:

| Mutation | Result |
|---|---|
| Invert `_own_words` | 5 red — both tolerance cases and all three hollow cases |
| Rename the skeleton's title line | 3 red, clean asserts, not a collection error |
| Reword one printed guidance line | 1 red — the regenerable-from-skeleton guard |
| Neuter the missing-heading branch | 1 red — the deleted-heading case |

Against the one real evidence file: 0 violations as it stands at `approved`. Flipped to `shipped`
in memory it draws 4 — rule 3 on the placeholders, rule 4 on What happened / What this doesn't prove /
Verdict — and does **not** flag the pass criterion, whose copied lines are a blockquote. That
blockquote is why the design rejected excluding blockquotes: it would have failed the only correct
file in the repo.

Suite 844 → **851**. Ruff clean. The doc diff is 2 lines in each of two files, all preamble: the
sentence saying deletion is "on your honour" became false. `_printed_lines` proves no skeleton section
body changed.

## The editor's one cut

`_printed_lines` now takes the block `_skeleton_block` already found, so fence scoping lives in one
place instead of two.

## Reviewer concern (not a blocker)

The skeleton preamble is now duplicated by hand in two files with nothing keeping them in sync — the
same drift the heading-agreement test prevents for the heading list, left unguarded for the prose that
explains the rule. Recorded in `.studio/output/impl_loop/shape_rule/reviewer-concerns.md`; worth a
small follow-up, deliberately not smuggled into this unit.

Draft until unit 5 (`shape_rule_record`) lands the CHANGELOG, README counts and usage-doc updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
