### PR TITLE
fix(paths): Studio recognizes its own source repo

### DIFF
--- a/studio/run_phase.py
+++ b/studio/run_phase.py
@@ -310,21 +310,20 @@ def get_artifact_root() -> Path:
 
     studio_root = get_studio_root().resolve()
     cwd = Path.cwd().resolve()
+    installed_root = _installed_repo_root(studio_root)
 
     if cwd == studio_root or _is_within(cwd, studio_root):
         # Running from the source tree (or from inside an installed snapshot).
         # In the source repo the artifact root IS the studio dir; in an installed
         # snapshot it's the consuming repo root, never the snapshot itself.
-        installed_root = _installed_repo_root(studio_root)
         return installed_root if installed_root is not None else studio_root
 
-    # Running from Studio's own repo root (or a subdir of it that isn't studio/ itself).
-    # The source repo is the one whose studio/ dir is the module we were loaded from, so
-    # a non-snapshot studio_root plus a cwd under its parent identifies it exactly. This
-    # has to come before the consumer heuristics below: the source repo keeps its own
-    # bare .studio/ for update.toml and usage.log, which would otherwise read as a
-    # scaffolded consuming repo.
-    if _installed_repo_root(studio_root) is None and _is_within(cwd, studio_root.parent):
+    # Running from Studio's own repo root, or a subdir of it other than studio/ itself.
+    # A studio_root that is not a snapshot, with cwd under its parent, is the source repo
+    # and nothing else. This has to come before the consumer heuristics below: the source
+    # repo keeps its own bare .studio/ for update.toml and usage.log, which those
+    # heuristics would otherwise read as a scaffolded consuming repo.
+    if installed_root is None and _is_within(cwd, studio_root.parent):
         return studio_root
 
     # The next two branches are distinct on purpose: an init'd repo is marked by

--- a/studio/run_phase.py
+++ b/studio/run_phase.py
@@ -318,6 +318,15 @@ def get_artifact_root() -> Path:
         installed_root = _installed_repo_root(studio_root)
         return installed_root if installed_root is not None else studio_root
 
+    # Running from Studio's own repo root (or a subdir of it that isn't studio/ itself).
+    # The source repo is the one whose studio/ dir is the module we were loaded from, so
+    # a non-snapshot studio_root plus a cwd under its parent identifies it exactly. This
+    # has to come before the consumer heuristics below: the source repo keeps its own
+    # bare .studio/ for update.toml and usage.log, which would otherwise read as a
+    # scaffolded consuming repo.
+    if _installed_repo_root(studio_root) is None and _is_within(cwd, studio_root.parent):
+        return studio_root
+
     # The next two branches are distinct on purpose: an init'd repo is marked by
     # .studio/VERSION (walk UP for it, which handles monorepo subdirs), whereas a merely
     # scaffolded repo has a bare .studio/ and no VERSION (check cwd ONLY). Don't merge.

--- a/studio/tests/test_run_phase.py
+++ b/studio/tests/test_run_phase.py
@@ -238,14 +238,13 @@ def test_artifact_root_cli_override(tmp_path, monkeypatch):
 def _make_source_repo(tmp_path, monkeypatch):
     """Studio's own repo: <repo>/studio holding the running code, plus a bare .studio/.
 
-    Mirrors the real source repo, where .studio/ holds update.toml and usage.log but
-    deliberately has no VERSION file (VERSION marks an *installed* repo).
+    Mirrors the real source repo, whose .studio/ deliberately has no VERSION file —
+    VERSION is what marks an *installed* repo.
     """
     repo_root = tmp_path / "TheGameStudio"
     studio_root = repo_root / "studio"
     studio_root.mkdir(parents=True)
     (repo_root / ".studio").mkdir()
-    (repo_root / ".studio" / "update.toml").write_text("[update]\n", encoding="utf-8")
 
     monkeypatch.setenv("STUDIO_ROOT", str(studio_root))
     monkeypatch.delenv("STUDIO_ARTIFACT_ROOT", raising=False)

--- a/studio/tests/test_run_phase.py
+++ b/studio/tests/test_run_phase.py
@@ -1,6 +1,7 @@
 """Unit tests for run_phase.py core functions."""
 import argparse
 import json
+from pathlib import Path
 
 import pytest
 
@@ -197,8 +198,11 @@ def test_question_mode_omits_editor_mandate_and_preflight(studio_root):
 
 
 def test_output_root_defaults_to_origin_repo_when_running_outside_studio(tmp_path, monkeypatch):
-    studio_root = tmp_path / "studio"
-    studio_root.mkdir()
+    # studio_root sits one level down so the caller's repo is genuinely outside the
+    # Studio source repo (tmp_path / "studio_src"). A sibling of studio/ would count as
+    # part of the source repo and resolve there instead — see the source-repo branch.
+    studio_root = tmp_path / "studio_src" / "studio"
+    studio_root.mkdir(parents=True)
     project_root = tmp_path / "game_repo"
     project_root.mkdir()
 
@@ -231,12 +235,120 @@ def test_artifact_root_cli_override(tmp_path, monkeypatch):
     assert output_root == explicit_root / ".studio" / "output"
 
 
+def _make_source_repo(tmp_path, monkeypatch):
+    """Studio's own repo: <repo>/studio holding the running code, plus a bare .studio/.
+
+    Mirrors the real source repo, where .studio/ holds update.toml and usage.log but
+    deliberately has no VERSION file (VERSION marks an *installed* repo).
+    """
+    repo_root = tmp_path / "TheGameStudio"
+    studio_root = repo_root / "studio"
+    studio_root.mkdir(parents=True)
+    (repo_root / ".studio").mkdir()
+    (repo_root / ".studio" / "update.toml").write_text("[update]\n", encoding="utf-8")
+
+    monkeypatch.setenv("STUDIO_ROOT", str(studio_root))
+    monkeypatch.delenv("STUDIO_ARTIFACT_ROOT", raising=False)
+    monkeypatch.setattr(run_phase, "_artifact_root_override", None)
+    monkeypatch.setattr(run_phase, "_artifact_root_warned", False)
+    return repo_root, studio_root
+
+
+def test_artifact_root_is_studio_dir_when_run_from_source_repo_root(tmp_path, monkeypatch):
+    """Studio run from its own repo root files artifacts in studio/, not <repo>/.studio/."""
+    repo_root, studio_root = _make_source_repo(tmp_path, monkeypatch)
+    monkeypatch.chdir(repo_root)
+
+    # Guard against passing for the old reason: this must NOT be the cwd == studio_root
+    # branch, which already worked before the source-repo branch existed.
+    assert Path.cwd().resolve() != studio_root.resolve()
+
+    assert run_phase.get_artifact_root() == studio_root.resolve()
+    assert run_phase.get_output_root() == studio_root.resolve() / "output"
+
+
+def test_artifact_root_is_studio_dir_when_run_from_studio_dir(tmp_path, monkeypatch):
+    """The pre-existing cwd-inside-studio branch: same answer, different reason."""
+    _repo_root, studio_root = _make_source_repo(tmp_path, monkeypatch)
+    monkeypatch.chdir(studio_root)
+
+    assert Path.cwd().resolve() == studio_root.resolve()
+    assert run_phase.get_artifact_root() == studio_root.resolve()
+
+
+def test_artifact_root_is_consuming_repo_for_installed_snapshot(tmp_path, monkeypatch):
+    """An installed <repo>/.studio/source snapshot still resolves to the consuming repo."""
+    repo_root = tmp_path / "my_game"
+    studio_root = repo_root / ".studio" / "source"
+    studio_root.mkdir(parents=True)
+    (repo_root / ".studio" / "VERSION").write_text("1.0.0\n", encoding="utf-8")
+
+    monkeypatch.setenv("STUDIO_ROOT", str(studio_root))
+    monkeypatch.delenv("STUDIO_ARTIFACT_ROOT", raising=False)
+    monkeypatch.setattr(run_phase, "_artifact_root_override", None)
+    monkeypatch.setattr(run_phase, "_artifact_root_warned", False)
+
+    monkeypatch.chdir(repo_root)
+    assert run_phase.get_artifact_root() == repo_root.resolve()
+
+    # studio_root.parent is <repo>/.studio here, so the source-repo branch must stay out
+    # of the way: a snapshot is never its own source repo.
+    monkeypatch.chdir(repo_root / ".studio")
+    assert run_phase.get_artifact_root() == repo_root.resolve()
+
+
+def test_artifact_root_is_cwd_for_scaffolded_repo_with_bare_studio_dir(tmp_path, monkeypatch):
+    """A repo with .studio/ but no VERSION, unrelated to studio_root, still gets cwd."""
+    studio_root = tmp_path / "studio_src" / "studio"
+    studio_root.mkdir(parents=True)
+    game_repo = tmp_path / "my_game"
+    (game_repo / ".studio").mkdir(parents=True)
+
+    monkeypatch.setenv("STUDIO_ROOT", str(studio_root))
+    monkeypatch.delenv("STUDIO_ARTIFACT_ROOT", raising=False)
+    monkeypatch.setattr(run_phase, "_artifact_root_override", None)
+    monkeypatch.setattr(run_phase, "_artifact_root_warned", False)
+    monkeypatch.chdir(game_repo)
+
+    assert run_phase.get_artifact_root() == game_repo.resolve()
+
+
+def test_artifact_root_flag_and_env_still_win_in_source_repo(tmp_path, monkeypatch):
+    """The deliberate overrides outrank the source-repo branch."""
+    repo_root, _studio_root = _make_source_repo(tmp_path, monkeypatch)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(repo_root)
+
+    monkeypatch.setenv("STUDIO_ARTIFACT_ROOT", str(elsewhere))
+    assert run_phase.get_artifact_root() == elsewhere.resolve()
+
+    monkeypatch.setattr(run_phase, "_artifact_root_override", elsewhere)
+    assert run_phase.get_artifact_root() == elsewhere.resolve()
+
+
+def test_source_repo_prepare_writes_no_bridge_doc(tmp_path, monkeypatch):
+    """Studio does not scaffold itself a consuming-repo bridge doc."""
+    from conftest import _seed_studio_root
+
+    repo_root, studio_root = _make_source_repo(tmp_path, monkeypatch)
+    _seed_studio_root(studio_root)
+    (studio_root / "docs" / "STUDIO_BRIDGE_TEMPLATE.md").write_text("template", encoding="utf-8")
+    monkeypatch.chdir(repo_root)
+
+    run_id = run_phase.prepare_run(make_prepare_args(phase="tech", text="Source repo run"))
+
+    assert (studio_root / "output" / "tech" / run_id / "instructions.md").exists()
+    assert not (repo_root / "docs" / "studio-bridge.md").exists()
+    assert not (repo_root / ".studio" / "output").exists()
+
+
 def test_cross_repo_prepare_creates_artifacts_in_caller_repo(tmp_path, monkeypatch):
     """Full prepare from an external repo puts artifacts in that repo, not Studio."""
     from conftest import _seed_studio_root
 
-    studio_root = tmp_path / "studio"
-    studio_root.mkdir()
+    studio_root = tmp_path / "studio_src" / "studio"
+    studio_root.mkdir(parents=True)
     _seed_studio_root(studio_root)
 
     game_repo = tmp_path / "my_game"
@@ -269,8 +381,8 @@ def test_cross_repo_scaffold_creates_bridge_doc(tmp_path, monkeypatch):
     """First prepare from external repo creates .studio/ and bridge doc."""
     from conftest import _seed_studio_root
 
-    studio_root = tmp_path / "studio"
-    studio_root.mkdir()
+    studio_root = tmp_path / "studio_src" / "studio"
+    studio_root.mkdir(parents=True)
     _seed_studio_root(studio_root)
 
     # Also need the bridge template to exist
@@ -306,8 +418,8 @@ def test_cross_repo_scaffold_skips_existing_bridge(tmp_path, monkeypatch):
     """Scaffold does not overwrite an existing bridge doc."""
     from conftest import _seed_studio_root
 
-    studio_root = tmp_path / "studio"
-    studio_root.mkdir()
+    studio_root = tmp_path / "studio_src" / "studio"
+    studio_root.mkdir(parents=True)
     _seed_studio_root(studio_root)
     (studio_root / "docs").mkdir(exist_ok=True)
     (studio_root / "docs" / "STUDIO_BRIDGE_TEMPLATE.md").write_text("template", encoding="utf-8")


### PR DESCRIPTION
Unit 1 of the approved spec `specs/source-repo-detection.md`. Built through `/forge --spec`, so the editor graded all six acceptance criteria individually with evidence.

## The bug

Running `python studio/run_phase.py <cmd>` from the repo root — the invocation `CLAUDE.md` documents — made Studio classify **its own repo** as a consuming repo. The source repo has a bare `.studio/` (holding `update.toml`, `usage.log`) with no `VERSION`, which is exactly Studio's signature for an already-scaffolded consumer.

Since 2026-07-08 that meant run artifacts landing in `.studio/output/` instead of `studio/output/`, and a stray `docs/studio-bridge.md` scaffolded into the source tree — a welcome note addressed to itself.

## The fix

One new branch in `get_artifact_root()`, above the `.studio/VERSION` walk-up:

```python
if installed_root is None and _is_within(cwd, studio_root.parent):
    return studio_root
```

It restores an invariant the rest of the module **already documents**: `get_output_root`, `get_knowledge_log_path`, `_project_name` and `get_outcomes_ledger_path` all branch on `artifact_root == studio_root` meaning "this is the source repo," and `impl_loop.py` already resolves it this way with no cwd test. `run_phase` was the outlier.

## Criteria — all 6 pass, with evidence the editor gathered itself

The one worth highlighting is **criterion 2**, which demanded the test be *watched* failing rather than assumed to fail. The editor re-ran the demonstration independently rather than trusting the writer: reverted `run_phase.py` to `96a46c5` keeping the new tests, got **2 failed, 8 passed**, and captured stdout showing `Created bridge doc: .../TheGameStudio/docs/studio-bridge.md` and the run landing in `.studio/output`.

**Criterion 3** — the wrong-reason trap — is pinned two ways: the new test asserts `Path.cwd() != studio_root` before calling, so it cannot enter the pre-existing `cwd == studio_root` branch; and during the hand-revert the control test stayed green while the new one went red, demonstrating the branches are separate.

**Criterion 5** was verified for real, not just in a fixture: `prepare --phase tech` run from the actual repo root, then `ls -d docs` → "No such file or directory."

## Editor's cuts

Hoisted a duplicated `_installed_repo_root()` call to a single `installed_root` binding so the snapshot question is asked once, and tightened a six-line comment to five without dropping a fact.

## Two concerns, both verified, neither fixed here

**1. A nested consuming repo would now lose (needs your call).** `installed_root is None and _is_within(cwd, studio_root.parent)` claims *every* directory under the repo root. A repo like `_TheGameStudio/sandbox/my_game` with its own `.studio/VERSION`, driven by the source `run_phase.py`, would file artifacts into `studio/output/` instead of its own root — the walk-up used to find it.

The spec's Key Decision 2 **knowingly accepted this**, having verified no `.studio/VERSION` exists anywhere in the tree. But the evidence is stronger than "theoretical": **four existing tests had to re-nest their fixtures under `studio_src/`** because the flat layout put the pretend consumer inside the pretend source repo, where the new branch legitimately claims it.

Suggested fix is one added condition — also gate on `_find_installed_root_upwards(cwd) is None` — which keeps the branch above the walk-up while letting an explicitly-init'd nested repo win. That contradicts nothing in the spec's intent but does amend its Decision 2, so I left it for a decision rather than deciding it.

**2. A pre-existing dead clause.** `if cwd == studio_root or _is_within(cwd, studio_root)` — `_is_within` is `relative_to` in a try/except, and `p.relative_to(p)` succeeds. Verified: `_is_within(p, p)` is `True`, so the equality check can never be why the branch is taken. Predates this unit; worth a separate one-line cleanup.

## Verification

**868 passed** (862 → 868), `ruff check .` clean. Out of scope by design: the migration of stranded run directories, the Slack side effect, and the docs — those are units 2, 3 and 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)