### PR TITLE
test: cover the two config-loader guards nothing was testing

### DIFF
--- a/studio/tests/test_impl_loop.py
+++ b/studio/tests/test_impl_loop.py
@@ -174,6 +174,41 @@ def test_load_loop_config_invalid_toml():
         config_path.unlink()
 
 
+@pytest.mark.parametrize("table", ["loop", "gate", "editor"])
+def test_load_loop_config_non_table_value_names_the_table(table):
+    """A scalar where a table belongs (`gate = "ruff"`) errors and names that table.
+
+    Without the name the message points at the file and leaves you to work out which
+    of the three sections is the wrong one.
+    """
+    config_path = _write_toml(f'{table} = "not a table"\n')
+    try:
+        with pytest.raises(ValueError, match=f"'{table}' must be a table/dict"):
+            load_loop_config(config_path)
+    finally:
+        config_path.unlink()
+
+
+def test_load_loop_config_plain_source_dir_is_not_an_installed_snapshot(tmp_path):
+    """Only the full `<repo>/.studio/source` shape climbs to the repo root.
+
+    A directory that merely happens to be named `source` reads its own `.studio/`, so
+    an unrelated `.studio/` two levels up can never hijack the config.
+    """
+    source = tmp_path / "checkout" / "source"
+    (source / ".studio").mkdir(parents=True)
+    (source / ".studio" / "implementation_loop.toml").write_text(
+        "[editor]\noutput_budget = 111\n"
+    )
+    # Decoy at the grandparent — where the installed-layout rule would have looked.
+    (tmp_path / ".studio").mkdir()
+    (tmp_path / ".studio" / "implementation_loop.toml").write_text(
+        "[editor]\noutput_budget = 222\n"
+    )
+
+    assert load_loop_config(studio_root=source).output_budget == 111
+
+
 def test_load_loop_config_studio_override_beats_shipped_default():
     """.studio/implementation_loop.toml wins over config/implementation_loop.toml."""
     with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Closes out the parked `impl/impl-loop-config-mutation-teeth` branch.

That branch had been sitting since early July. Looking at it properly: it forked before roughly everything that has landed since, so almost all of its apparent diff was just main having moved on. The genuinely salvageable content was **two tests**, and both cover error branches that had no test at all.

**`gate = "ruff"` names the section.** `impl_loop.py` raises `'<name>' must be a table/dict` when a scalar sits where a table belongs — untested until now. Without the section name, the message points at the file and leaves you to work out which of `loop` / `gate` / `editor` is the wrong one.

**A directory named `source` isn't an installed snapshot.** Only the full `<repo>/.studio/source` shape climbs to the repo root for its config. A checkout that merely happens to have a `source/` directory reads its own `.studio/`, so an unrelated `.studio/` two levels up can't hijack it. That guard was load-bearing and unpinned.

Three mutations spot-checked, all caught: remove the table guard, drop the table name from its message, and loosen the snapshot check to match on directory name alone.

Suite **900 passed** (up from 896), ruff clean. I did not port the parked branch's third change — it altered a test signature to match an implementation that never landed. Once this merges the parked branch can be deleted; nothing else on it is worth keeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)