### PR TITLE
spec: say shipped on the eight specs that shipped

### DIFF
--- a/specs/contrarian-finding-verifier.md
+++ b/specs/contrarian-finding-verifier.md
@@ -2,7 +2,7 @@
 feature: Independent Verifier for Contrarian Findings (Studio roadmap R1)
 slug: contrarian-finding-verifier
 ticket: none (roadmap item R1 — see studio/docs/GSTACK_COMPARISON.md)
-status: approved
+status: shipped
 studio_run: studio/output/tech/run_tech_20260716_163522
 ---
 

--- a/specs/doc-parity-tests.md
+++ b/specs/doc-parity-tests.md
@@ -2,7 +2,7 @@
 feature: Doc-parity tests (Studio roadmap R2, reframed)
 slug: doc-parity-tests
 ticket: none (roadmap item R2 — see studio/docs/GSTACK_COMPARISON.md)
-status: approved
+status: shipped
 studio_run: studio/output/tech/run_tech_20260716_181851
 ---
 

--- a/specs/pull-source-opt-in.md
+++ b/specs/pull-source-opt-in.md
@@ -2,7 +2,7 @@
 feature: Opt-in Source Fast-Forward for /studio-update
 slug: pull-source-opt-in
 ticket: none
-status: approved
+status: shipped
 studio_run: studio/output/tech/run_tech_20260708_223215
 ---
 

--- a/specs/source-repo-detection.md
+++ b/specs/source-repo-detection.md
@@ -2,7 +2,7 @@
 feature: Studio recognizes its own source repo
 slug: source-repo-detection
 ticket: bridge-detection
-status: approved
+status: shipped
 studio_run: studio/output/tech/run_tech_20260730_134434
 ---
 

--- a/specs/unit-acceptance-criteria.md
+++ b/specs/unit-acceptance-criteria.md
@@ -2,7 +2,7 @@
 feature: Unit Acceptance Criteria from the Approved Spec
 slug: unit-acceptance-criteria
 ticket: none
-status: approved
+status: shipped
 studio_run: (run directory no longer on disk; removed by retention cleanup)
 ---
 

--- a/specs/update-availability-nudge.md
+++ b/specs/update-availability-nudge.md
@@ -2,7 +2,7 @@
 feature: Proactive Update-Availability Nudge for Consuming Repos
 slug: update-availability-nudge
 ticket: none
-status: approved
+status: shipped
 studio_run: studio/output/tech/run_tech_20260708_164348
 ---
 

--- a/specs/update-staleness-detection.md
+++ b/specs/update-staleness-detection.md
@@ -2,7 +2,7 @@
 feature: Source-Staleness Detection for /studio-update
 slug: update-staleness-detection
 ticket: none
-status: approved
+status: shipped
 studio_run: (run directory no longer on disk; removed by retention cleanup)
 ---
 

--- a/specs/writer-escalation-channel.md
+++ b/specs/writer-escalation-channel.md
@@ -2,7 +2,7 @@
 feature: Writer Escalation Channel
 slug: writer-escalation-channel
 ticket: none
-status: approved
+status: shipped
 studio_run: (run directory no longer on disk; removed by retention cleanup)
 ---
 


### PR DESCRIPTION
Every spec in this repo said `approved` except two — including eight whose features have been built, merged, and in daily use for weeks. The status field couldn't tell you what had actually shipped.

That's not just untidy. It's the same blindness that let the verification convention's own evidence file sit blank for five days: `approved` had quietly become a resting place for finished work, so "not shipped" carried no information.

**Checked against the code, not memory.** Each of the eight was verified to exist on main before flipping: the verifier module and its workflow, the doc-parity test, `auto_pull_source`, the source-repo branch in `get_artifact_root`, `acceptance_criteria` in the loop, the `check-updates` command, the staleness check, and the writer's `stuck` field.

**None of them promises evidence** — they either predate the verification convention or are code-shaped features where the tests are the criterion — so `shipped` costs no results file here and all four enforcement rules stay satisfied. Suite **900 passed**, ruff clean.

**What this deliberately does not do:** close the enforcement hole recorded in `prompt-feature-verification-eval-results.md`. Nothing here stops a *future* spec parking at `approved` with a blank evidence file, because `test_spec_verification.py` still only refuses a spec that claims completion. That needs a design pass, not a status edit, and it's the next thing I'm picking up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)