### PR TITLE
docs: merge the three write-for-humans principles into one, and fold in the response rules

### DIFF
--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -203,7 +203,7 @@ truly has no structure worth drawing, it probably didn't need a spec.
 
 Present the spec to the user for approval. Summarize in plain words what the architecture landed on,
 the decisions that shaped it, and anything still open — enough that they can approve without opening
-the file (Coding Principles §8). Then:
+the file (the Coding Principles section "Write for Humans"). Then:
 
 - **On approval:** set `status: approved` in the frontmatter, save the file, and confirm the path.
   If a `--ticket` was given, remind the user to link/attach the spec on that ticket so the tracker
@@ -303,4 +303,4 @@ python ".studio/source/run_phase.py" rate --run-dir {run_dir} --score {1-5} --no
   `/forge --spec` judges the built unit against them one by one. Vague criteria there become a vague
   verdict downstream.
 - **A spec precedes the build.** Once approved, this is what `/forge` and the feature
-  work build against. (See Coding Principle 9, "Spec Before Build.")
+  work build against. (See the Coding Principles section "Spec Before Build.")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,15 +75,16 @@ A new PR starts as a **draft**, not ready-for-review. Mark it ready only when th
 **Your docs, your code, and your updates are all read by a person. Write for that person.**
 
 **Docs, comments, docstrings, commit messages, PR descriptions.**
-- Use plain language, and cut the tells of machine-written prose: inflated phrasing, filler, hedging, and padding add length without adding meaning. If a term of art is unavoidable, define it the first time or pick a simpler word.
+- Use plain language. If a term of art is unavoidable, define it the first time or pick a simpler word.
+- Cut the tells of machine-written prose: inflated phrasing, filler, hedging, and padding add length without adding meaning.
 - Say what a thing does and why it matters, not just its name. "Refuses to overwrite your local edits" beats "enforces the clobber-guard precondition."
-- Match the voice already in the file instead of importing your own, and match the length of a file to what it actually has to say — no filler sections, no restating one point three ways. CLAUDE.md and architecture docs drift toward bloat because appending is easier than editing, so prefer editing a line over appending a section.
+- Match the voice already in the file instead of importing your own.
+- Match the length of a file to what it actually has to say — no filler sections, no restating one point three ways. CLAUDE.md and architecture docs drift toward bloat because appending is easier than editing, so prefer editing a line over appending a section.
 - The test: could a teammate who is new to the code read it once and understand it, without asking you to translate?
 
 **Code.** Its first reader is a person, not the compiler, so write code for humans. Simple and readable are not the same thing: simple code has few moving parts, readable code spells those parts out. Aim for both, and never trade readability away to save lines.
 - Name things in full, for what they are. `remaining_budget` over `rb`, `resolve_source_dir` over `rsd`. A good name is a comment you don't have to write.
 - Reach for the plain, conventional form a reader expects: explicit and a little verbose over compact and clever, one obvious thing per line rather than a dense expression to decode. Cleverness is a cost paid again by everyone who reads the code later.
-- Don't compress just to shorten. Saving three lines isn't worth making the next person stop and work out what they do.
 - The test: could a teammate seeing this file for the first time read it top to bottom and follow it, without you narrating over their shoulder?
 
 **Updates to a person: progress, questions, decisions.** They haven't opened the files you changed or the notes you kept, so nothing you name explains itself.
@@ -92,7 +93,8 @@ A new PR starts as a **draft**, not ready-for-review. Mark it ready only when th
 - When you flag a decision or a question, give enough context and a recommendation that they can answer without digging. Say what's at stake and which way you'd lean.
 - Don't narrate self-corrections. Fix the error, note it in one line only if it changes a decision the reader has to make, then move on.
 - End a long update with a `## TL;DR`: one to three sentences or bullets covering what changed, anything that needs their attention, and what's next. Skip it when the update is already short enough to read at a glance.
-- Plain and a little warm beats a dense status log. A person is reading this, not a build server. The test: could the reader act on your update — approve the call, answer the question, trust the "it's done" — without opening a single file or asking you to translate?
+- Plain and a little warm beats a dense status log. A person is reading this, not a build server.
+- The test: could the reader act on your update — approve the call, answer the question, trust the "it's done" — without opening a single file or asking you to translate?
 
 ### 7. Spec Before Build
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ When editing existing code:
 - Don't "improve" adjacent code, comments, or formatting.
 - Don't refactor things that aren't broken.
 - Match existing style, even if you'd do it differently.
-- If you notice unrelated dead code, mention it. Don't delete it.
+- If you notice unrelated dead code, mention it, don't delete it.
 
 When your changes create orphans:
 - Remove imports/variables/functions that YOUR changes made unused.
@@ -70,46 +70,31 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 
 A new PR starts as a **draft**, not ready-for-review. Mark it ready only when the work is complete, tests pass, and you actually want a human to review and merge it. Opening as a draft prevents two failure modes: accidental early merges (a not-yet-finished PR getting merged by mistake) and reviewer churn (reviewers spending attention on a still-moving target). Flip to ready when it's genuinely ready for eyes.
 
-### 6. Write Docs & Comments for Humans
+### 6. Write for Humans
 
-**A person reads your docs and comments. Write for that person.**
+**Your docs, your code, and your updates are all read by a person. Write for that person.**
 
-This covers everything you write for humans rather than the compiler: doc files, code comments, docstrings, commit messages, and PR descriptions.
-
-- Use plain language. If a term of art is unavoidable, define it the first time or pick a simpler word.
+**Docs, comments, docstrings, commit messages, PR descriptions.**
+- Use plain language, and cut the tells of machine-written prose: inflated phrasing, filler, hedging, and padding add length without adding meaning. If a term of art is unavoidable, define it the first time or pick a simpler word.
 - Say what a thing does and why it matters, not just its name. "Refuses to overwrite your local edits" beats "enforces the clobber-guard precondition."
-- Cut the tells of machine-written prose: inflated phrasing, filler, hedging, and padding add length without adding meaning.
-- Match the voice already in the file instead of importing your own.
+- Match the voice already in the file instead of importing your own, and match the length of a file to what it actually has to say — no filler sections, no restating one point three ways. CLAUDE.md and architecture docs drift toward bloat because appending is easier than editing, so prefer editing a line over appending a section.
+- The test: could a teammate who is new to the code read it once and understand it, without asking you to translate?
 
-The test: could a teammate who is new to the code read it once and understand it, without asking you to translate?
-
-### 7. Write Code for Humans
-
-**The code's first reader is a person, not the compiler. Write for that person.**
-
-The previous principle covers what you write *around* the code: docs, comments, commits. This one is about the code itself. Simple code and readable code are not the same thing: simple code has few moving parts; readable code spells those parts out. Aim for both, and never trade readability away to save lines.
-
+**Code.** Its first reader is a person, not the compiler, so write code for humans. Simple and readable are not the same thing: simple code has few moving parts, readable code spells those parts out. Aim for both, and never trade readability away to save lines.
 - Name things in full, for what they are. `remaining_budget` over `rb`, `resolve_source_dir` over `rsd`. A good name is a comment you don't have to write.
-- Prefer explicit and a little verbose over compact and clever. One obvious thing per line beats a dense expression a reader has to decode.
-- Reach for the plain, conventional form a reader expects. Cleverness is a cost paid again by everyone who reads the code later.
+- Reach for the plain, conventional form a reader expects: explicit and a little verbose over compact and clever, one obvious thing per line rather than a dense expression to decode. Cleverness is a cost paid again by everyone who reads the code later.
 - Don't compress just to shorten. Saving three lines isn't worth making the next person stop and work out what they do.
+- The test: could a teammate seeing this file for the first time read it top to bottom and follow it, without you narrating over their shoulder?
 
-The test: could a teammate seeing this file for the first time read it top to bottom and follow it, without you narrating over their shoulder?
-
-### 8. Talk to Humans
-
-**When you report back or ask for a decision, the reader hasn't seen what you just did. Write for that reader.**
-
-Principles 6 and 7 cover what you write into the codebase. This one is about the live conversation: progress updates, flagging a question, surfacing a decision. The person reading has not opened the files you changed, the docs you wrote, or the notes you kept, so nothing you name explains itself.
-
-- Lead with what changed for them and why it matters, not the mechanism you used to get there.
-- Don't drop internal handles — file names, section numbers, config keys, ticket or PR IDs, function names — as if they carry meaning on their own. Leave them out, or say in plain words what the thing is and why the reader should care. Keep the identifier only when it's something they'll act on: a link to click, a command to run, a PR to review.
+**Updates to a person: progress, questions, decisions.** They haven't opened the files you changed or the notes you kept, so nothing you name explains itself.
+- Lead with what changed for them and why it matters, not the mechanism you used to get there. Keep it short and information-dense: skip preamble, restated context, and a play-by-play of work the diff already shows.
+- Don't drop internal handles — file names, section numbers, config keys, ticket or PR IDs, function names — as if they carry meaning on their own. Say in plain words what the thing is, and keep the identifier only when it's something they'll act on: a link to click, a command to run, a PR to review.
 - When you flag a decision or a question, give enough context and a recommendation that they can answer without digging. Say what's at stake and which way you'd lean.
-- Plain and a little warm beats a dense status log. A person is reading this, not a build server.
+- Don't narrate self-corrections. Fix the error, note it in one line only if it changes a decision the reader has to make, then move on.
+- End a long update with a `## TL;DR`: one to three sentences or bullets covering what changed, anything that needs their attention, and what's next. Skip it when the update is already short enough to read at a glance.
+- Plain and a little warm beats a dense status log. A person is reading this, not a build server. The test: could the reader act on your update — approve the call, answer the question, trust the "it's done" — without opening a single file or asking you to translate?
 
-The test: could the reader act on your update — approve the call, answer the question, trust the "it's done" — without opening a single file or asking you to translate?
-
-### 9. Spec Before Build
+### 7. Spec Before Build
 
 **A non-trivial feature gets an approved architecture spec before you build it.**
 

--- a/specs/writer-escalation-channel.md
+++ b/specs/writer-escalation-channel.md
@@ -146,7 +146,7 @@ if (writer.stuck) {
 ```
 
 A standalone `if`, not an interpolation into the existing gate-fail log. The interpolation would need
-a ternary nested in a template literal (against Coding Principles §7) and would miss the advisory
+a ternary nested in a template literal (against the "Write for Humans" coding principle) and would miss the advisory
 case on a green unit. This version touches no existing line.
 
 ### The entry gate, extracted

--- a/studio/docs/CODING_PRINCIPLES.md
+++ b/studio/docs/CODING_PRINCIPLES.md
@@ -66,46 +66,31 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 
 A new PR starts as a **draft**, not ready-for-review. Mark it ready only when the work is complete, tests pass, and you actually want a human to review and merge it. Opening as a draft prevents two failure modes: accidental early merges (a not-yet-finished PR getting merged by mistake) and reviewer churn (reviewers spending attention on a still-moving target). Flip to ready when it's genuinely ready for eyes.
 
-## 6. Write Docs & Comments for Humans
+## 6. Write for Humans
 
-**A person reads your docs and comments. Write for that person.**
+**Your docs, your code, and your updates are all read by a person. Write for that person.**
 
-This covers everything you write for humans rather than the compiler: doc files, code comments, docstrings, commit messages, and PR descriptions.
-
-- Use plain language. If a term of art is unavoidable, define it the first time or pick a simpler word.
+**Docs, comments, docstrings, commit messages, PR descriptions.**
+- Use plain language, and cut the tells of machine-written prose: inflated phrasing, filler, hedging, and padding add length without adding meaning. If a term of art is unavoidable, define it the first time or pick a simpler word.
 - Say what a thing does and why it matters, not just its name. "Refuses to overwrite your local edits" beats "enforces the clobber-guard precondition."
-- Cut the tells of machine-written prose: inflated phrasing, filler, hedging, and padding add length without adding meaning.
-- Match the voice already in the file instead of importing your own.
+- Match the voice already in the file instead of importing your own, and match the length of a file to what it actually has to say — no filler sections, no restating one point three ways. CLAUDE.md and architecture docs drift toward bloat because appending is easier than editing, so prefer editing a line over appending a section.
+- The test: could a teammate who is new to the code read it once and understand it, without asking you to translate?
 
-The test: could a teammate who is new to the code read it once and understand it, without asking you to translate?
-
-## 7. Write Code for Humans
-
-**The code's first reader is a person, not the compiler. Write for that person.**
-
-The previous principle covers what you write *around* the code: docs, comments, commits. This one is about the code itself. Simple code and readable code are not the same thing: simple code has few moving parts; readable code spells those parts out. Aim for both, and never trade readability away to save lines.
-
+**Code.** Its first reader is a person, not the compiler, so write code for humans. Simple and readable are not the same thing: simple code has few moving parts, readable code spells those parts out. Aim for both, and never trade readability away to save lines.
 - Name things in full, for what they are. `remaining_budget` over `rb`, `resolve_source_dir` over `rsd`. A good name is a comment you don't have to write.
-- Prefer explicit and a little verbose over compact and clever. One obvious thing per line beats a dense expression a reader has to decode.
-- Reach for the plain, conventional form a reader expects. Cleverness is a cost paid again by everyone who reads the code later.
+- Reach for the plain, conventional form a reader expects: explicit and a little verbose over compact and clever, one obvious thing per line rather than a dense expression to decode. Cleverness is a cost paid again by everyone who reads the code later.
 - Don't compress just to shorten. Saving three lines isn't worth making the next person stop and work out what they do.
+- The test: could a teammate seeing this file for the first time read it top to bottom and follow it, without you narrating over their shoulder?
 
-The test: could a teammate seeing this file for the first time read it top to bottom and follow it, without you narrating over their shoulder?
-
-## 8. Talk to Humans
-
-**When you report back or ask for a decision, the reader hasn't seen what you just did. Write for that reader.**
-
-Principles 6 and 7 cover what you write into the codebase. This one is about the live conversation: progress updates, flagging a question, surfacing a decision. The person reading has not opened the files you changed, the docs you wrote, or the notes you kept, so nothing you name explains itself.
-
-- Lead with what changed for them and why it matters, not the mechanism you used to get there.
-- Don't drop internal handles — file names, section numbers, config keys, ticket or PR IDs, function names — as if they carry meaning on their own. Leave them out, or say in plain words what the thing is and why the reader should care. Keep the identifier only when it's something they'll act on: a link to click, a command to run, a PR to review.
+**Updates to a person: progress, questions, decisions.** They haven't opened the files you changed or the notes you kept, so nothing you name explains itself.
+- Lead with what changed for them and why it matters, not the mechanism you used to get there. Keep it short and information-dense: skip preamble, restated context, and a play-by-play of work the diff already shows.
+- Don't drop internal handles — file names, section numbers, config keys, ticket or PR IDs, function names — as if they carry meaning on their own. Say in plain words what the thing is, and keep the identifier only when it's something they'll act on: a link to click, a command to run, a PR to review.
 - When you flag a decision or a question, give enough context and a recommendation that they can answer without digging. Say what's at stake and which way you'd lean.
-- Plain and a little warm beats a dense status log. A person is reading this, not a build server.
+- Don't narrate self-corrections. Fix the error, note it in one line only if it changes a decision the reader has to make, then move on.
+- End a long update with a `## TL;DR`: one to three sentences or bullets covering what changed, anything that needs their attention, and what's next. Skip it when the update is already short enough to read at a glance.
+- Plain and a little warm beats a dense status log. A person is reading this, not a build server. The test: could the reader act on your update — approve the call, answer the question, trust the "it's done" — without opening a single file or asking you to translate?
 
-The test: could the reader act on your update — approve the call, answer the question, trust the "it's done" — without opening a single file or asking you to translate?
-
-## 9. Spec Before Build
+## 7. Spec Before Build
 
 **A non-trivial feature gets an approved architecture spec before you build it.**
 

--- a/studio/docs/CODING_PRINCIPLES.md
+++ b/studio/docs/CODING_PRINCIPLES.md
@@ -71,15 +71,16 @@ A new PR starts as a **draft**, not ready-for-review. Mark it ready only when th
 **Your docs, your code, and your updates are all read by a person. Write for that person.**
 
 **Docs, comments, docstrings, commit messages, PR descriptions.**
-- Use plain language, and cut the tells of machine-written prose: inflated phrasing, filler, hedging, and padding add length without adding meaning. If a term of art is unavoidable, define it the first time or pick a simpler word.
+- Use plain language. If a term of art is unavoidable, define it the first time or pick a simpler word.
+- Cut the tells of machine-written prose: inflated phrasing, filler, hedging, and padding add length without adding meaning.
 - Say what a thing does and why it matters, not just its name. "Refuses to overwrite your local edits" beats "enforces the clobber-guard precondition."
-- Match the voice already in the file instead of importing your own, and match the length of a file to what it actually has to say — no filler sections, no restating one point three ways. CLAUDE.md and architecture docs drift toward bloat because appending is easier than editing, so prefer editing a line over appending a section.
+- Match the voice already in the file instead of importing your own.
+- Match the length of a file to what it actually has to say — no filler sections, no restating one point three ways. CLAUDE.md and architecture docs drift toward bloat because appending is easier than editing, so prefer editing a line over appending a section.
 - The test: could a teammate who is new to the code read it once and understand it, without asking you to translate?
 
 **Code.** Its first reader is a person, not the compiler, so write code for humans. Simple and readable are not the same thing: simple code has few moving parts, readable code spells those parts out. Aim for both, and never trade readability away to save lines.
 - Name things in full, for what they are. `remaining_budget` over `rb`, `resolve_source_dir` over `rsd`. A good name is a comment you don't have to write.
 - Reach for the plain, conventional form a reader expects: explicit and a little verbose over compact and clever, one obvious thing per line rather than a dense expression to decode. Cleverness is a cost paid again by everyone who reads the code later.
-- Don't compress just to shorten. Saving three lines isn't worth making the next person stop and work out what they do.
 - The test: could a teammate seeing this file for the first time read it top to bottom and follow it, without you narrating over their shoulder?
 
 **Updates to a person: progress, questions, decisions.** They haven't opened the files you changed or the notes you kept, so nothing you name explains itself.
@@ -88,7 +89,8 @@ A new PR starts as a **draft**, not ready-for-review. Mark it ready only when th
 - When you flag a decision or a question, give enough context and a recommendation that they can answer without digging. Say what's at stake and which way you'd lean.
 - Don't narrate self-corrections. Fix the error, note it in one line only if it changes a decision the reader has to make, then move on.
 - End a long update with a `## TL;DR`: one to three sentences or bullets covering what changed, anything that needs their attention, and what's next. Skip it when the update is already short enough to read at a glance.
-- Plain and a little warm beats a dense status log. A person is reading this, not a build server. The test: could the reader act on your update — approve the call, answer the question, trust the "it's done" — without opening a single file or asking you to translate?
+- Plain and a little warm beats a dense status log. A person is reading this, not a build server.
+- The test: could the reader act on your update — approve the call, answer the question, trust the "it's done" — without opening a single file or asking you to translate?
 
 ## 7. Spec Before Build
 

--- a/studio/docs/SUPERPOWERS_COMPARISON.md
+++ b/studio/docs/SUPERPOWERS_COMPARISON.md
@@ -121,7 +121,8 @@ exemption clauses don't scope. Plus two rules from their micro-test protocol at 
 lines 575-585: always include a no-guidance control, and treat variance across reps as a metric.
 
 **How it lands.** About 25 lines as §10 "Writing for Agents" in
-`studio/docs/CODING_PRINCIPLES.md` — sibling to §6 (docs), §7 (code) and §8 (conversation), which
+`studio/docs/CODING_PRINCIPLES.md` — sibling to §6 "Write for Humans", which now covers docs,
+code and conversation in one section, and which
 already partition writing by reader and leave agents as the obvious gap. That file already ships
 cross-repo (`install.py`) and is injected into a consuming repo's CLAUDE.md between sentinels, so it
 needs no new plumbing, no INDEX/README churn, and no `/spec` wiring. The section must say plainly
@@ -434,7 +435,7 @@ this plan is measurable, which is exactly the failure the gstack scorecard is st
 riders the rejections surfaced: hoist the R3 scar to one owner constant, fix the hand-mutation
 instruction to break production code rather than assertions, add "test output pristine — warnings are
 a finding" to the editor's checks, and add the six-line ship-list parity test for
-`SLASH_COMMANDS`/`WORKFLOW_FILES` (**done**). **Usable output:** §10 of CODING_PRINCIPLES — which does not exist yet; the file still ends at §9 — ships to every
+`SLASH_COMMANDS`/`WORKFLOW_FILES` (**done**). **Usable output:** a prompt-doctrine section of CODING_PRINCIPLES — which does not exist yet; the file ends at §7 — ships to every
 installed repo; the contrarian's escape hatch now costs evidence; two shipped bugs-in-waiting closed.
 One commit each, one PR. Measured against Phase 0's `editor_liveness`.
 
@@ -481,7 +482,7 @@ every row below that names a baseline is unmeasured.
 
 | Item | Signal (instrument) | Helping looks like | Hurting looks like | Trigger to act |
 |---|---|---|---|---|
-| §10 prompt doctrine *(not yet written — Phase 1; CODING_PRINCIPLES ends at §9, so this row cannot fire yet)* | Whether it gets cited when prompt text changes; no new nuance clauses land in `scopes.py` / `question_mode.py` | New prompt edits pick a form deliberately and say which | It is never referenced in any prompt-change PR | Two prompt-change PRs in a row that cite no form → the section is decoration; cut it |
+| Prompt doctrine *(not yet written — Phase 1; CODING_PRINCIPLES ends at §7, so this row cannot fire yet)* | Whether it gets cited when prompt text changes; no new nuance clauses land in `scopes.py` / `question_mode.py` | New prompt edits pick a form deliberately and say which | It is never referenced in any prompt-change PR | Two prompt-change PRs in a row that cite no form → the section is decoration; cut it |
 | Escape hatches earn their invocation | `editor_liveness` / `shrink_ratio` (`stats.py:151-158`, `session.py:108-130`), against the Phase 0 baseline | More forge units end with a real cut; "no edits" handoffs stop citing the mandate's own clauses | Liveness flat, or the editor starts compressing readable code (the regression the clauses exist to stop) | Liveness does not move after ~10 forge units → revert the text. Any review flagging over-compression → revert immediately |
 | Writer escalation channel | Count of handoffs carrying a non-empty `escalation`; count of green-but-wrong units caught later | A genuinely stuck writer stops instead of guessing, and says what it needs | Field never used across ~10 units (the hole was theoretical), or used to dodge tractable work | Never populated across ~10 units → the schema hole was real but the failure was not; keep the field, drop the prompt prose |
 | Rationale is a claim | Whether a contrarian finding survives an advocate's justification; whether the editor logs a concern it previously dropped | Findings get engaged with rather than withdrawn after a good explanation | Iteration burn: runs take more passes to reach APPROVED because rebuttals no longer resolve anything | Median iterations-to-verdict rises across ~10 runs → the wording is fighting the rejection-feedback loop; revert |

--- a/studio/tests/test_doc_parity.py
+++ b/studio/tests/test_doc_parity.py
@@ -112,3 +112,52 @@ class TestLoopConfigParity:
             "LoopConfig fields not defined in the TOML config block of "
             f"IMPLEMENTATION_LOOP_SPEC.md: {sorted(missing)}"
         )
+
+
+def _principle_lines(text: str) -> list[str]:
+    """The numbered coding principles in a doc, as `N. Title` plus their content.
+
+    Works on both copies: CODING_PRINCIPLES.md heads each principle with `## N.`,
+    this repo's own CLAUDE.md with `### N.`. Blank lines are dropped so the
+    comparison is about wording, not spacing.
+    """
+    lines: list[str] = []
+    inside_a_principle = False
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        heading = re.match(r"^#{2,3} (\d+\. .+)$", line)
+        if heading:
+            inside_a_principle = True
+            lines.append(heading.group(1))
+            continue
+        if line.startswith("#") or line.startswith("---"):
+            inside_a_principle = False  # left the principles for another section
+        elif inside_a_principle and line:
+            lines.append(line)
+    return lines
+
+
+class TestCodingPrinciplesMirror:
+    """The principles live in two hand-maintained copies and must not drift.
+
+    `studio/docs/CODING_PRINCIPLES.md` ships to every installed repo; this repo's
+    own `CLAUDE.md` carries the same text inline. Edit one and forget the other,
+    and Studio starts telling other repos something it doesn't tell itself.
+    """
+
+    def test_claude_md_matches_the_shipped_principles(self):
+        shipped = _principle_lines(
+            (_DOCS / "CODING_PRINCIPLES.md").read_text(encoding="utf-8")
+        )
+        own = _principle_lines(
+            (_DOCS.parent.parent / "CLAUDE.md").read_text(encoding="utf-8")
+        )
+        assert shipped, "no numbered principles found in CODING_PRINCIPLES.md"
+
+        only_in_claude_md = [line for line in own if line not in shipped]
+        only_in_shipped = [line for line in shipped if line not in own]
+        assert own == shipped, (
+            "CLAUDE.md and docs/CODING_PRINCIPLES.md disagree.\n"
+            f"Only in CLAUDE.md: {only_in_claude_md}\n"
+            f"Only in CODING_PRINCIPLES.md: {only_in_shipped}"
+        )

--- a/studio/tests/test_install.py
+++ b/studio/tests/test_install.py
@@ -516,7 +516,7 @@ class TestClaudeMdSync:
         content = claude_md.read_text(encoding="utf-8")
         start = content.index(_SENTINEL_BEGIN)
         end = content.index(_SENTINEL_END) + len(_SENTINEL_END)
-        drifted = content[start:end].replace("Talk to Humans", "OLD PRINCIPLE")
+        drifted = content[start:end].replace("Write for Humans", "OLD PRINCIPLE")
         claude_md.write_text(content[:start] + drifted + content[end:], encoding="utf-8")
 
     def test_fresh_install_block_not_stale(self, target_dir, studio_dir):
@@ -567,7 +567,7 @@ class TestClaudeMdSync:
         assert result.get("claude_md_refreshed") is True
 
         refreshed = claude_md.read_text(encoding="utf-8")
-        assert "Talk to Humans" in refreshed        # template restored
+        assert "Write for Humans" in refreshed      # template restored
         assert "OLD PRINCIPLE" not in refreshed      # drift gone
         assert "My project notes." in refreshed      # notes above kept
         assert "Keep me." in refreshed               # notes below kept


### PR DESCRIPTION
`CODING_PRINCIPLES.md` is injected verbatim into every consuming repo's CLAUDE.md. It was **131 lines there — 100% of the CLAUDE.md in `miresu` and `Multica`**, which have no project context of their own. Sections 6, 7 and 8 were 36 lines all saying "write for humans" about three different surfaces, with three near-identical framing paragraphs.

**129 → 116 lines, 9 → 7 sections, and it carries four rules it didn't have before.**

## The rule inventory

The real risk in a merge like this is silently losing a directive. The suite can't catch that — only `test_install.py` touches this file and it tests the *injection mechanism*, not the content. So here is every directive that existed, mapped to where it landed. **21 of 22 survive verbatim or reworded; one was cut, deliberately, and it's called out below.**

### From §6 — docs, comments, docstrings, commits, PRs

| Directive | Where it landed |
|---|---|
| Plain language; define a term of art or pick a simpler word | Docs bullet 1, unchanged |
| Say what it does and why, not just its name | Docs bullet 3, with the `"Refuses to overwrite your local edits"` contrast intact |
| Cut the tells of machine-written prose | Docs bullet 2, unchanged |
| Match the voice already in the file | Docs bullet 4, unchanged |
| The test: could a new teammate read it once? | Docs closing line, unchanged |

### From §7 — the code itself

| Directive | Where it landed |
|---|---|
| Simple ≠ readable; never trade readability to save lines | **Code subsection lead**, kept whole — it's the reason the code half exists |
| Name things in full (`remaining_budget` over `rb`) | Code bullet 1, unchanged |
| Explicit and verbose over compact and clever; one thing per line | Merged into Code bullet 2 |
| Plain conventional form; cleverness is a cost paid again | Merged into Code bullet 2 |
| **Don't compress just to shorten** | **CUT — see below** |
| The test: could a teammate read it top to bottom? | Code closing line, unchanged |

### From §8 — the live conversation

| Directive | Where it landed |
|---|---|
| The reader hasn't opened your files | Updates subsection lead |
| Lead with what changed and why it matters | Updates bullet 1 |
| Don't drop internal handles; keep an identifier only if actionable | Updates bullet 2, with the link/command/PR carve-out intact |
| Give context *and* a recommendation when flagging a decision | Updates bullet 3, unchanged |
| Plain and a little warm beats a dense status log | Updates bullet 6, unchanged |
| The test: could the reader act without opening a file? | Updates closing line, unchanged |

### The four new rules

| New rule | Where |
|---|---|
| Short and information-dense; skip preamble and play-by-play | Folded into Updates bullet 1 |
| End a long update with `## TL;DR` | Updates bullet 5 |
| Don't narrate self-corrections | Updates bullet 4 |
| Match a file's length to its content; edit a line over appending a section | Docs bullet 5 |

## The one cut, and why I'm flagging rather than burying it

The editor removed *"Don't compress just to shorten. Saving three lines isn't worth making the next person stop and work out what they do."*

Its reasoning: the Code lead three lines above already says **"never trade readability away to save lines"** — so the *instruction* survives and the bullet only restated it. I checked, and that's accurate rather than a "felt similar" cut. What's lost is the concrete "three lines" framing that made it vivid.

**Say the word and I'll restore it** — it's one line and the section has room.

## What the editor did

It pushed back on the writer for the right reason. The writer hit the line target partly by compressing readable prose into denser lines — the exact failure this principle warns against. The editor cut the genuine duplicate above, then **un-jammed three compound bullets** back to one idea per line, including giving the new anti-bloat rule its own visible home instead of leaving it buried mid-bullet.

Result: 26 lines against the 39 it replaces, roughly flat word count while absorbing four new rules.

## Also in here

- **A new mirror test** (`TestCodingPrinciplesMirror`) — the principles live in two hand-maintained copies (`CODING_PRINCIPLES.md` and this repo's own `CLAUDE.md`) with nothing syncing them. It caught a real pre-existing drift on its first run.
- **Four dead references fixed.** The renumbering broke citations by number, including two live instructions in the `/spec` prompt pointing at "Coding Principles §8" and "Coding Principle 9" in a file that now ends at §7. Fixed by citing **by title**, so the next renumbering can't break them again. Three false statements in the superpowers study corrected too, including two using "the file still ends at §9" as a live trigger condition.

## Verification

**862 passed** (861 + the new mirror test), `ruff check .` clean. Every directive above was verified against the shipped file by hand, not taken from the writer's self-report.

No spec for this one, deliberately: there's no architecture to discover, it's one `git revert` from undone, and the question a spec would want to answer — *does this make agents behave better?* — is unmeasurable until the superpowers Phase 0 baseline exists, which it still doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)