### PR TITLE
spec: approve forge-work-dir and open its evidence file

### DIFF
--- a/specs/forge-work-dir-eval-results.md
+++ b/specs/forge-work-dir-eval-results.md
@@ -1,0 +1,39 @@
+# /forge can build in a git worktree — Verification Results
+
+**Spec:** [`forge-work-dir.md`](./forge-work-dir.md). The pass criterion below was copied from that spec before
+anything was measured. Don't edit it to match what happened — if it turned out to be the wrong
+criterion, say so under "What this doesn't prove."
+
+Every placeholder below marks data that does not exist yet. Replacing one is the act of reporting.
+Dropping a whole section, or clearing a placeholder and writing nothing under its heading, fails the
+suite once this spec says `status: shipped` — every heading here needs an answer you wrote yourself.
+
+## Pass criterion (written before the build)
+> This feature works if and only if a `/forge` run with `--work-dir` pointed at a
+> real worktree produces every commit it makes on the worktree's branch, leaves the main checkout's
+> `HEAD` and working tree unchanged, and runs its tests against the worktree's code — all four
+> observed in a single live run, not inferred from the rendered prompts.
+
+## What happened
+| Condition | What was run | Times | Criterion met | Notes |
+|---|---|---|---|---|
+| Baseline (feature off) | FILL_ME | FILL_ME | FILL_ME | FILL_ME |
+| With the feature | FILL_ME | FILL_ME | FILL_ME | FILL_ME |
+
+The baseline row should read "no". If the criterion was already met with the feature off, stop and
+say so: a feature that fixes a problem you could never trigger has not been shown to do anything.
+
+## What this doesn't prove
+Required — this section is the point of the file.
+- Did the criterion pass *as written*, un-rewritten after the fact? Name every number that moved the
+  wrong way, cost included.
+- What could a reader wrongly conclude from that table? At minimum: the sample size, the conditions
+  you did not test, and the alternative explanation you can't rule out. "Nothing" is not an answer;
+  if you can't name a limit, you haven't looked yet.
+
+FILL_ME
+
+## Verdict
+One of **criterion met** / **criterion not met** / **inconclusive, and why**.
+
+FILL_ME

--- a/specs/forge-work-dir.md
+++ b/specs/forge-work-dir.md
@@ -2,7 +2,7 @@
 feature: /forge can build in a git worktree
 slug: forge-work-dir
 ticket: forge-worktree
-status: draft
+status: approved
 studio_run: studio/output/tech/run_tech_20260730_152947
 ---
 


### PR DESCRIPTION
Approval housekeeping for the spec merged in #97, so `/forge --spec forge-work-dir` builds against it instead of pausing on a draft.

- `status: draft` → `approved`
- Creates `specs/forge-work-dir-eval-results.md` from the skeleton, **empty**, with the pass criterion copied word for word rather than summarized

The empty-file-first ordering is the point of the convention: headings written before the outcome is known can't be arranged to flatter it. Every `FILL_ME` stays in place. While they do, nobody may call the feature working and the spec stays at `approved` — flipping to `shipped` is the claim, and `test_spec_verification.py` is what makes that claim cost evidence.

Confirmed the evidence file is tracked, not gitignored, so the evidence can actually be committed when it exists.

Spec-verification suite: 20 passed.

Opened ready rather than draft — this is the complete unit of work and I plan no further commits on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)