### PR TITLE
chore: migrate the stranded run history into studio/output/

### DIFF
--- a/specs/contrarian-finding-verifier.md
+++ b/specs/contrarian-finding-verifier.md
@@ -3,7 +3,7 @@ feature: Independent Verifier for Contrarian Findings (Studio roadmap R1)
 slug: contrarian-finding-verifier
 ticket: none (roadmap item R1 — see studio/docs/GSTACK_COMPARISON.md)
 status: approved
-studio_run: .studio/output/tech/run_tech_20260716_163522
+studio_run: studio/output/tech/run_tech_20260716_163522
 ---
 
 # Independent Verifier for Contrarian Findings — Architecture Spec

--- a/specs/doc-parity-tests.md
+++ b/specs/doc-parity-tests.md
@@ -3,7 +3,7 @@ feature: Doc-parity tests (Studio roadmap R2, reframed)
 slug: doc-parity-tests
 ticket: none (roadmap item R2 — see studio/docs/GSTACK_COMPARISON.md)
 status: approved
-studio_run: .studio/output/tech/run_tech_20260716_181851
+studio_run: studio/output/tech/run_tech_20260716_181851
 ---
 
 # Doc-Parity Tests — Architecture Spec

--- a/specs/prompt-feature-verification.md
+++ b/specs/prompt-feature-verification.md
@@ -3,7 +3,7 @@ feature: Pre-committed Verification for Prompt-Shaped Features
 slug: prompt-feature-verification
 ticket: none
 status: approved
-studio_run: .studio/output/tech/run_tech_20260728_192832
+studio_run: (run directory no longer on disk; removed by retention cleanup)
 ---
 
 # Pre-committed Verification for Prompt-Shaped Features — Architecture Spec

--- a/specs/pull-source-opt-in.md
+++ b/specs/pull-source-opt-in.md
@@ -3,7 +3,7 @@ feature: Opt-in Source Fast-Forward for /studio-update
 slug: pull-source-opt-in
 ticket: none
 status: approved
-studio_run: .studio/output/tech/run_tech_20260708_223215
+studio_run: studio/output/tech/run_tech_20260708_223215
 ---
 
 # Opt-in Source Fast-Forward for `/studio-update` — Architecture Spec

--- a/specs/unit-acceptance-criteria.md
+++ b/specs/unit-acceptance-criteria.md
@@ -3,7 +3,7 @@ feature: Unit Acceptance Criteria from the Approved Spec
 slug: unit-acceptance-criteria
 ticket: none
 status: approved
-studio_run: .studio/output/tech/run_tech_20260728_211955
+studio_run: (run directory no longer on disk; removed by retention cleanup)
 ---
 
 # Unit Acceptance Criteria from the Approved Spec — Architecture Spec

--- a/specs/update-availability-nudge.md
+++ b/specs/update-availability-nudge.md
@@ -3,7 +3,7 @@ feature: Proactive Update-Availability Nudge for Consuming Repos
 slug: update-availability-nudge
 ticket: none
 status: approved
-studio_run: .studio/output/tech/run_tech_20260708_164348
+studio_run: studio/output/tech/run_tech_20260708_164348
 ---
 
 # Proactive Update-Availability Nudge — Architecture Spec

--- a/specs/update-staleness-detection.md
+++ b/specs/update-staleness-detection.md
@@ -3,7 +3,7 @@ feature: Source-Staleness Detection for /studio-update
 slug: update-staleness-detection
 ticket: none
 status: approved
-studio_run: .studio/output/tech/run_tech_20260706_193131
+studio_run: (run directory no longer on disk; removed by retention cleanup)
 ---
 
 # Source-Staleness Detection for `/studio-update` — Architecture Spec

--- a/specs/writer-escalation-channel.md
+++ b/specs/writer-escalation-channel.md
@@ -3,7 +3,7 @@ feature: Writer Escalation Channel
 slug: writer-escalation-channel
 ticket: none
 status: approved
-studio_run: .studio/output/tech/run_tech_20260728_155545
+studio_run: (run directory no longer on disk; removed by retention cleanup)
 ---
 
 # Writer Escalation Channel — Architecture Spec


### PR DESCRIPTION
Unit 2 of `specs/source-repo-detection.md`. Unit 1 (#98) fixed the detection; this moves the runs it had been misfiling since 2026-07-08, so `stats` can see them again.

**`stats` now reports 8 runs where it saw 3.**

## Done by hand, deliberately

Everything being moved is **gitignored** — it exists only in the main checkout, and no worktree contains it. There's also no test for the loop to gate on. `/forge` would have added ceremony, not safety, so I did it directly and verified each step.

## Two collisions the spec didn't anticipate — neither a duplicate

- **`ledger_auto_append`** had its *writer* handoff in one location and its *editor* handoff in the other, two minutes apart. One run, split across both trees. Merging the directories reconstructs it.
- **`unit_impl_loop_config`** was **two different runs sharing a unit_id** (Jun 28 and Jul 29) with identically-named files. A plain `mv` would have silently destroyed one. The older editor handoff is preserved as `impl--unit_impl_loop_config--editor.2026-06-28.json`.

**All 28 handoff files survive.** Nothing was overwritten.

## What moved

| | |
|---|---|
| Directories moved | 19 (5 tech runs + 14 forge unit dirs) |
| `usage.log` | two files merged in timestamp order, 11 entries, none dropped |
| `knowledge/run_log.md` | moved |
| `index.md` | **regenerated, not moved** — it's derived, and the spec says so |

## The spec pointers

Eight specs carried a `studio_run:` pointer into the old location. Four now point at the moved directory. The other four pointed at runs that are **absent everywhere** — deleted by retention cleanup long before this migration, so repointing them would just name a second path that doesn't exist. Those now say so plainly instead.

## Verification

**871 passed.** `git status` shows only the 8 spec frontmatter edits — which is the spec's own acceptance criterion, since everything moved is gitignored. A live `prepare` from the repo root landed in `studio/output/` and created no stray bridge doc, confirming unit 1's fix end to end.

Remaining on this spec: unit 3 (`integrations_side_effect`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)